### PR TITLE
MAINT Lint with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+
+jobs:
+  lint:
+    docker:
+      - image: rust:1.36.0-slim-buster
+    steps:
+      - checkout
+      - run:
+          name: cargo fmt
+          command: |
+            cargo fmt -- --check
+      - run:
+          name: cargo clippy
+          command: |
+            cargo clippy || true
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,14 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: rust:1.36.0-slim-buster
+      - image: rust:1.36.0-buster
     steps:
       - checkout
+      - run:
+          name: dependencies
+          command: |
+            rustup component add rustfmt
+            rustup component add clippy
       - run:
           name: cargo fmt
           command: |

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! [1] S Kirkpatrick, CD Gelatt Jr, MP Vecchi. (1983). "Optimization by Simulated Annealing".
 //! Science 13 May 1983, Vol. 220, Issue 4598, pp. 671-680
-//! DOI: 10.1126/science.220.4598.671  
+//! DOI: 10.1126/science.220.4598.671
 
 use crate::prelude::*;
 use rand::prelude::*;


### PR DESCRIPTION
Add a CircleCI config that runs,
 - `cargo fmt`
 - `cargo clippy`: failures are allowed, and one would need to actually look at the logs to see warnings / errors there.