### PR TITLE
Derive Clone trait for all optimizers

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,5 @@ macro_rules! test_trait_impl {
                 assert_clone::<$t>();
             }
         }
-
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,7 +10,7 @@
 /// This macro crates a test for send an sync
 #[cfg(test)]
 #[macro_export]
-macro_rules! send_sync_test {
+macro_rules! test_trait_impl {
     ($n:ident, $t:ty) => {
         paste::item! {
             #[test]
@@ -29,5 +29,15 @@ macro_rules! send_sync_test {
                 assert_sync::<$t>();
             }
         }
+
+        paste::item! {
+            #[test]
+            #[allow(non_snake_case)]
+            fn [<test_clone_ $n>]() {
+                fn assert_clone<T: Clone>() {}
+                assert_clone::<$t>();
+            }
+        }
+
     };
 }

--- a/src/solver/conjugategradient/beta.rs
+++ b/src/solver/conjugategradient/beta.rs
@@ -116,10 +116,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(fletcher_reeves, FletcherReeves);
-    send_sync_test!(polak_ribiere, PolakRibiere);
-    send_sync_test!(polak_ribiere_plus, PolakRibierePlus);
-    send_sync_test!(hestenes_stiefel, HestenesStiefel);
+    test_trait_impl!(fletcher_reeves, FletcherReeves);
+    test_trait_impl!(polak_ribiere, PolakRibiere);
+    test_trait_impl!(polak_ribiere_plus, PolakRibierePlus);
+    test_trait_impl!(hestenes_stiefel, HestenesStiefel);
 }

--- a/src/solver/conjugategradient/cg.rs
+++ b/src/solver/conjugategradient/cg.rs
@@ -143,9 +143,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(
+    test_trait_impl!(
         conjugate_gradient,
         ConjugateGradient<NoOperator<Vec<f64>, Vec<f64>, (), ()>, f64>
     );

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -183,9 +183,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::conjugategradient::beta::PolakRibiere;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
     use crate::MinimalNoOperator;
 
     test_trait_impl!(

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -27,7 +27,7 @@ use std::default::Default;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct NonlinearConjugateGradient<P, L, B> {
     /// p
     p: P,
@@ -183,12 +183,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::conjugategradient::beta::PolakRibiere;
     use crate::solver::linesearch::MoreThuenteLineSearch;
     use crate::MinimalNoOperator;
 
-    send_sync_test!(
+    test_trait_impl!(
         nonlinear_cg,
         NonlinearConjugateGradient<
             MinimalNoOperator,

--- a/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -136,8 +136,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     test_trait_impl!(
         gauss_newton_linesearch_method,

--- a/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -22,7 +22,7 @@ use std::default::Default;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GaussNewtonLS<L> {
     /// linesearch
     linesearch: L,
@@ -136,10 +136,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
-    send_sync_test!(
+    test_trait_impl!(
         gauss_newton_linesearch_method,
         GaussNewtonLS<MoreThuenteLineSearch<Vec<f64>>>
     );

--- a/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/src/solver/gaussnewton/gaussnewton_method.rs
@@ -22,7 +22,7 @@ use std::default::Default;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct GaussNewton {
     /// gamma
     gamma: f64,
@@ -104,7 +104,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(gauss_newton_method, GaussNewton);
+    test_trait_impl!(gauss_newton_method, GaussNewton);
 }

--- a/src/solver/gradientdescent/steepestdescent.rs
+++ b/src/solver/gradientdescent/steepestdescent.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SteepestDescent<L> {
     /// line search
     linesearch: L,
@@ -96,10 +96,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
-    send_sync_test!(
+    test_trait_impl!(
         steepest_descent,
         SteepestDescent<MoreThuenteLineSearch<Vec<f64>>>
     );

--- a/src/solver/gradientdescent/steepestdescent.rs
+++ b/src/solver/gradientdescent/steepestdescent.rs
@@ -96,8 +96,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     test_trait_impl!(
         steepest_descent,

--- a/src/solver/landweber/mod.rs
+++ b/src/solver/landweber/mod.rs
@@ -67,7 +67,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(landweber, Landweber);
+    test_trait_impl!(landweber, Landweber);
 }

--- a/src/solver/linesearch/backtracking.rs
+++ b/src/solver/linesearch/backtracking.rs
@@ -174,9 +174,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::MinimalNoOperator;
 
-    send_sync_test!(backtrackinglinesearch,
+    test_trait_impl!(backtrackinglinesearch,
                     BacktrackingLineSearch<MinimalNoOperator, ArmijoCondition>);
 }

--- a/src/solver/linesearch/condition.rs
+++ b/src/solver/linesearch/condition.rs
@@ -212,10 +212,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(goldstein, GoldsteinCondition);
-    send_sync_test!(armijo, ArmijoCondition);
-    send_sync_test!(wolfe, WolfeCondition);
-    send_sync_test!(strongwolfe, StrongWolfeCondition);
+    test_trait_impl!(goldstein, GoldsteinCondition);
+    test_trait_impl!(armijo, ArmijoCondition);
+    test_trait_impl!(wolfe, WolfeCondition);
+    test_trait_impl!(strongwolfe, StrongWolfeCondition);
 }

--- a/src/solver/linesearch/hagerzhang.rs
+++ b/src/solver/linesearch/hagerzhang.rs
@@ -553,8 +553,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::MinimalNoOperator;
 
-    send_sync_test!(hagerzhang, HagerZhangLineSearch<MinimalNoOperator>);
+    test_trait_impl!(hagerzhang, HagerZhangLineSearch<MinimalNoOperator>);
 }

--- a/src/solver/linesearch/morethuente.rs
+++ b/src/solver/linesearch/morethuente.rs
@@ -580,8 +580,8 @@ fn cstep(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::MinimalNoOperator;
 
-    send_sync_test!(morethuente, MoreThuenteLineSearch<MinimalNoOperator>);
+    test_trait_impl!(morethuente, MoreThuenteLineSearch<MinimalNoOperator>);
 }

--- a/src/solver/neldermead/mod.rs
+++ b/src/solver/neldermead/mod.rs
@@ -36,7 +36,7 @@ use std::default::Default;
 /// # References:
 ///
 /// [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct NelderMead<O: ArgminOp> {
     /// alpha
     alpha: f64,
@@ -306,8 +306,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(nelder_mead, NelderMead<Operator>);
+    test_trait_impl!(nelder_mead, NelderMead<Operator>);
 }

--- a/src/solver/newton/newton_cg.rs
+++ b/src/solver/newton/newton_cg.rs
@@ -188,8 +188,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     test_trait_impl!(newton_cg, NewtonCG<MoreThuenteLineSearch<Vec<f64>>>);
 

--- a/src/solver/newton/newton_cg.rs
+++ b/src/solver/newton/newton_cg.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct NewtonCG<L> {
     /// line search
     linesearch: L,
@@ -188,10 +188,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
-    send_sync_test!(newton_cg, NewtonCG<MoreThuenteLineSearch<Vec<f64>>>);
+    test_trait_impl!(newton_cg, NewtonCG<MoreThuenteLineSearch<Vec<f64>>>);
 
-    send_sync_test!(cg_subproblem, CGSubProblem<Vec<f64>, Vec<Vec<f64>>>);
+    test_trait_impl!(cg_subproblem, CGSubProblem<Vec<f64>, Vec<Vec<f64>>>);
 }

--- a/src/solver/newton/newton_method.rs
+++ b/src/solver/newton/newton_method.rs
@@ -23,7 +23,7 @@ use std::default::Default;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Newton {
     /// gamma
     gamma: f64,
@@ -78,7 +78,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(newton_method, Newton);
+    test_trait_impl!(newton_method, Newton);
 }

--- a/src/solver/particleswarm/mod.rs
+++ b/src/solver/particleswarm/mod.rs
@@ -234,7 +234,7 @@ trait_bound!(Position
 );
 
 /// A single particle
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Particle<T: Position> {
     /// Position of particle
     pub position: T,

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -168,8 +168,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct BFGS<L, H> {
     /// Inverse Hessian
     inv_hessian: H,
@@ -168,10 +168,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(bfgs, BFGS<Operator, MoreThuenteLineSearch<Operator>>);
+    test_trait_impl!(bfgs, BFGS<Operator, MoreThuenteLineSearch<Operator>>);
 }

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct DFP<L, H> {
     /// Inverse Hessian
     inv_hessian: H,
@@ -148,10 +148,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(dfp, DFP<Operator, MoreThuenteLineSearch<Operator>>);
+    test_trait_impl!(dfp, DFP<Operator, MoreThuenteLineSearch<Operator>>);
 }

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -148,8 +148,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -177,8 +177,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -26,7 +26,7 @@ use std::fmt::Debug;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct LBFGS<L, P> {
     /// line search
     linesearch: L,
@@ -177,10 +177,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(lbfgs, LBFGS<Operator, MoreThuenteLineSearch<Operator>>);
+    test_trait_impl!(lbfgs, LBFGS<Operator, MoreThuenteLineSearch<Operator>>);
 }

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SR1<L, H> {
     /// parameter for skipping rule
     r: f64,
@@ -179,10 +179,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(sr1, SR1<Operator, MoreThuenteLineSearch<Operator>>);
+    test_trait_impl!(sr1, SR1<Operator, MoreThuenteLineSearch<Operator>>);
 }

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -179,8 +179,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::linesearch::MoreThuenteLineSearch;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -246,8 +246,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::trustregion::CauchyPoint;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -23,7 +23,7 @@ use std::fmt::Debug;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SR1TrustRegion<B, R> {
     /// parameter for skipping rule
     r: f64,
@@ -246,10 +246,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::trustregion::CauchyPoint;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(sr1, SR1TrustRegion<Operator, CauchyPoint>);
+    test_trait_impl!(sr1, SR1TrustRegion<Operator, CauchyPoint>);
 }

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -60,7 +60,7 @@ impl std::default::Default for SATempFunc {
 /// [1] S Kirkpatrick, CD Gelatt Jr, MP Vecchi. (1983). "Optimization by Simulated Annealing".
 /// Science 13 May 1983, Vol. 220, Issue 4598, pp. 671-680
 /// DOI: 10.1126/science.220.4598.671  
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct SimulatedAnnealing {
     /// Initial temperature
     init_temp: f64,
@@ -321,7 +321,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(sa, SimulatedAnnealing);
+    test_trait_impl!(sa, SimulatedAnnealing);
 }

--- a/src/solver/trustregion/cauchypoint.rs
+++ b/src/solver/trustregion/cauchypoint.rs
@@ -92,7 +92,7 @@ impl ArgminTrustRegion for CauchyPoint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(cauchypoint, CauchyPoint);
+    test_trait_impl!(cauchypoint, CauchyPoint);
 }

--- a/src/solver/trustregion/dogleg.rs
+++ b/src/solver/trustregion/dogleg.rs
@@ -134,7 +134,7 @@ impl ArgminTrustRegion for Dogleg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(dogleg, Dogleg);
+    test_trait_impl!(dogleg, Dogleg);
 }

--- a/src/solver/trustregion/steihaug.rs
+++ b/src/solver/trustregion/steihaug.rs
@@ -249,7 +249,7 @@ impl<P: Clone + Serialize> ArgminTrustRegion for Steihaug<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
 
-    send_sync_test!(steihaug, Steihaug<MinimalNoOperator>);
+    test_trait_impl!(steihaug, Steihaug<MinimalNoOperator>);
 }

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -35,7 +35,7 @@ use std::fmt::Debug;
 ///
 /// [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TrustRegion<R> {
     /// Radius
     radius: f64,
@@ -200,10 +200,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::send_sync_test;
+    use crate::test_trait_impl;
     use crate::solver::trustregion::steihaug::Steihaug;
 
     type Operator = MinimalNoOperator;
 
-    send_sync_test!(trustregion, TrustRegion<Steihaug<Operator>>);
+    test_trait_impl!(trustregion, TrustRegion<Steihaug<Operator>>);
 }

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -200,8 +200,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
     use crate::solver::trustregion::steihaug::Steihaug;
+    use crate::test_trait_impl;
 
     type Operator = MinimalNoOperator;
 


### PR DESCRIPTION
Makes sure all optimizer derive the `Clone` trait.

The only exception is `ParticleSwarm` because it sounds like `Callback<T>` does not implement `Clone` and I have not investigated further.

Something I have run into in `pyargmin` when changing solvers.

Helps toward "Interoperability" in https://github.com/argmin-rs/argmin/issues/1

