### PR TITLE
Moved `argmin_core` crate into `core` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,28 +17,40 @@ exclude = [
 ]
 
 [dependencies]
-# argmin_core = { path = "../argmin-core"}
 # argmin_testfunctions = { path = "../argmin-testfunctions" }
-argmin_core = { git = "https://github.com/argmin-rs/argmin-core.git", branch = "master"}
-argmin_testfunctions = { git = "https://github.com/argmin-rs/argmin-testfunctions.git", branch = "master"}
-# argmin_core = "0.2.5"
-# argmin_testfunctions = "0.1.1"
+# argmin_testfunctions = { git = "https://github.com/argmin-rs/argmin-testfunctions.git", branch = "master"}
+argmin_testfunctions = "0.1.1"
 rand = { version = "0.7.2", features = ["serde1"] }
 rand_xorshift = { version = "0.2.0", features = ["serde1"] }
-serde = { version = "1.0", features = ["rc"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0"
+erased-serde = "0.3"
+bincode = "1.1.4"
 approx = "0.3.2"
+failure = "0.1.5"
+failure_derive = "0.1.5"
+ctrlc = { version = "3.1.2", optional = true }
+slog = "2.4.1"
+slog-term = "2.4.0"
+slog-async = "2.3.0"
+slog-json = "2.3.0"
+modcholesky = "0.1.2"
+ndarray = { version = "0.13", optional = true, features = ["serde-1"] }
+ndarray-linalg = { version = "0.12", optional = true }
+ndarray-rand = {version = "0.11.0", optional = true }
+num = { version = "0.2" }
+paste = "0.1.5"
+gnuplot = { version = "0.0.34", optional = true}
+num-complex = "0.2"
 
 [dev-dependencies]
-ndarray = { version = "0.13", features = ["serde-1"] }
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
-gnuplot = "0.0.34"
-paste = "0.1.5"
+finitediff = "0.1.2"
 
 [features]
 default = []
-ctrlc = ["argmin_core/ctrlc"]
-ndarrayl = ["argmin_core/ndarrayl"]
-visualizer = ["argmin_core/visualizer"]
+ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand", "finitediff/ndarray"]
+visualizer = ["gnuplot"]
 
 [badges]
 travis-ci = { repository = "argmin-rs/argmin", branch = "master" }

--- a/examples/bfgs.rs
+++ b/examples/bfgs.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/checkpoint_3.rs
+++ b/examples/checkpoint_3.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;
 use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
-use argmin_core::Error;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/dfp.rs
+++ b/examples/dfp.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::DFP;
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/landweber.rs
+++ b/examples/landweber.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;
 use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
-use argmin_core::Error;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/lbfgs.rs
+++ b/examples/lbfgs.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::LBFGS;
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/sr1.rs
+++ b/examples/sr1.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::SR1;
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/sr1_trustregion.rs
+++ b/examples/sr1_trustregion.rs
@@ -6,13 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::quasinewton::SR1TrustRegion;
 #[allow(unused_imports)]
 use argmin::solver::trustregion::{CauchyPoint, Dogleg, Steihaug, TrustRegion};
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/writers.rs
+++ b/examples/writers.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;
 use argmin::testfunctions::rosenbrock;
-use argmin_core::finitediff::*;
+use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -1,0 +1,65 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Errors
+//!
+//! Gigantic TODO: Remove `failure` dependency and implement own error handling.
+
+use failure_derive::Fail;
+
+/// Argmin error type
+#[derive(Debug, Fail)]
+pub enum ArgminError {
+    /// Indicates and invalid parameter
+    #[fail(display = "Invalid parameter: {}", text)]
+    InvalidParameter {
+        /// Text
+        text: String,
+    },
+
+    /// Indicates that a function is not implemented
+    #[fail(display = "Not implemented: {}", text)]
+    NotImplemented {
+        /// Text
+        text: String,
+    },
+
+    /// Indicates that a function is not initialized
+    #[fail(display = "Not initialized: {}", text)]
+    NotInitialized {
+        /// Text
+        text: String,
+    },
+
+    /// Indicates that a condition is violated
+    #[fail(display = "Condition violated: {}", text)]
+    ConditionViolated {
+        /// Text
+        text: String,
+    },
+
+    /// Checkpoint was not found
+    #[fail(display = "Checkpoint not found: {}", text)]
+    CheckpointNotFound {
+        /// Text
+        text: String,
+    },
+
+    /// Indicates an impossible error
+    #[fail(display = "Impossible Error: {}", text)]
+    ImpossibleError {
+        /// Text
+        text: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    send_sync_test!(error, ArgminError);
+}

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -1,0 +1,269 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// TODO: Logging of "initial info"
+
+use crate::core::serialization::*;
+use crate::core::{
+    ArgminCheckpoint, ArgminIterData, ArgminKV, ArgminOp, ArgminResult, Error, IterState, Observe,
+    Observer, ObserverMode, OpWrapper, Solver, TerminationReason,
+};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Executes a solver
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Executor<O: ArgminOp, S> {
+    /// solver
+    solver: S,
+    /// operator
+    op: OpWrapper<O>,
+    /// State
+    state: IterState<O>,
+    /// Storage for observers
+    #[serde(skip)]
+    observers: Observer<O>,
+    /// Checkpoint
+    checkpoint: ArgminCheckpoint,
+    /// Indicates whether Ctrl-C functionality should be active or not
+    ctrlc: bool,
+}
+
+impl<O, S> Executor<O, S>
+where
+    O: ArgminOp,
+    O::Param: Clone + Default,
+    O::Hessian: Default,
+    S: Solver<O>,
+{
+    /// Create a new executor with a `solver` and an initial parameter `init_param`
+    pub fn new(op: O, solver: S, init_param: O::Param) -> Self {
+        let state = IterState::new(init_param);
+        Executor {
+            solver,
+            op: OpWrapper::new(&op),
+            state,
+            observers: Observer::new(),
+            checkpoint: ArgminCheckpoint::default(),
+            ctrlc: true,
+        }
+    }
+
+    /// Create a new executor from a checkpoint
+    pub fn from_checkpoint<P: AsRef<Path>>(path: P) -> Result<Self, Error>
+    where
+        Self: Sized + DeserializeOwned,
+    {
+        load_checkpoint(path)
+    }
+
+    fn update(&mut self, data: &ArgminIterData<O>) -> Result<(), Error> {
+        if let Some(cur_param) = data.get_param() {
+            self.state.param(cur_param);
+        }
+        if let Some(cur_cost) = data.get_cost() {
+            self.state.cost(cur_cost);
+        }
+        // check if parameters are the best so far
+        if self.state.get_cost() <= self.state.get_best_cost() {
+            let param = self.state.get_param().clone();
+            let cost = self.state.get_cost();
+            self.state.best_param(param).best_cost(cost);
+            self.state.new_best();
+        }
+
+        if let Some(grad) = data.get_grad() {
+            self.state.grad(grad);
+        }
+        if let Some(hessian) = data.get_hessian() {
+            self.state.hessian(hessian);
+        }
+        if let Some(jacobian) = data.get_jacobian() {
+            self.state.jacobian(jacobian);
+        }
+        if let Some(population) = data.get_population() {
+            self.state.population(population.clone());
+        }
+
+        if let Some(termination_reason) = data.get_termination_reason() {
+            self.state.termination_reason(termination_reason);
+        }
+        Ok(())
+    }
+
+    /// Run the executor
+    pub fn run(mut self) -> Result<ArgminResult<O>, Error> {
+        let total_time = std::time::Instant::now();
+
+        let running = Arc::new(AtomicBool::new(true));
+
+        if self.ctrlc {
+            #[cfg(feature = "ctrlc")]
+            {
+                // Set up the Ctrl-C handler
+                let r = running.clone();
+                // This is currently a hack to allow checkpoints to be run again within the
+                // same program (usually not really a usecase anyway). Unfortunately, this
+                // means that any subsequent run started afterwards will have not Ctrl-C
+                // handling available... This should also be a problem in case one tries to run
+                // two consecutive optimizations. There is ongoing work in the ctrlc crate
+                // (channels and such) which may solve this problem. So far, we have to live
+                // with this.
+                match ctrlc::set_handler(move || {
+                    r.store(false, Ordering::SeqCst);
+                }) {
+                    Err(ctrlc::Error::MultipleHandlers) => Ok(()),
+                    r => r,
+                }?;
+            }
+        }
+
+        // let mut op_wrapper = OpWrapper::new(&self.op);
+        let init_data = self.solver.init(&mut self.op, &self.state)?;
+
+        let mut logs = make_kv!("max_iters" => self.state.get_max_iters(););
+
+        // If init() returned something, deal with it
+        if let Some(data) = init_data {
+            self.update(&data)?;
+            logs = logs.merge(&mut data.get_kv());
+        }
+
+        // Observe after init
+        self.observers.observe_init(S::NAME, &logs)?;
+
+        self.state.set_func_counts(&self.op);
+
+        while running.load(Ordering::SeqCst) {
+            // check first if it has already terminated
+            // This should probably be solved better.
+            // First, check if it isn't already terminated. If it isn't, evaluate the
+            // stopping criteria. If `self.terminate()` is called without the checking
+            // whether it has terminated already, then it may overwrite a termination set
+            // within `next_iter()`!
+            if !self.state.terminated() {
+                self.state
+                    .termination_reason(self.solver.terminate_internal(&self.state));
+            }
+            // Now check once more if the algorithm has terminated. If yes, then break.
+            if self.state.terminated() {
+                break;
+            }
+
+            // Start time measurement
+            let start = std::time::Instant::now();
+
+            let data = self.solver.next_iter(&mut self.op, &self.state)?;
+
+            self.state.set_func_counts(&self.op);
+
+            // End time measurement
+            let duration = start.elapsed();
+
+            self.update(&data)?;
+
+            let log = data.get_kv().merge(&mut make_kv!(
+                "time" => duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) * 1e-9;
+            ));
+
+            self.observers.observe_iter(&self.state, &log)?;
+
+            // increment iteration number
+            self.state.increment_iter();
+
+            self.checkpoint.store_cond(&self, self.state.get_iter())?;
+
+            self.state.time(total_time.elapsed());
+
+            // Check if termination occured inside next_iter()
+            if self.state.terminated() {
+                break;
+            }
+        }
+
+        // in case it stopped prematurely and `termination_reason` is still `NotTerminated`,
+        // someone must have pulled the handbrake
+        if self.state.get_iter() < self.state.get_max_iters() && !self.state.terminated() {
+            self.state.termination_reason(TerminationReason::Aborted);
+        }
+
+        Ok(ArgminResult::new(self.op.get_op(), self.state))
+    }
+
+    /// Attaches a observer which implements `ArgminLog` to the solver.
+    pub fn add_observer<OBS: Observe<O> + 'static>(
+        mut self,
+        observer: OBS,
+        mode: ObserverMode,
+    ) -> Self {
+        self.observers.push(observer, mode);
+        self
+    }
+
+    /// Set maximum number of iterations
+    pub fn max_iters(mut self, iters: u64) -> Self {
+        self.state.max_iters(iters);
+        self
+    }
+
+    /// Set target cost value
+    pub fn target_cost(mut self, cost: f64) -> Self {
+        self.state.target_cost(cost);
+        self
+    }
+
+    /// Set cost value
+    pub fn cost(mut self, cost: f64) -> Self {
+        self.state.cost(cost);
+        self
+    }
+
+    /// Set Gradient
+    pub fn grad(mut self, grad: O::Param) -> Self {
+        self.state.grad(grad);
+        self
+    }
+
+    /// Set Hessian
+    pub fn hessian(mut self, hessian: O::Hessian) -> Self {
+        self.state.hessian(hessian);
+        self
+    }
+
+    /// Set Jacobian
+    pub fn jacobian(mut self, jacobian: O::Jacobian) -> Self {
+        self.state.jacobian(jacobian);
+        self
+    }
+
+    /// Set checkpoint directory
+    pub fn checkpoint_dir(mut self, dir: &str) -> Self {
+        self.checkpoint.set_dir(dir);
+        self
+    }
+
+    /// Set checkpoint name
+    pub fn checkpoint_name(mut self, dir: &str) -> Self {
+        self.checkpoint.set_name(dir);
+        self
+    }
+
+    /// Set the checkpoint mode
+    pub fn checkpoint_mode(mut self, mode: CheckpointMode) -> Self {
+        self.checkpoint.set_mode(mode);
+        self
+    }
+
+    /// Turn Ctrl-C handling on or off (default: on)
+    pub fn ctrlc(mut self, ctrlc: bool) -> Self {
+        self.ctrlc = ctrlc;
+        self
+    }
+}

--- a/src/core/iterstate.rs
+++ b/src/core/iterstate.rs
@@ -1,0 +1,505 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::{ArgminOp, OpWrapper, TerminationReason};
+use paste::item;
+use serde::{Deserialize, Serialize};
+
+/// Maintains the state from iteration to iteration of a solver
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IterState<O: ArgminOp> {
+    /// Current parameter vector
+    pub param: O::Param,
+    /// Previous parameter vector
+    pub prev_param: O::Param,
+    /// Current best parameter vector
+    pub best_param: O::Param,
+    /// Previous best parameter vector
+    pub prev_best_param: O::Param,
+    /// Current cost function value
+    pub cost: f64,
+    /// Previous cost function value
+    pub prev_cost: f64,
+    /// Current best cost function value
+    pub best_cost: f64,
+    /// Previous best cost function value
+    pub prev_best_cost: f64,
+    /// Target cost function value
+    pub target_cost: f64,
+    /// Current gradient
+    pub grad: Option<O::Param>,
+    /// Previous gradient
+    pub prev_grad: Option<O::Param>,
+    /// Current Hessian
+    pub hessian: Option<O::Hessian>,
+    /// Previous Hessian
+    pub prev_hessian: Option<O::Hessian>,
+    /// Current Jacobian
+    pub jacobian: Option<O::Jacobian>,
+    /// Previous Jacobian
+    pub prev_jacobian: Option<O::Jacobian>,
+    /// All members for population-based algorithms as (param, cost) tuples
+    pub population: Option<Vec<(O::Param, f64)>>,
+    /// Current iteration
+    pub iter: u64,
+    /// Iteration number of last best cost
+    pub last_best_iter: u64,
+    /// Maximum number of iterations
+    pub max_iters: u64,
+    /// Number of cost function evaluations so far
+    pub cost_func_count: u64,
+    /// Number of gradient evaluations so far
+    pub grad_func_count: u64,
+    /// Number of Hessian evaluations so far
+    pub hessian_func_count: u64,
+    /// Number of Jacobian evaluations so far
+    pub jacobian_func_count: u64,
+    /// Number of modify evaluations so far
+    pub modify_func_count: u64,
+    /// Time required so far
+    pub time: std::time::Duration,
+    /// Reason of termination
+    pub termination_reason: TerminationReason,
+}
+
+macro_rules! setter {
+    ($name:ident, $type:ty) => {
+        /// Set
+        pub fn $name(&mut self, $name: $type) -> &mut Self {
+            self.$name = $name;
+            self
+        }
+    };
+}
+
+macro_rules! getter_option {
+    ($name:ident, $type:ty) => {
+        item! {
+            /// Get
+            pub fn [<get_ $name>](&self) -> Option<$type> {
+                self.$name.clone()
+            }
+        }
+    };
+}
+
+macro_rules! getter {
+    ($name:ident, $type:ty) => {
+        item! {
+            /// Get
+            pub fn [<get_ $name>](&self) -> $type {
+                self.$name.clone()
+            }
+        }
+    };
+}
+
+impl<O: ArgminOp> std::default::Default for IterState<O>
+where
+    O::Param: Default,
+{
+    fn default() -> Self {
+        IterState::new(O::Param::default())
+    }
+}
+
+impl<O: ArgminOp> IterState<O> {
+    /// Create new IterState from `param`
+    pub fn new(param: O::Param) -> Self {
+        IterState {
+            param: param.clone(),
+            prev_param: param.clone(),
+            best_param: param.clone(),
+            prev_best_param: param,
+            cost: std::f64::INFINITY,
+            prev_cost: std::f64::INFINITY,
+            best_cost: std::f64::INFINITY,
+            prev_best_cost: std::f64::INFINITY,
+            target_cost: std::f64::NEG_INFINITY,
+            grad: None,
+            prev_grad: None,
+            hessian: None,
+            prev_hessian: None,
+            jacobian: None,
+            prev_jacobian: None,
+            population: None,
+            iter: 0,
+            last_best_iter: 0,
+            max_iters: std::u64::MAX,
+            cost_func_count: 0,
+            grad_func_count: 0,
+            hessian_func_count: 0,
+            jacobian_func_count: 0,
+            modify_func_count: 0,
+            time: std::time::Duration::new(0, 0),
+            termination_reason: TerminationReason::NotTerminated,
+        }
+    }
+
+    /// Set parameter vector. This shifts the stored parameter vector to the previous parameter
+    /// vector.
+    pub fn param(&mut self, param: O::Param) -> &mut Self {
+        std::mem::swap(&mut self.prev_param, &mut self.param);
+        self.param = param;
+        self
+    }
+
+    /// Set best paramater vector. This shifts the stored best parameter vector to the previous
+    /// best parameter vector.
+    pub fn best_param(&mut self, param: O::Param) -> &mut Self {
+        std::mem::swap(&mut self.prev_best_param, &mut self.best_param);
+        self.best_param = param;
+        self
+    }
+
+    /// Set the current cost function value. This shifts the stored cost function value to the
+    /// previous cost function value.
+    pub fn cost(&mut self, cost: f64) -> &mut Self {
+        std::mem::swap(&mut self.prev_cost, &mut self.cost);
+        self.cost = cost;
+        self
+    }
+
+    /// Set the current best cost function value. This shifts the stored best cost function value to
+    /// the previous cost function value.
+    pub fn best_cost(&mut self, cost: f64) -> &mut Self {
+        std::mem::swap(&mut self.prev_best_cost, &mut self.best_cost);
+        self.best_cost = cost;
+        self
+    }
+
+    /// Set gradient. This shifts the stored gradient to the previous gradient.
+    pub fn grad(&mut self, grad: O::Param) -> &mut Self {
+        std::mem::swap(&mut self.prev_grad, &mut self.grad);
+        self.grad = Some(grad);
+        self
+    }
+
+    /// Set Hessian. This shifts the stored Hessian to the previous Hessian.
+    pub fn hessian(&mut self, hessian: O::Hessian) -> &mut Self {
+        std::mem::swap(&mut self.prev_hessian, &mut self.hessian);
+        self.hessian = Some(hessian);
+        self
+    }
+
+    /// Set Jacobian. This shifts the stored Jacobian to the previous Jacobian.
+    pub fn jacobian(&mut self, jacobian: O::Jacobian) -> &mut Self {
+        std::mem::swap(&mut self.prev_jacobian, &mut self.jacobian);
+        self.jacobian = Some(jacobian);
+        self
+    }
+
+    /// Set population
+    pub fn population(&mut self, population: Vec<(O::Param, f64)>) -> &mut Self {
+        self.population = Some(population);
+        self
+    }
+
+    /// Set target cost value
+    setter!(target_cost, f64);
+    /// Set maximum number of iterations
+    setter!(max_iters, u64);
+    /// Set iteration number where the previous best parameter vector was found
+    setter!(last_best_iter, u64);
+    /// Set termination_reston
+    setter!(termination_reason, TerminationReason);
+    /// Set time required so far
+    setter!(time, std::time::Duration);
+    /// Returns current parameter vector
+    getter!(param, O::Param);
+    /// Returns previous parameter vector
+    getter!(prev_param, O::Param);
+    /// Returns best parameter vector
+    getter!(best_param, O::Param);
+    /// Returns previous best parameter vector
+    getter!(prev_best_param, O::Param);
+    /// Returns current cost function value
+    getter!(cost, f64);
+    /// Returns previous cost function value
+    getter!(prev_cost, f64);
+    /// Returns current best cost function value
+    getter!(best_cost, f64);
+    /// Returns previous best cost function value
+    getter!(prev_best_cost, f64);
+    /// Returns target cost
+    getter!(target_cost, f64);
+    /// Returns current cost function evaluation count
+    getter!(cost_func_count, u64);
+    /// Returns current gradient function evaluation count
+    getter!(grad_func_count, u64);
+    /// Returns current Hessian function evaluation count
+    getter!(hessian_func_count, u64);
+    /// Returns current Jacobian function evaluation count
+    getter!(jacobian_func_count, u64);
+    /// Returns current Modify function evaluation count
+    getter!(modify_func_count, u64);
+    /// Returns iteration number where the last best parameter vector was found
+    getter!(last_best_iter, u64);
+    /// Get termination_reason
+    getter!(termination_reason, TerminationReason);
+    /// Get time required so far
+    getter!(time, std::time::Duration);
+    /// Returns gradient
+    getter_option!(grad, O::Param);
+    /// Returns previous gradient
+    getter_option!(prev_grad, O::Param);
+    /// Returns current Hessian
+    getter_option!(hessian, O::Hessian);
+    /// Returns previous Hessian
+    getter_option!(prev_hessian, O::Hessian);
+    /// Returns current Jacobian
+    getter_option!(jacobian, O::Jacobian);
+    /// Returns previous Jacobian
+    getter_option!(prev_jacobian, O::Jacobian);
+    /// Returns current number of iterations
+    getter!(iter, u64);
+    /// Returns maximum number of iterations
+    getter!(max_iters, u64);
+
+    /// Returns population
+    pub fn get_population(&self) -> Option<&Vec<(O::Param, f64)>> {
+        match &self.population {
+            Some(population) => Some(&population),
+            None => None,
+        }
+    }
+
+    /// Increment the number of iterations by one
+    pub fn increment_iter(&mut self) {
+        self.iter += 1;
+    }
+
+    /// Increment all function evaluation counts by the evaluation counts of another operator
+    /// wrapped in `OpWrapper`.
+    pub fn increment_func_counts(&mut self, op: &OpWrapper<O>) {
+        self.cost_func_count += op.cost_func_count;
+        self.grad_func_count += op.grad_func_count;
+        self.hessian_func_count += op.hessian_func_count;
+        self.jacobian_func_count += op.jacobian_func_count;
+        self.modify_func_count += op.modify_func_count;
+    }
+
+    /// Set all function evaluation counts to the evaluation counts of another operator
+    /// wrapped in `OpWrapper`.
+    pub fn set_func_counts(&mut self, op: &OpWrapper<O>) {
+        self.cost_func_count = op.cost_func_count;
+        self.grad_func_count = op.grad_func_count;
+        self.hessian_func_count = op.hessian_func_count;
+        self.jacobian_func_count = op.jacobian_func_count;
+        self.modify_func_count = op.modify_func_count;
+    }
+
+    /// Increment cost function evaluation count by `num`
+    pub fn increment_cost_func_count(&mut self, num: u64) {
+        self.cost_func_count += num;
+    }
+
+    /// Increment gradient function evaluation count by `num`
+    pub fn increment_grad_func_count(&mut self, num: u64) {
+        self.grad_func_count += num;
+    }
+
+    /// Increment Hessian function evaluation count by `num`
+    pub fn increment_hessian_func_count(&mut self, num: u64) {
+        self.hessian_func_count += num;
+    }
+
+    /// Increment Jacobian function evaluation count by `num`
+    pub fn increment_jacobian_func_count(&mut self, num: u64) {
+        self.jacobian_func_count += num;
+    }
+
+    /// Increment modify function evaluation count by `num`
+    pub fn increment_modify_func_count(&mut self, num: u64) {
+        self.modify_func_count += num;
+    }
+
+    /// Indicate that a new best parameter vector was found
+    pub fn new_best(&mut self) {
+        self.last_best_iter = self.iter;
+    }
+
+    /// Returns whether the current parameter vector is also the best parameter vector found so
+    /// far.
+    pub fn is_best(&self) -> bool {
+        self.last_best_iter == self.iter
+    }
+
+    /// Return whether the algorithm has terminated or not
+    pub fn terminated(&self) -> bool {
+        self.termination_reason.terminated()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::MinimalNoOperator;
+
+    #[test]
+    fn test_iterstate() {
+        let param = vec![1.0, 2.0];
+        let cost = 42.0;
+
+        let mut state: IterState<MinimalNoOperator> = IterState::new(param.clone());
+
+        assert_eq!(state.get_param(), param);
+        assert_eq!(state.get_prev_param(), param);
+        assert_eq!(state.get_best_param(), param);
+        assert_eq!(state.get_prev_best_param(), param);
+        assert_eq!(state.get_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_prev_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_best_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_prev_best_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_target_cost(), std::f64::NEG_INFINITY);
+        assert_eq!(state.get_grad(), None);
+        assert_eq!(state.get_prev_grad(), None);
+        assert_eq!(state.get_hessian(), None);
+        assert_eq!(state.get_prev_hessian(), None);
+        assert_eq!(state.get_jacobian(), None);
+        assert_eq!(state.get_prev_jacobian(), None);
+        assert_eq!(state.get_iter(), 0);
+        assert_eq!(state.is_best(), true);
+        assert_eq!(state.get_max_iters(), std::u64::MAX);
+        assert_eq!(state.get_cost_func_count(), 0);
+        assert_eq!(state.get_grad_func_count(), 0);
+        assert_eq!(state.get_hessian_func_count(), 0);
+        assert_eq!(state.get_jacobian_func_count(), 0);
+        assert_eq!(state.get_modify_func_count(), 0);
+
+        state.max_iters(42);
+
+        assert_eq!(state.get_max_iters(), 42);
+
+        state.cost(cost);
+
+        assert_eq!(state.get_cost(), cost);
+        assert_eq!(state.get_prev_cost(), std::f64::INFINITY);
+
+        state.best_cost(cost);
+
+        assert_eq!(state.get_best_cost(), cost);
+        assert_eq!(state.get_prev_best_cost(), std::f64::INFINITY);
+
+        let new_param = vec![2.0, 1.0];
+
+        state.param(new_param.clone());
+
+        assert_eq!(state.get_param(), new_param);
+        assert_eq!(state.get_prev_param(), param);
+
+        state.best_param(new_param.clone());
+
+        assert_eq!(state.get_best_param(), new_param);
+        assert_eq!(state.get_prev_best_param(), param);
+
+        let new_cost = 21.0;
+
+        state.cost(new_cost);
+
+        assert_eq!(state.get_cost(), new_cost);
+        assert_eq!(state.get_prev_cost(), cost);
+
+        state.best_cost(new_cost);
+
+        assert_eq!(state.get_best_cost(), new_cost);
+        assert_eq!(state.get_prev_best_cost(), cost);
+
+        state.increment_iter();
+
+        assert_eq!(state.get_iter(), 1);
+
+        assert_eq!(state.is_best(), false);
+
+        state.new_best();
+
+        assert_eq!(state.is_best(), true);
+
+        let grad = vec![1.0, 2.0];
+
+        state.grad(grad.clone());
+        assert_eq!(state.get_grad(), Some(grad.clone()));
+        assert_eq!(state.get_prev_grad(), None);
+
+        let new_grad = vec![2.0, 1.0];
+
+        state.grad(new_grad.clone());
+
+        assert_eq!(state.get_grad(), Some(new_grad.clone()));
+        assert_eq!(state.get_prev_grad(), Some(grad.clone()));
+
+        let hessian = vec![vec![1.0, 2.0], vec![2.0, 1.0]];
+
+        state.hessian(hessian.clone());
+        assert_eq!(state.get_hessian(), Some(hessian.clone()));
+        assert_eq!(state.get_prev_hessian(), None);
+
+        let new_hessian = vec![vec![2.0, 1.0], vec![1.0, 2.0]];
+
+        state.hessian(new_hessian.clone());
+
+        assert_eq!(state.get_hessian(), Some(new_hessian.clone()));
+        assert_eq!(state.get_prev_hessian(), Some(hessian.clone()));
+
+        let jacobian = vec![1.0, 2.0];
+
+        state.jacobian(jacobian.clone());
+        assert_eq!(state.get_jacobian(), Some(jacobian.clone()));
+        assert_eq!(state.get_prev_jacobian(), None);
+
+        let new_jacobian = vec![2.0, 1.0];
+
+        state.jacobian(new_jacobian.clone());
+
+        assert_eq!(state.get_jacobian(), Some(new_jacobian.clone()));
+        assert_eq!(state.get_prev_jacobian(), Some(jacobian.clone()));
+
+        state.increment_iter();
+
+        assert_eq!(state.get_iter(), 2);
+        assert_eq!(state.get_last_best_iter(), 1);
+        assert_eq!(state.is_best(), false);
+
+        state.increment_cost_func_count(42);
+        assert_eq!(state.get_cost_func_count(), 42);
+        state.increment_grad_func_count(43);
+        assert_eq!(state.get_grad_func_count(), 43);
+        state.increment_hessian_func_count(44);
+        assert_eq!(state.get_hessian_func_count(), 44);
+        state.increment_jacobian_func_count(46);
+        assert_eq!(state.get_jacobian_func_count(), 46);
+        state.increment_modify_func_count(45);
+        assert_eq!(state.get_modify_func_count(), 45);
+
+        // check again!
+        assert_eq!(state.get_iter(), 2);
+        assert_eq!(state.get_last_best_iter(), 1);
+        assert_eq!(state.get_max_iters(), 42);
+        assert_eq!(state.is_best(), false);
+        assert_eq!(state.get_cost(), new_cost);
+        assert_eq!(state.get_prev_cost(), cost);
+        assert_eq!(state.get_param(), new_param);
+        assert_eq!(state.get_prev_param(), param);
+        assert_eq!(state.get_best_cost(), new_cost);
+        assert_eq!(state.get_prev_best_cost(), cost);
+        assert_eq!(state.get_best_param(), new_param);
+        assert_eq!(state.get_prev_best_param(), param);
+        assert_eq!(state.get_best_cost(), new_cost);
+        assert_eq!(state.get_prev_best_cost(), cost);
+        assert_eq!(state.get_grad(), Some(new_grad));
+        assert_eq!(state.get_prev_grad(), Some(grad));
+        assert_eq!(state.get_hessian(), Some(new_hessian));
+        assert_eq!(state.get_prev_hessian(), Some(hessian));
+        assert_eq!(state.get_jacobian(), Some(new_jacobian));
+        assert_eq!(state.get_prev_jacobian(), Some(jacobian));
+        assert_eq!(state.get_cost_func_count(), 42);
+        assert_eq!(state.get_grad_func_count(), 43);
+        assert_eq!(state.get_hessian_func_count(), 44);
+        assert_eq!(state.get_jacobian_func_count(), 46);
+        assert_eq!(state.get_modify_func_count(), 45);
+    }
+}

--- a/src/core/kv.rs
+++ b/src/core/kv.rs
@@ -1,0 +1,84 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Key Value storage
+//!
+//! A very simple key-value storage.
+//!
+//! TODOs:
+//!   * Either use something existing, or at least evaluate the performance and if necessary,
+//!     improve performance.
+
+use serde::{Deserialize, Serialize};
+use std;
+
+/// A simple key-value storage
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+pub struct ArgminKV {
+    /// The actual key value storage
+    #[serde(borrow)]
+    pub kv: Vec<(&'static str, String)>,
+}
+
+impl std::fmt::Display for ArgminKV {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "ArgminKV")?;
+        self.kv
+            .iter()
+            .map(|(key, val)| -> std::fmt::Result { writeln!(f, "   {}: {}", key, val) })
+            .count();
+        Ok(())
+    }
+}
+
+impl ArgminKV {
+    /// Constructor
+    pub fn new() -> Self {
+        ArgminKV { kv: vec![] }
+    }
+
+    /// Push a key-value pair to the `kv` vector.
+    ///
+    /// This formats the `val` using `format!`. Therefore `T` has to implement `Display`.
+    pub fn push<T: std::fmt::Display>(&mut self, key: &'static str, val: T) -> &mut Self {
+        self.kv.push((key, format!("{}", val)));
+        self
+    }
+
+    /// Merge another `kv` into `self.kv`
+    pub fn merge(mut self, other: &mut ArgminKV) -> Self {
+        self.kv.append(&mut other.kv);
+        self
+    }
+}
+
+impl std::iter::FromIterator<(&'static str, String)> for ArgminKV {
+    fn from_iter<I: IntoIterator<Item = (&'static str, String)>>(iter: I) -> Self {
+        let mut c = ArgminKV::new();
+
+        for i in iter {
+            c.push(i.0, i.1);
+        }
+
+        c
+    }
+}
+
+impl std::iter::Extend<(&'static str, String)> for ArgminKV {
+    fn extend<I: IntoIterator<Item = (&'static str, String)>>(&mut self, iter: I) {
+        for i in iter {
+            self.push(i.0, i.1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    send_sync_test!(argmin_kv, ArgminKV);
+}

--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -1,0 +1,71 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Macros
+
+/// Creates an `ArgminKV` at compile time in order to avoid pushing to the `kv` vector.
+#[macro_export]
+macro_rules! make_kv {
+    ($($k:expr =>  $v:expr;)*) => {
+        ArgminKV { kv: vec![ $(($k, format!("{:?}", $v))),* ] }
+    };
+}
+
+/// Release an `T` from an `Option<T>` if it is not `None`. If it is `None`, return an
+/// `ArgminError` with a message that needs to be provided.
+#[macro_export]
+macro_rules! check_param {
+    ($param:expr, $msg:expr, $error:ident) => {
+        match $param {
+            None => {
+                return Err(ArgminError::$error {
+                    text: $msg.to_string(),
+                }
+                .into());
+            }
+            Some(ref x) => x.clone(),
+        }
+    };
+    ($param:expr, $msg:expr) => {
+        check_param!($param, $msg, NotInitialized);
+    };
+}
+
+/// Implements a simple send and a simple sync test for a given type.
+#[cfg(test)]
+macro_rules! send_sync_test {
+    ($n:ident, $t:ty) => {
+        paste::item! {
+            #[test]
+            #[allow(non_snake_case)]
+            fn [<test_send_ $n>]() {
+                fn assert_send<T: Send>() {}
+                assert_send::<$t>();
+            }
+        }
+
+        paste::item! {
+            #[test]
+            #[allow(non_snake_case)]
+            fn [<test_sync_ $n>]() {
+                fn assert_sync<T: Sync>() {}
+                assert_sync::<$t>();
+            }
+        }
+    };
+}
+
+/// Reuse a list of trait bounds by giving it a name,
+/// e.g. trait_bound!(CopyAndDefault; Copy, Default);
+#[macro_export]
+macro_rules! trait_bound {
+    ($name:ident ; $head:path $(, $tail:path)*) => {
+        #[allow(missing_docs)]
+        pub trait $name : $head $(+ $tail)* {}
+        impl<T> $name for T where T: $head $(+ $tail)* {}
+    };
+}

--- a/src/core/math/add.rs
+++ b/src/core/math/add.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminAdd;
+use num_complex::Complex;
+
+macro_rules! make_add {
+    ($t:ty) => {
+        impl ArgminAdd<$t, $t> for $t {
+            #[inline]
+            fn add(&self, other: &$t) -> $t {
+                self + other
+            }
+        }
+    };
+}
+
+make_add!(isize);
+make_add!(usize);
+make_add!(i8);
+make_add!(i16);
+make_add!(i32);
+make_add!(i64);
+make_add!(u8);
+make_add!(u16);
+make_add!(u32);
+make_add!(u64);
+make_add!(f32);
+make_add!(f64);
+make_add!(Complex<isize>);
+make_add!(Complex<usize>);
+make_add!(Complex<i8>);
+make_add!(Complex<i16>);
+make_add!(Complex<i32>);
+make_add!(Complex<i64>);
+make_add!(Complex<u8>);
+make_add!(Complex<u16>);
+make_add!(Complex<u32>);
+make_add!(Complex<u64>);
+make_add!(Complex<f32>);
+make_add!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_add_ $t>]() {
+                    let a = 8 as $t;
+                    let b = 34 as $t;
+                    let res = <$t as ArgminAdd<$t, $t>>::add(&a, &b);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/add_ndarray.rs
+++ b/src/core/math/add_ndarray.rs
@@ -1,0 +1,226 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminAdd;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_add {
+    ($t:ty) => {
+        impl ArgminAdd<$t, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn add(&self, other: &$t) -> Array1<$t> {
+                self + *other
+            }
+        }
+
+        impl ArgminAdd<Array1<$t>, Array1<$t>> for $t {
+            #[inline]
+            fn add(&self, other: &Array1<$t>) -> Array1<$t> {
+                *self + other
+            }
+        }
+
+        impl ArgminAdd<Array1<$t>, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn add(&self, other: &Array1<$t>) -> Array1<$t> {
+                self + other
+            }
+        }
+
+        impl ArgminAdd<Array2<$t>, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn add(&self, other: &Array2<$t>) -> Array2<$t> {
+                self + other
+            }
+        }
+
+        impl ArgminAdd<$t, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn add(&self, other: &$t) -> Array2<$t> {
+                self + *other
+            }
+        }
+    };
+}
+
+make_add!(i8);
+make_add!(i16);
+make_add!(i32);
+make_add!(i64);
+make_add!(u8);
+make_add!(u16);
+make_add!(u32);
+make_add!(u64);
+make_add!(f32);
+make_add!(f64);
+make_add!(Complex<f32>);
+make_add!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_add_vec_scalar_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = 34 as $t;
+                    let target = array![35 as $t, 38 as $t, 42 as $t];
+                    let res = <Array1<$t> as ArgminAdd<$t, Array1<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_scalar_vec_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = 34 as $t;
+                    let target = array![35 as $t, 38 as $t, 42 as $t];
+                    let res = <$t as ArgminAdd<Array1<$t>, Array1<$t>>>::add(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_vec_vec_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    let target = array![42 as $t, 42 as $t, 42 as $t];
+                    let res = <Array1<$t> as ArgminAdd<Array1<$t>, Array1<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_ $t>]() {
+                    let a = array![1 as $t, 4 as $t];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminAdd<Array1<$t>, Array1<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_2_ $t>]() {
+                    let a = array![];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminAdd<Array1<$t>, Array1<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_3_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![];
+                    <Array1<$t> as ArgminAdd<Array1<$t>, Array1<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_mat_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![
+                        [41 as $t, 38 as $t, 34 as $t],
+                        [40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    let target = array![
+                        [42 as $t, 42 as $t, 42 as $t],
+                        [42 as $t, 42 as $t, 42 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminAdd<Array2<$t>, Array2<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_scalar_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = array![
+                        [3 as $t, 6 as $t, 10 as $t],
+                        [4 as $t, 7 as $t, 11 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminAdd<$t, Array2<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_2_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![
+                        [41 as $t, 38 as $t],
+                    ];
+                    <Array2<$t> as ArgminAdd<Array2<$t>, Array2<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_3_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![[]];
+                    <Array2<$t> as ArgminAdd<Array2<$t>, Array2<$t>>>::add(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/add_vec.rs
+++ b/src/core/math/add_vec.rs
@@ -1,0 +1,267 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminAdd;
+
+macro_rules! make_add {
+    ($t:ty) => {
+        impl ArgminAdd<$t, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn add(&self, other: &$t) -> Vec<$t> {
+                self.iter().map(|a| a + other).collect()
+            }
+        }
+
+        impl ArgminAdd<Vec<$t>, Vec<$t>> for $t {
+            #[inline]
+            fn add(&self, other: &Vec<$t>) -> Vec<$t> {
+                other.iter().map(|a| a + self).collect()
+            }
+        }
+
+        impl ArgminAdd<Vec<$t>, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn add(&self, other: &Vec<$t>) -> Vec<$t> {
+                let n1 = self.len();
+                let n2 = other.len();
+                assert!(n1 > 0);
+                assert!(n2 > 0);
+                assert_eq!(n1, n2);
+                self.iter().zip(other.iter()).map(|(a, b)| a + b).collect()
+            }
+        }
+
+        impl ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn add(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                let or = other.len();
+                assert!(sr > 0);
+                // implicitly, or > 0
+                assert_eq!(sr, or);
+                let sc = self[0].len();
+                self.iter()
+                    .zip(other.iter())
+                    .map(|(a, b)| {
+                        assert_eq!(a.len(), sc);
+                        assert_eq!(b.len(), sc);
+                        <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b)
+                    })
+                    .collect()
+            }
+        }
+
+        impl ArgminAdd<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn add(&self, other: &$t) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                assert!(sr > 0);
+                let sc = self[0].len();
+                self.iter()
+                    .map(|a| {
+                        assert_eq!(a.len(), sc);
+                        <Vec<$t> as ArgminAdd<$t, Vec<$t>>>::add(&a, &other)
+                    })
+                    .collect()
+            }
+        }
+    };
+}
+
+make_add!(isize);
+make_add!(usize);
+make_add!(i8);
+make_add!(i16);
+make_add!(i32);
+make_add!(i64);
+make_add!(u8);
+make_add!(u16);
+make_add!(u32);
+make_add!(u64);
+make_add!(f32);
+make_add!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_add_vec_scalar_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = 34 as $t;
+                    let target = vec![35 as $t, 38 as $t, 42 as $t];
+                    let res = <Vec<$t> as ArgminAdd<$t, Vec<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_scalar_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = 34 as $t;
+                    let target = vec![35 as $t, 38 as $t, 42 as $t];
+                    let res = <$t as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_vec_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    let target = vec![42 as $t, 42 as $t, 42 as $t];
+                    let res = <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_2_ $t>]() {
+                    let a = vec![];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_3_ $t>]() {
+                    let a = vec![41 as $t, 38 as $t, 34 as $t];
+                    let b = vec![];
+                    <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                        vec![40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    let target = vec![
+                        vec![42 as $t, 42 as $t, 42 as $t],
+                        vec![42 as $t, 42 as $t, 42 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_scalar_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = vec![
+                        vec![3 as $t, 6 as $t, 10 as $t],
+                        vec![4 as $t, 7 as $t, 11 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminAdd<$t, Vec<Vec<$t>>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                        vec![40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                    ];
+                    <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![];
+                    <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/conj.rs
+++ b/src/core/math/conj.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminConj;
+use num_complex::Complex;
+
+macro_rules! make_conj {
+    ($t:ty) => {
+        impl ArgminConj for $t {
+            #[inline]
+            fn conj(&self) -> $t {
+                *self
+            }
+        }
+    };
+}
+
+macro_rules! make_complex_conj {
+    ($t:ty) => {
+        impl ArgminConj for $t {
+            #[inline]
+            fn conj(&self) -> $t {
+                Complex::conj(self)
+            }
+        }
+    };
+}
+
+make_conj!(isize);
+make_conj!(usize);
+make_conj!(i8);
+make_conj!(i16);
+make_conj!(i32);
+make_conj!(i64);
+make_conj!(u8);
+make_conj!(u16);
+make_conj!(u32);
+make_conj!(u64);
+make_conj!(f32);
+make_conj!(f64);
+make_complex_conj!(Complex<isize>);
+make_complex_conj!(Complex<i8>);
+make_complex_conj!(Complex<i16>);
+make_complex_conj!(Complex<i32>);
+make_complex_conj!(Complex<i64>);
+make_complex_conj!(Complex<f32>);
+make_complex_conj!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test_complex {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_complex_conj_ $t>]() {
+                    let a = 8 as $t;
+                    let b = 34 as $t;
+                    let res = <Complex<$t> as ArgminConj>::conj(&Complex::new(a, b));
+                    assert!(((a as $t - res.re) as f64).abs() < std::f64::EPSILON);
+                    assert!(((-b as $t - res.im) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_conj_ $t>]() {
+                    let a = 8 as $t;
+                    let res = <$t as ArgminConj>::conj(&a);
+                    assert!(((a as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test_complex!(isize);
+    make_test_complex!(i8);
+    make_test_complex!(i16);
+    make_test_complex!(i32);
+    make_test_complex!(i64);
+    make_test_complex!(f32);
+    make_test_complex!(f64);
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/conj_ndarray.rs
+++ b/src/core/math/conj_ndarray.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// TODO: Tests for Array2 impl
+
+use crate::core::math::ArgminConj;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_conj {
+    ($t:ty) => {
+        impl ArgminConj for Array1<$t> {
+            #[inline]
+            fn conj(&self) -> Array1<$t> {
+                self.iter().map(|a| <$t as ArgminConj>::conj(a)).collect()
+            }
+        }
+
+        impl ArgminConj for Array2<$t> {
+            #[inline]
+            fn conj(&self) -> Array2<$t> {
+                let n = self.shape();
+                let mut out = self.clone();
+                for i in 0..n[0] {
+                    for j in 0..n[1] {
+                        out[(i, j)] = out[(i, j)].conj();
+                    }
+                }
+                out
+            }
+        }
+    };
+}
+
+make_conj!(isize);
+make_conj!(i8);
+make_conj!(i16);
+make_conj!(i32);
+make_conj!(i64);
+make_conj!(f32);
+make_conj!(f64);
+make_conj!(Complex<isize>);
+make_conj!(Complex<i8>);
+make_conj!(Complex<i16>);
+make_conj!(Complex<i32>);
+make_conj!(Complex<i64>);
+make_conj!(Complex<f32>);
+make_conj!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_conj_complex_ndarray_ $t>]() {
+                    let a = Array1::from(vec![
+                        Complex::new(1 as $t, 2 as $t),
+                        Complex::new(4 as $t, -3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    ]);
+                    let b = vec![
+                        Complex::new(1 as $t, -2 as $t),
+                        Complex::new(4 as $t, 3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    ];
+                    let res = <Array1<Complex<$t>> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let tmp = b[i] - res[i];
+                        let norm = ((tmp.re * tmp.re + tmp.im * tmp.im) as f64).sqrt();
+                        assert!(norm  < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_conj_ndarray_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = vec![1 as $t, 4 as $t, 8 as $t];
+                    let res = <Vec<$t> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let diff = (b[i] as f64 - res[i] as f64).abs();
+                        assert!(diff  < std::f64::EPSILON);
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(i8);
+    make_test!(i16);
+    make_test!(i32);
+    make_test!(i64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/conj_vec.rs
+++ b/src/core/math/conj_vec.rs
@@ -1,0 +1,135 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminConj;
+use num_complex::Complex;
+
+macro_rules! make_conj {
+    ($t:ty) => {
+        impl ArgminConj for Vec<$t> {
+            #[inline]
+            fn conj(&self) -> Vec<$t> {
+                self.iter().map(|a| <$t as ArgminConj>::conj(a)).collect()
+            }
+        }
+
+        impl ArgminConj for Vec<Vec<$t>> {
+            #[inline]
+            fn conj(&self) -> Vec<Vec<$t>> {
+                self.iter()
+                    .map(|a| a.iter().map(|b| <$t as ArgminConj>::conj(b)).collect())
+                    .collect()
+            }
+        }
+    };
+}
+
+make_conj!(isize);
+make_conj!(i8);
+make_conj!(i16);
+make_conj!(i32);
+make_conj!(i64);
+make_conj!(f32);
+make_conj!(f64);
+make_conj!(Complex<isize>);
+make_conj!(Complex<i8>);
+make_conj!(Complex<i16>);
+make_conj!(Complex<i32>);
+make_conj!(Complex<i64>);
+make_conj!(Complex<f32>);
+make_conj!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_conj_complex_vec_ $t>]() {
+                    let a = vec![
+                        Complex::new(1 as $t, 2 as $t),
+                        Complex::new(4 as $t, -3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    ];
+                    let b = vec![
+                        Complex::new(1 as $t, -2 as $t),
+                        Complex::new(4 as $t, 3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    ];
+                    let res = <Vec<Complex<$t>> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let tmp = b[i] - res[i];
+                        let norm = ((tmp.re * tmp.re + tmp.im * tmp.im) as f64).sqrt();
+                        assert!(norm  < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_conj_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = vec![1 as $t, 4 as $t, 8 as $t];
+                    let res = <Vec<$t> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let diff = (b[i] as f64 - res[i] as f64).abs();
+                        assert!(diff  < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_conj_complex_vec_vec_ $t>]() {
+                    let a = vec![
+                        vec![
+                            Complex::new(1 as $t, 2 as $t),
+                            Complex::new(4 as $t, -3 as $t),
+                            Complex::new(8 as $t, 0 as $t)
+                        ],
+                        vec![
+                            Complex::new(1 as $t, -5 as $t),
+                            Complex::new(4 as $t, 6 as $t),
+                            Complex::new(8 as $t, 0 as $t)
+                        ],
+                    ];
+                    let b = vec![
+                        vec![
+                            Complex::new(1 as $t, -2 as $t),
+                            Complex::new(4 as $t, 3 as $t),
+                            Complex::new(8 as $t, 0 as $t)
+                        ],
+                        vec![
+                            Complex::new(1 as $t, 5 as $t),
+                            Complex::new(4 as $t, -6 as $t),
+                            Complex::new(8 as $t, 0 as $t)
+                        ],
+                    ];
+                    let res = <Vec<Vec<Complex<$t>>> as ArgminConj>::conj(&a);
+                    for i in 0..2 {
+                        for j in 0..3 {
+                            let tmp = b[i][j] - res[i][j];
+                            let norm = ((tmp.re * tmp.re + tmp.im * tmp.im) as f64).sqrt();
+                            assert!(norm  < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(i8);
+    make_test!(i16);
+    make_test!(i32);
+    make_test!(i64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/div.rs
+++ b/src/core/math/div.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDiv;
+use num_complex::Complex;
+
+macro_rules! make_div {
+    ($t:ty) => {
+        impl ArgminDiv<$t, $t> for $t {
+            #[inline]
+            fn div(&self, other: &$t) -> $t {
+                self / other
+            }
+        }
+    };
+}
+
+make_div!(isize);
+make_div!(usize);
+make_div!(i8);
+make_div!(u8);
+make_div!(i16);
+make_div!(u16);
+make_div!(i32);
+make_div!(u32);
+make_div!(i64);
+make_div!(u64);
+make_div!(f32);
+make_div!(f64);
+make_div!(Complex<isize>);
+make_div!(Complex<usize>);
+make_div!(Complex<i8>);
+make_div!(Complex<u8>);
+make_div!(Complex<i16>);
+make_div!(Complex<u16>);
+make_div!(Complex<i32>);
+make_div!(Complex<u32>);
+make_div!(Complex<i64>);
+make_div!(Complex<u64>);
+make_div!(Complex<f32>);
+make_div!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_div_ $t>]() {
+                    let a = 84 as $t;
+                    let b = 2 as $t;
+                    let res = <$t as ArgminDiv<$t, $t>>::div(&a, &b);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/div_ndarray.rs
+++ b/src/core/math/div_ndarray.rs
@@ -1,0 +1,198 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDiv;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_div {
+    ($t:ty) => {
+        impl ArgminDiv<$t, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn div(&self, other: &$t) -> Array1<$t> {
+                self / *other
+            }
+        }
+
+        impl ArgminDiv<Array1<$t>, Array1<$t>> for $t {
+            #[inline]
+            fn div(&self, other: &Array1<$t>) -> Array1<$t> {
+                *self / other
+            }
+        }
+
+        impl ArgminDiv<Array1<$t>, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn div(&self, other: &Array1<$t>) -> Array1<$t> {
+                self / other
+            }
+        }
+
+        impl ArgminDiv<Array2<$t>, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn div(&self, other: &Array2<$t>) -> Array2<$t> {
+                self / other
+            }
+        }
+    };
+}
+
+make_div!(i8);
+make_div!(u8);
+make_div!(i16);
+make_div!(u16);
+make_div!(i32);
+make_div!(u32);
+make_div!(i64);
+make_div!(u64);
+make_div!(f32);
+make_div!(f64);
+make_div!(Complex<f32>);
+make_div!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_div_vec_scalar_ $t>]() {
+                    let a = array![4 as $t, 16 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = array![2 as $t, 8 as $t, 4 as $t];
+                    let res = <Array1<$t> as ArgminDiv<$t, Array1<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_scalar_vec_ $t>]() {
+                    let a = array![2 as $t, 4 as $t, 8 as $t];
+                    let b = 32 as $t;
+                    let target = array![16 as $t, 8 as $t, 4 as $t];
+                    let res = <$t as ArgminDiv<Array1<$t>, Array1<$t>>>::div(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_vec_vec_ $t>]() {
+                    let a = array![4 as $t, 9 as $t, 8 as $t];
+                    let b = array![2 as $t, 3 as $t, 4 as $t];
+                    let target = array![2 as $t, 3 as $t, 2 as $t];
+                    let res = <Array1<$t> as ArgminDiv<Array1<$t>, Array1<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_ $t>]() {
+                    let a = array![1 as $t, 4 as $t];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminDiv<Array1<$t>, Array1<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_2_ $t>]() {
+                    let a = array![];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminDiv<Array1<$t>, Array1<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_3_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![];
+                    <Array1<$t> as ArgminDiv<Array1<$t>, Array1<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_mat_mat_ $t>]() {
+                    let a = array![
+                        [4 as $t, 12 as $t, 8 as $t],
+                        [9 as $t, 20 as $t, 45 as $t]
+                    ];
+                    let b = array![
+                        [2 as $t, 3 as $t, 4 as $t],
+                        [3 as $t, 4 as $t, 5 as $t]
+                    ];
+                    let target = array![
+                        [2 as $t, 4 as $t, 2 as $t],
+                        [3 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminDiv<Array2<$t>, Array2<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_2_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![
+                        [41 as $t, 38 as $t],
+                    ];
+                    <Array2<$t> as ArgminDiv<Array2<$t>, Array2<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_3_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![[]];
+                    <Array2<$t> as ArgminDiv<Array2<$t>, Array2<$t>>>::div(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/div_vec.rs
+++ b/src/core/math/div_vec.rs
@@ -1,0 +1,244 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDiv;
+use num_complex::Complex;
+
+macro_rules! make_div {
+    ($t:ty) => {
+        impl ArgminDiv<$t, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn div(&self, other: &$t) -> Vec<$t> {
+                self.iter().map(|a| a / other).collect()
+            }
+        }
+
+        impl ArgminDiv<Vec<$t>, Vec<$t>> for $t {
+            #[inline]
+            fn div(&self, other: &Vec<$t>) -> Vec<$t> {
+                other.iter().map(|a| self / a).collect()
+            }
+        }
+
+        impl ArgminDiv<Vec<$t>, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn div(&self, other: &Vec<$t>) -> Vec<$t> {
+                let n1 = self.len();
+                let n2 = other.len();
+                assert!(n1 > 0);
+                assert!(n2 > 0);
+                assert_eq!(n1, n2);
+                self.iter().zip(other.iter()).map(|(a, b)| a / b).collect()
+            }
+        }
+
+        impl ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn div(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                let or = other.len();
+                assert!(sr > 0);
+                // implicitly, or > 0
+                assert_eq!(sr, or);
+                let sc = self[0].len();
+                self.iter()
+                    .zip(other.iter())
+                    .map(|(a, b)| {
+                        assert_eq!(a.len(), sc);
+                        assert_eq!(b.len(), sc);
+                        <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b)
+                    })
+                    .collect()
+            }
+        }
+    };
+}
+
+make_div!(isize);
+make_div!(usize);
+make_div!(i8);
+make_div!(u8);
+make_div!(i16);
+make_div!(u16);
+make_div!(i32);
+make_div!(u32);
+make_div!(i64);
+make_div!(u64);
+make_div!(f32);
+make_div!(f64);
+make_div!(Complex<isize>);
+make_div!(Complex<usize>);
+make_div!(Complex<i8>);
+make_div!(Complex<u8>);
+make_div!(Complex<i16>);
+make_div!(Complex<u16>);
+make_div!(Complex<i32>);
+make_div!(Complex<u32>);
+make_div!(Complex<i64>);
+make_div!(Complex<u64>);
+make_div!(Complex<f32>);
+make_div!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_div_vec_scalar_ $t>]() {
+                    let a = vec![2 as $t, 4 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = vec![1 as $t, 2 as $t, 4 as $t];
+                    let res = <Vec<$t> as ArgminDiv<$t, Vec<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_scalar_vec_ $t>]() {
+                    let a = vec![2 as $t, 4 as $t, 8 as $t];
+                    let b = 64 as $t;
+                    let target = vec![32 as $t, 16 as $t, 8 as $t];
+                    let res = <$t as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_vec_vec_ $t>]() {
+                    let a = vec![4 as $t, 9 as $t, 8 as $t];
+                    let b = vec![2 as $t, 3 as $t, 4 as $t];
+                    let target = vec![2 as $t, 3 as $t, 2 as $t];
+                    let res = <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_2_ $t>]() {
+                    let a = vec![];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_3_ $t>]() {
+                    let a = vec![41 as $t, 38 as $t, 34 as $t];
+                    let b = vec![];
+                    <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![4 as $t, 12 as $t, 8 as $t],
+                        vec![9 as $t, 20 as $t, 45 as $t]
+                    ];
+                    let b = vec![
+                        vec![2 as $t, 3 as $t, 4 as $t],
+                        vec![3 as $t, 4 as $t, 5 as $t]
+                    ];
+                    let target = vec![
+                        vec![2 as $t, 4 as $t, 2 as $t],
+                        vec![3 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                        vec![40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                    ];
+                    <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![];
+                    <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/dot.rs
+++ b/src/core/math/dot.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDot;
+use num_complex::Complex;
+
+macro_rules! make_dot_vec {
+    ($t:ty) => {
+        impl<'a> ArgminDot<$t, $t> for $t {
+            #[inline]
+            fn dot(&self, other: &$t) -> $t {
+                self * other
+            }
+        }
+    };
+}
+
+make_dot_vec!(f32);
+make_dot_vec!(f64);
+make_dot_vec!(i8);
+make_dot_vec!(i16);
+make_dot_vec!(i32);
+make_dot_vec!(i64);
+make_dot_vec!(u8);
+make_dot_vec!(u16);
+make_dot_vec!(u32);
+make_dot_vec!(u64);
+make_dot_vec!(isize);
+make_dot_vec!(usize);
+make_dot_vec!(Complex<f32>);
+make_dot_vec!(Complex<f64>);
+make_dot_vec!(Complex<i8>);
+make_dot_vec!(Complex<i16>);
+make_dot_vec!(Complex<i32>);
+make_dot_vec!(Complex<i64>);
+make_dot_vec!(Complex<u8>);
+make_dot_vec!(Complex<u16>);
+make_dot_vec!(Complex<u32>);
+make_dot_vec!(Complex<u64>);
+make_dot_vec!(Complex<isize>);
+make_dot_vec!(Complex<usize>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_vec_vec_ $t>]() {
+                    let a = 21 as $t;
+                    let b = 2 as $t;
+                    let res = a.dot(&b);
+                    assert!((((res - 42 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/dot_ndarray.rs
+++ b/src/core/math/dot_ndarray.rs
@@ -1,0 +1,327 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDot;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_dot_ndarray {
+    ($t:ty) => {
+        impl ArgminDot<Array1<$t>, $t> for Array1<$t> {
+            #[inline]
+            fn dot(&self, other: &Array1<$t>) -> $t {
+                ndarray::Array1::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<$t, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn dot(&self, other: &$t) -> Array1<$t> {
+                *other * self
+            }
+        }
+
+        impl<'a> ArgminDot<Array1<$t>, Array1<$t>> for $t {
+            #[inline]
+            fn dot(&self, other: &Array1<$t>) -> Array1<$t> {
+                other * *self
+            }
+        }
+
+        impl ArgminDot<Array1<$t>, Array2<$t>> for Array1<$t> {
+            #[inline]
+            fn dot(&self, other: &Array1<$t>) -> Array2<$t> {
+                let mut out = Array2::zeros((self.len(), other.len()));
+                for i in 0..self.len() {
+                    for j in 0..other.len() {
+                        out[(i, j)] = self[i] * other[j];
+                    }
+                }
+                out
+            }
+        }
+
+        impl ArgminDot<Array1<$t>, Array1<$t>> for Array2<$t> {
+            #[inline]
+            fn dot(&self, other: &Array1<$t>) -> Array1<$t> {
+                ndarray::Array2::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<Array2<$t>, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn dot(&self, other: &Array2<$t>) -> Array2<$t> {
+                ndarray::Array2::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<$t, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn dot(&self, other: &$t) -> Array2<$t> {
+                *other * self
+            }
+        }
+
+        impl<'a> ArgminDot<Array2<$t>, Array2<$t>> for $t {
+            #[inline]
+            fn dot(&self, other: &Array2<$t>) -> Array2<$t> {
+                other * *self
+            }
+        }
+    };
+}
+
+macro_rules! make_dot_complex_ndarray {
+    ($t:ty) => {
+        impl ArgminDot<Array1<Complex<$t>>, Complex<$t>> for Array1<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Array1<Complex<$t>>) -> Complex<$t> {
+                ndarray::Array1::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<Complex<$t>, Array1<Complex<$t>>> for Array1<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Complex<$t>) -> Array1<Complex<$t>> {
+                *other * self
+            }
+        }
+
+        impl<'a> ArgminDot<Array1<Complex<$t>>, Array1<Complex<$t>>> for Complex<$t> {
+            #[inline]
+            fn dot(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
+                other * *self
+            }
+        }
+
+        impl ArgminDot<Array1<Complex<$t>>, Array2<Complex<$t>>> for Array1<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Array1<Complex<$t>>) -> Array2<Complex<$t>> {
+                let mut out = Array2::zeros((self.len(), other.len()));
+                for i in 0..self.len() {
+                    for j in 0..other.len() {
+                        out[(i, j)] = self[i] * other[j];
+                    }
+                }
+                out
+            }
+        }
+
+        impl ArgminDot<Array1<Complex<$t>>, Array1<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
+                ndarray::Array2::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<Array2<Complex<$t>>, Array2<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
+                ndarray::Array2::dot(self, other)
+            }
+        }
+
+        impl ArgminDot<Complex<$t>, Array2<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn dot(&self, other: &Complex<$t>) -> Array2<Complex<$t>> {
+                *other * self
+            }
+        }
+
+        impl<'a> ArgminDot<Array2<Complex<$t>>, Array2<Complex<$t>>> for Complex<$t> {
+            #[inline]
+            fn dot(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
+                other * *self
+            }
+        }
+    };
+}
+
+make_dot_ndarray!(f32);
+make_dot_ndarray!(f64);
+make_dot_complex_ndarray!(f32);
+make_dot_complex_ndarray!(f64);
+make_dot_ndarray!(i8);
+make_dot_ndarray!(i16);
+make_dot_ndarray!(i32);
+make_dot_ndarray!(i64);
+make_dot_ndarray!(u8);
+make_dot_ndarray!(u16);
+make_dot_ndarray!(u32);
+make_dot_ndarray!(u64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_vec_vec_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![4 as $t, 5 as $t, 6 as $t];
+                    let res: $t = <Array1<$t> as ArgminDot<Array1<$t>, $t>>::dot(&a, &b);
+                    assert!((((res - 32 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_vec_scalar_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let product: Array1<$t> =
+                        <Array1<$t> as ArgminDot<$t, Array1<$t>>>::dot(&a, &b);
+                    let res = array![2 as $t, 4 as $t, 6 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scalar_vec_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let product: Array1<$t> =
+                        <$t as ArgminDot<Array1<$t>, Array1<$t>>>::dot(&b, &a);
+                    let res = array![2 as $t, 4 as $t, 6 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![4 as $t, 5 as $t, 6 as $t];
+                    let res = array![
+                        [4 as $t, 5 as $t, 6 as $t],
+                        [8 as $t, 10 as $t, 12 as $t],
+                        [12 as $t, 15 as $t, 18 as $t]
+                    ];
+                    let product: Array2<$t> =
+                        <Array1<$t> as ArgminDot<Array1<$t>, Array2<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_2_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t, 3 as $t],
+                        [4 as $t, 5 as $t, 6 as $t],
+                        [7 as $t, 8 as $t, 9 as $t]
+                    ];
+                    let b = array![1 as $t, 2 as $t, 3 as $t];
+                    let res = array![14 as $t, 32 as $t, 50 as $t];
+                    let product: Array1<$t> =
+                        <Array2<$t> as ArgminDot<Array1<$t>, Array1<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_mat_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t, 3 as $t],
+                        [4 as $t, 5 as $t, 6 as $t],
+                        [3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let b = array![
+                        [3 as $t, 2 as $t, 1 as $t],
+                        [6 as $t, 5 as $t, 4 as $t],
+                        [2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    let res = array![
+                        [21 as $t, 24 as $t, 18 as $t],
+                        [54 as $t, 57 as $t, 42 as $t],
+                        [23 as $t, 20 as $t, 14 as $t]
+                    ];
+                    let product: Array2<$t> =
+                        <Array2<$t> as ArgminDot<Array2<$t>, Array2<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_primitive_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t, 3 as $t],
+                        [4 as $t, 5 as $t, 6 as $t],
+                        [3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let res = array![
+                        [2 as $t, 4 as $t, 6 as $t],
+                        [8 as $t, 10 as $t, 12 as $t],
+                        [6 as $t, 4 as $t, 2 as $t]
+                    ];
+                    let product: Array2<$t> =
+                        <Array2<$t> as ArgminDot<$t, Array2<$t>>>::dot(&a, &(2 as $t));
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_primitive_mat_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t, 3 as $t],
+                        [4 as $t, 5 as $t, 6 as $t],
+                        [3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let res = array![
+                        [2 as $t, 4 as $t, 6 as $t],
+                        [8 as $t, 10 as $t, 12 as $t],
+                        [6 as $t, 4 as $t, 2 as $t]
+                    ];
+                    let product: Array2<$t> =
+                        <$t as ArgminDot<Array2<$t>, Array2<$t>>>::dot(&(2 as $t), &a);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/dot_vec.rs
+++ b/src/core/math/dot_vec.rs
@@ -1,0 +1,390 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDot;
+use crate::core::math::ArgminTranspose;
+use num_complex::Complex;
+
+macro_rules! make_dot_vec {
+    ($t:ty) => {
+        impl<'a> ArgminDot<Vec<$t>, $t> for Vec<$t> {
+            #[inline]
+            fn dot(&self, other: &Vec<$t>) -> $t {
+                self.iter().zip(other.iter()).map(|(a, b)| a * b).sum()
+            }
+        }
+
+        impl<'a> ArgminDot<$t, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn dot(&self, other: &$t) -> Vec<$t> {
+                self.iter().map(|a| a * other).collect()
+            }
+        }
+
+        impl<'a> ArgminDot<Vec<$t>, Vec<$t>> for $t {
+            #[inline]
+            fn dot(&self, other: &Vec<$t>) -> Vec<$t> {
+                other.iter().map(|a| a * self).collect()
+            }
+        }
+
+        impl ArgminDot<Vec<$t>, Vec<Vec<$t>>> for Vec<$t> {
+            #[inline]
+            fn dot(&self, other: &Vec<$t>) -> Vec<Vec<$t>> {
+                self.iter()
+                    .map(|b| other.iter().map(|a| a * b).collect())
+                    .collect()
+            }
+        }
+
+        impl ArgminDot<Vec<$t>, Vec<$t>> for Vec<Vec<$t>> {
+            #[inline]
+            fn dot(&self, other: &Vec<$t>) -> Vec<$t> {
+                (0..self.len()).map(|i| self[i].dot(other)).collect()
+            }
+        }
+
+        impl ArgminDot<Vec<Vec<$t>>, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn dot(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                // Would be more efficient if this wasn't necessary!
+                let other = other.clone().t();
+                let sr = self.len();
+                assert!(sr > 0);
+                let sc = self[0].len();
+                assert!(sc > 0);
+                let or = other.len();
+                assert!(or > 0);
+                let oc = other[0].len();
+                assert_eq!(sc, or);
+                assert!(oc > 0);
+                let mut v = Vec::with_capacity(oc);
+                unsafe {
+                    v.set_len(oc);
+                }
+                let mut out = vec![v; sr];
+                for i in 0..sr {
+                    assert_eq!(self[i].len(), sc);
+                    // assert_eq!(other[i].len(), oc);
+                    for j in 0..oc {
+                        out[i][j] = self[i].dot(&other[j]);
+                    }
+                }
+                out
+            }
+        }
+
+        impl<'a> ArgminDot<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn dot(&self, other: &$t) -> Vec<Vec<$t>> {
+                (0..self.len())
+                    .map(|i| self[i].iter().map(|a| a * other).collect())
+                    .collect()
+            }
+        }
+
+        impl<'a> ArgminDot<Vec<Vec<$t>>, Vec<Vec<$t>>> for $t {
+            #[inline]
+            fn dot(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                (0..other.len())
+                    .map(|i| other[i].iter().map(|a| a * self).collect())
+                    .collect()
+            }
+        }
+    };
+}
+
+make_dot_vec!(f32);
+make_dot_vec!(f64);
+make_dot_vec!(i8);
+make_dot_vec!(i16);
+make_dot_vec!(i32);
+make_dot_vec!(i64);
+make_dot_vec!(u8);
+make_dot_vec!(u16);
+make_dot_vec!(u32);
+make_dot_vec!(u64);
+make_dot_vec!(isize);
+make_dot_vec!(usize);
+make_dot_vec!(Complex<f32>);
+make_dot_vec!(Complex<f64>);
+make_dot_vec!(Complex<i8>);
+make_dot_vec!(Complex<i16>);
+make_dot_vec!(Complex<i32>);
+make_dot_vec!(Complex<i64>);
+make_dot_vec!(Complex<u8>);
+make_dot_vec!(Complex<u16>);
+make_dot_vec!(Complex<u32>);
+make_dot_vec!(Complex<u64>);
+make_dot_vec!(Complex<isize>);
+make_dot_vec!(Complex<usize>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_vec_vec_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res: $t = a.dot(&b);
+                    assert!((((res - 32 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_vec_scalar_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let product = a.dot(&b);
+                    let res = vec![2 as $t, 4 as $t, 6 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scalar_vec_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let product = b.dot(&a);
+                    let res = vec![2 as $t, 4 as $t, 6 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res = vec![
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![8 as $t, 10 as $t, 12 as $t],
+                        vec![12 as $t, 15 as $t, 18 as $t]
+                    ];
+                    let product: Vec<Vec<$t>> = a.dot(&b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![7 as $t, 8 as $t, 9 as $t]
+                    ];
+                    let b = vec![1 as $t, 2 as $t, 3 as $t];
+                    let res = vec![14 as $t, 32 as $t, 50 as $t];
+                    let product = a.dot(&b);
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    let res = vec![
+                        vec![21 as $t, 24 as $t, 18 as $t],
+                        vec![54 as $t, 57 as $t, 42 as $t],
+                        vec![23 as $t, 20 as $t, 14 as $t]
+                    ];
+                    let product = a.dot(&b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_1_ $t>]() {
+                    let a = vec![];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    a.dot(&b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_2_ $t>]() {
+                    let a: Vec<Vec<$t>> = vec![];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    b.dot(&a);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![4 as $t, 5 as $t],
+                        vec![3 as $t, 2 as $t]
+                    ];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    a.dot(&b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_4_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t],
+                        vec![6 as $t, 5 as $t],
+                        vec![3 as $t, 2 as $t]
+                    ];
+                    a.dot(&b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_5_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 3 as $t]
+                    ];
+                    a.dot(&b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mat_mat_panic_6_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let b = vec![
+                        vec![3 as $t, 2 as $t, 1 as $t],
+                        vec![6 as $t, 5 as $t, 4 as $t],
+                        vec![2 as $t, 4 as $t, 3 as $t]
+                    ];
+                    a.dot(&b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_primitive_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let res = vec![
+                        vec![2 as $t, 4 as $t, 6 as $t],
+                        vec![8 as $t, 10 as $t, 12 as $t],
+                        vec![6 as $t, 4 as $t, 2 as $t]
+                    ];
+                    let product = a.dot(&(2 as $t));
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_primitive_mat_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t, 3 as $t],
+                        vec![4 as $t, 5 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 1 as $t]
+                    ];
+                    let res = vec![
+                        vec![2 as $t, 4 as $t, 6 as $t],
+                        vec![8 as $t, 10 as $t, 12 as $t],
+                        vec![6 as $t, 4 as $t, 2 as $t]
+                    ];
+                    let product = (2 as $t).dot(&a);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/eye_ndarray.rs
+++ b/src/core/math/eye_ndarray.rs
@@ -1,0 +1,116 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminEye;
+use ndarray::Array2;
+
+macro_rules! make_eye {
+    ($t:ty) => {
+        impl ArgminEye for Array2<$t> {
+            #[inline]
+            fn eye_like(&self) -> Array2<$t> {
+                // TODO: Should return an error!
+                assert!(self.is_square());
+                ndarray::Array2::eye(self.dim().0)
+            }
+
+            #[inline]
+            fn eye(n: usize) -> Array2<$t> {
+                ndarray::Array2::eye(n)
+            }
+        }
+    };
+}
+
+make_eye!(isize);
+make_eye!(usize);
+make_eye!(i8);
+make_eye!(i16);
+make_eye!(i32);
+make_eye!(i64);
+make_eye!(u8);
+make_eye!(u16);
+make_eye!(u32);
+make_eye!(u64);
+make_eye!(f32);
+make_eye!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_eye_ $t>]() {
+                    let e: Array2<$t> = <Array2<$t> as ArgminEye>::eye(3);
+                    let res = array![
+                        [1 as $t, 0 as $t, 0 as $t],
+                        [0 as $t, 1 as $t, 0 as $t],
+                        [0 as $t, 0 as $t, 1 as $t]
+                    ];
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - e[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_eye_like_ $t>]() {
+                    let a = array![
+                        [0 as $t, 2 as $t, 6 as $t],
+                        [3 as $t, 2 as $t, 7 as $t],
+                        [9 as $t, 8 as $t, 1 as $t]
+                    ];
+                    let e: Array2<$t> = a.eye_like();
+                    let res = array![
+                        [1 as $t, 0 as $t, 0 as $t],
+                        [0 as $t, 1 as $t, 0 as $t],
+                        [0 as $t, 0 as $t, 1 as $t]
+                    ];
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - e[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                #[allow(unused)]
+                fn [<test_eye_like_panic_ $t>]() {
+                    let a = array![
+                        [0 as $t, 2 as $t, 6 as $t],
+                        [3 as $t, 2 as $t, 7 as $t],
+                    ];
+                    let e: Array2<$t> = a.eye_like();
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/eye_vec.rs
+++ b/src/core/math/eye_vec.rs
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminEye;
+
+macro_rules! make_eye {
+    ($t:ty) => {
+        impl ArgminEye for Vec<Vec<$t>> {
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn eye_like(&self) -> Vec<Vec<$t>> {
+                let n = self.len();
+                let mut out = vec![vec![0 as $t; n]; n];
+                for i in 0..n {
+                    out[i][i] = 1 as $t;
+                }
+                out
+            }
+
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn eye(n: usize) -> Vec<Vec<$t>> {
+                let mut out = vec![vec![0 as $t; n]; n];
+                for i in 0..n {
+                    out[i][i] = 1 as $t;
+                }
+                out
+            }
+        }
+    };
+}
+
+make_eye!(f32);
+make_eye!(f64);
+make_eye!(i8);
+make_eye!(i16);
+make_eye!(i32);
+make_eye!(i64);
+make_eye!(u8);
+make_eye!(u16);
+make_eye!(u32);
+make_eye!(u64);
+make_eye!(isize);
+make_eye!(usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_eye_ $t>]() {
+                    let e: Vec<Vec<$t>> = <Vec<Vec<$t>> as ArgminEye>::eye(3);
+                    let res = vec![
+                        vec![1 as $t, 0 as $t, 0 as $t],
+                        vec![0 as $t, 1 as $t, 0 as $t],
+                        vec![0 as $t, 0 as $t, 1 as $t]
+                    ];
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - e[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_eye_like_ $t>]() {
+                    let a = vec![
+                        vec![0 as $t, 2 as $t, 6 as $t],
+                        vec![3 as $t, 2 as $t, 7 as $t],
+                        vec![9 as $t, 8 as $t, 1 as $t]
+                    ];
+                    let e: Vec<Vec<$t>> = a.eye_like();
+                    let res = vec![
+                        vec![1 as $t, 0 as $t, 0 as $t],
+                        vec![0 as $t, 1 as $t, 0 as $t],
+                        vec![0 as $t, 0 as $t, 1 as $t]
+                    ];
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[i][j] - e[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/inv_ndarray.rs
+++ b/src/core/math/inv_ndarray.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminInv;
+use crate::core::Error;
+use ndarray::Array2;
+use ndarray_linalg::Inverse;
+use num_complex::Complex;
+
+macro_rules! make_inv {
+    ($t:ty) => {
+        impl<'a> ArgminInv<Array2<$t>> for Array2<$t>
+        where
+            Array2<$t>: Inverse,
+        {
+            #[inline]
+            fn inv(&self) -> Result<Array2<$t>, Error> {
+                // Stupid error types...
+                Ok(<Self as Inverse>::inv(&self)?)
+            }
+        }
+    };
+}
+
+make_inv!(f32);
+make_inv!(f64);
+make_inv!(Complex<f32>);
+make_inv!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_inv_ $t>]() {
+                    let a = array![
+                        [2 as $t, 5 as $t],
+                        [1 as $t, 3 as $t],
+                    ];
+                    let target = array![
+                        [3 as $t, -5 as $t],
+                        [-1 as $t, 2 as $t],
+                    ];
+                    let res = <Array2<$t> as ArgminInv<Array2<$t>>>::inv(&a).unwrap();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/minmax.rs
+++ b/src/core/math/minmax.rs
@@ -1,0 +1,51 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMinMax;
+use num_complex::Complex;
+
+macro_rules! make_minmax {
+    ($t:ty) => {
+        impl ArgminMinMax for $t {
+            #[inline]
+            fn min(x: &Self, y: &Self) -> $t {
+                std::cmp::min(x, y)
+            }
+
+            fn max(x: &Self, y: &Self) -> $t {
+                std::cmp::max(x, y)
+            }
+        }
+    };
+}
+
+make_minmax!(f32);
+make_minmax!(f64);
+make_minmax!(i8);
+make_minmax!(i16);
+make_minmax!(i32);
+make_minmax!(i64);
+make_minmax!(u8);
+make_minmax!(u16);
+make_minmax!(u32);
+make_minmax!(u64);
+make_minmax!(isize);
+make_minmax!(usize);
+make_minmax!(Complex<f32>);
+make_minmax!(Complex<f64>);
+make_minmax!(Complex<i8>);
+make_minmax!(Complex<i16>);
+make_minmax!(Complex<i32>);
+make_minmax!(Complex<i64>);
+make_minmax!(Complex<u8>);
+make_minmax!(Complex<u16>);
+make_minmax!(Complex<u32>);
+make_minmax!(Complex<u64>);
+make_minmax!(Complex<isize>);
+make_minmax!(Complex<usize>);
+
+// TODO: tests!!!

--- a/src/core/math/minmax_vec.rs
+++ b/src/core/math/minmax_vec.rs
@@ -1,0 +1,33 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMinMax;
+
+impl<T> ArgminMinMax for Vec<T>
+where
+    T: std::cmp::PartialOrd + Clone,
+{
+    fn min(x: &Self, y: &Self) -> Vec<T> {
+        assert!(!x.is_empty());
+        assert_eq!(x.len(), y.len());
+
+        x.iter()
+            .zip(y.iter())
+            .map(|(a, b)| if a < b { a.clone() } else { b.clone() })
+            .collect()
+    }
+
+    fn max(x: &Self, y: &Self) -> Vec<T> {
+        assert!(!x.is_empty());
+        assert_eq!(x.len(), y.len());
+
+        x.iter()
+            .zip(y.iter())
+            .map(|(a, b)| if a > b { a.clone() } else { b.clone() })
+            .collect()
+    }
+}

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -1,0 +1,248 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Math
+//!
+//! Mathematics related traits which some solvers require. This provides an abstraction over
+//! different types of parameter vectors. The idea is, that it does not matter whether you would
+//! like to use simple `Vec`s, `ndarray`, `nalgebra` or custom defined types: As long as the traits
+//! required by the solver are implemented, you should be fine. In this module several of these
+//! traits are defined and implemented. These will be extended as needed. They are also already
+//! implemented for basic `Vec`s, and will in the future also be implemented for types defined by
+//! `ndarray` and `nalgebra`.
+//!
+//! # TODO
+//!
+//! * Implement tests for Complex<T> impls
+
+mod add;
+#[cfg(feature = "ndarrayl")]
+mod add_ndarray;
+mod add_vec;
+mod conj;
+#[cfg(feature = "ndarrayl")]
+mod conj_ndarray;
+mod conj_vec;
+mod div;
+#[cfg(feature = "ndarrayl")]
+mod div_ndarray;
+mod div_vec;
+mod dot;
+#[cfg(feature = "ndarrayl")]
+mod dot_ndarray;
+mod dot_vec;
+#[cfg(feature = "ndarrayl")]
+mod eye_ndarray;
+mod eye_vec;
+#[cfg(feature = "ndarrayl")]
+mod inv_ndarray;
+mod mul;
+#[cfg(feature = "ndarrayl")]
+mod mul_ndarray;
+mod mul_vec;
+mod norm;
+#[cfg(feature = "ndarrayl")]
+mod norm_ndarray;
+mod norm_vec;
+mod scaledadd;
+#[cfg(feature = "ndarrayl")]
+mod scaledadd_ndarray;
+mod scaledadd_vec;
+mod scaledsub;
+#[cfg(feature = "ndarrayl")]
+mod scaledsub_ndarray;
+mod scaledsub_vec;
+mod sub;
+#[cfg(feature = "ndarrayl")]
+mod sub_ndarray;
+mod sub_vec;
+mod transpose;
+#[cfg(feature = "ndarrayl")]
+mod transpose_ndarray;
+mod transpose_vec;
+mod weighteddot;
+mod zero;
+#[cfg(feature = "ndarrayl")]
+mod zero_ndarray;
+mod zero_vec;
+// #[cfg(feature = "ndarrayl")]
+// mod random_ndarray; // TODO
+mod random_vec;
+// #[cfg(feature = "ndarrayl")]
+// mod minmax_ndarray; // TODO
+mod minmax_vec;
+pub use crate::core::math::add::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::add_ndarray::*;
+pub use crate::core::math::add_vec::*;
+pub use crate::core::math::conj::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::conj_ndarray::*;
+pub use crate::core::math::conj_vec::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::div_ndarray::*;
+pub use crate::core::math::dot::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::dot_ndarray::*;
+pub use crate::core::math::dot_vec::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::eye_ndarray::*;
+pub use crate::core::math::eye_vec::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::inv_ndarray::*;
+pub use crate::core::math::mul::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::mul_ndarray::*;
+pub use crate::core::math::mul_vec::*;
+pub use crate::core::math::norm::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::norm_ndarray::*;
+pub use crate::core::math::norm_vec::*;
+pub use crate::core::math::scaledadd::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::scaledadd_ndarray::*;
+pub use crate::core::math::scaledadd_vec::*;
+pub use crate::core::math::scaledsub::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::scaledsub_ndarray::*;
+pub use crate::core::math::scaledsub_vec::*;
+pub use crate::core::math::sub::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::sub_ndarray::*;
+pub use crate::core::math::sub_vec::*;
+pub use crate::core::math::transpose::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::transpose_ndarray::*;
+pub use crate::core::math::transpose_vec::*;
+pub use crate::core::math::weighteddot::*;
+pub use crate::core::math::zero::*;
+#[cfg(feature = "ndarrayl")]
+pub use crate::core::math::zero_ndarray::*;
+pub use crate::core::math::zero_vec::*;
+// #[cfg(feature = "ndarrayl")] // TODO
+// pub use crate::core::math::random_ndarray::*;
+pub use crate::core::math::random_vec::*;
+// #[cfg(feature = "ndarrayl")] // TODO
+// pub use crate::core::math::minmax_ndarray::*;
+pub use crate::core::math::minmax_vec::*;
+
+use crate::core::Error;
+
+/// Modified Cholesky decompositions
+pub mod modcholesky {
+    //! Modified Cholesky decompositions
+    //!
+    //! Reexport of `modcholesky` crate.
+    pub use modcholesky::*;
+}
+
+/// Dot/scalar product of `T` and `self`
+pub trait ArgminDot<T, U> {
+    /// Dot/scalar product of `T` and `self`
+    fn dot(&self, other: &T) -> U;
+}
+
+/// Dot/scalar product of `T` and `self` weighted by W (p^TWv)
+pub trait ArgminWeightedDot<T, U, V> {
+    /// Dot/scalar product of `T` and `self`
+    fn weighted_dot(&self, w: &V, vec: &T) -> U;
+}
+
+/// Return param vector of all zeros (for now, this is a hack. It should be done better)
+pub trait ArgminZero {
+    /// Return zero(s)
+    fn zero() -> Self;
+}
+
+/// Return the conjugate
+pub trait ArgminConj {
+    /// Return conjugate
+    fn conj(&self) -> Self;
+}
+
+/// Zero for dynamically sized objects
+pub trait ArgminZeroLike {
+    /// Return zero(s)
+    fn zero_like(&self) -> Self;
+}
+
+/// Identity matrix
+pub trait ArgminEye {
+    /// Identity matrix of size `n`
+    fn eye(n: usize) -> Self;
+    /// Identity matrix of same size as `self`
+    fn eye_like(&self) -> Self;
+}
+
+/// Add a `T` to `self`
+pub trait ArgminAdd<T, U> {
+    /// Add a `T` to `self`
+    fn add(&self, other: &T) -> U;
+}
+
+/// Subtract a `T` from `self`
+pub trait ArgminSub<T, U> {
+    /// Subtract a `T` from `self`
+    fn sub(&self, other: &T) -> U;
+}
+
+/// (Pointwise) Multiply a `T` with `self`
+pub trait ArgminMul<T, U> {
+    /// (Pointwise) Multiply a `T` with `self`
+    fn mul(&self, other: &T) -> U;
+}
+
+/// (Pointwise) Divide a `T` by `self`
+pub trait ArgminDiv<T, U> {
+    /// (Pointwise) Divide a `T` by `self`
+    fn div(&self, other: &T) -> U;
+}
+
+/// Add a `T` scaled by an `U` to `self`
+pub trait ArgminScaledAdd<T, U, V> {
+    /// Add a `T` scaled by an `U` to `self`
+    fn scaled_add(&self, factor: &U, vec: &T) -> V;
+}
+
+/// Subtract a `T` scaled by an `U` from `self`
+pub trait ArgminScaledSub<T, U, V> {
+    /// Subtract a `T` scaled by an `U` from `self`
+    fn scaled_sub(&self, factor: &U, vec: &T) -> V;
+}
+
+/// Compute the l2-norm (`U`) of `self`
+pub trait ArgminNorm<U> {
+    /// Compute the l2-norm (`U`) of `self`
+    fn norm(&self) -> U;
+}
+
+// Suboptimal: self is moved. ndarray however offers array views...
+/// Transposing a type
+pub trait ArgminTranspose {
+    /// Transpose
+    fn t(self) -> Self;
+}
+
+/// Compute the inverse (`T`) of `self`
+pub trait ArgminInv<T> {
+    /// Compute the inverse
+    fn inv(&self) -> Result<T, Error>;
+}
+
+/// Create a random number
+pub trait ArgminRandom {
+    /// Get a random element between min and max,
+    fn rand_from_range(min: &Self, max: &Self) -> Self;
+}
+
+/// Minimum and Maximum of type `T`
+pub trait ArgminMinMax {
+    /// Select piecewise minimum
+    fn min(x: &Self, y: &Self) -> Self;
+    /// Select piecewise maximum
+    fn max(x: &Self, y: &Self) -> Self;
+}

--- a/src/core/math/mul.rs
+++ b/src/core/math/mul.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMul;
+use num_complex::Complex;
+
+macro_rules! make_mul {
+    ($t:ty) => {
+        impl ArgminMul<$t, $t> for $t {
+            #[inline]
+            fn mul(&self, other: &$t) -> $t {
+                self * other
+            }
+        }
+    };
+}
+
+make_mul!(isize);
+make_mul!(usize);
+make_mul!(i8);
+make_mul!(u8);
+make_mul!(i16);
+make_mul!(u16);
+make_mul!(i32);
+make_mul!(u32);
+make_mul!(i64);
+make_mul!(u64);
+make_mul!(f32);
+make_mul!(f64);
+make_mul!(Complex<isize>);
+make_mul!(Complex<usize>);
+make_mul!(Complex<i8>);
+make_mul!(Complex<u8>);
+make_mul!(Complex<i16>);
+make_mul!(Complex<u16>);
+make_mul!(Complex<i32>);
+make_mul!(Complex<u32>);
+make_mul!(Complex<i64>);
+make_mul!(Complex<u64>);
+make_mul!(Complex<f32>);
+make_mul!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_mul_ $t>]() {
+                    let a = 2 as $t;
+                    let b = 21 as $t;
+                    let res = <$t as ArgminMul<$t, $t>>::mul(&a, &b);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/mul_ndarray.rs
+++ b/src/core/math/mul_ndarray.rs
@@ -1,0 +1,321 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMul;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_mul {
+    ($t:ty) => {
+        impl ArgminMul<$t, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Array1<$t> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<Array1<$t>, Array1<$t>> for $t {
+            #[inline]
+            fn mul(&self, other: &Array1<$t>) -> Array1<$t> {
+                *self * other
+            }
+        }
+
+        impl ArgminMul<Array1<$t>, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn mul(&self, other: &Array1<$t>) -> Array1<$t> {
+                self * other
+            }
+        }
+
+        impl ArgminMul<Array2<$t>, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn mul(&self, other: &Array2<$t>) -> Array2<$t> {
+                self * other
+            }
+        }
+
+        impl ArgminMul<$t, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Array2<$t> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<Array2<$t>, Array2<$t>> for $t {
+            #[inline]
+            fn mul(&self, other: &Array2<$t>) -> Array2<$t> {
+                *self * other
+            }
+        }
+    };
+}
+
+macro_rules! make_complex_mul {
+    ($t:ty) => {
+        impl ArgminMul<Complex<$t>, Array1<Complex<$t>>> for Array1<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &Complex<$t>) -> Array1<Complex<$t>> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<$t, Array1<Complex<$t>>> for Array1<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Array1<Complex<$t>> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<Array1<Complex<$t>>, Array1<Complex<$t>>> for Complex<$t> {
+            #[inline]
+            fn mul(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
+                *self * other
+            }
+        }
+
+        impl ArgminMul<Array1<Complex<$t>>, Array1<Complex<$t>>> for $t {
+            #[inline]
+            fn mul(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
+                Complex::new(*self, 0 as $t) * other
+            }
+        }
+
+        impl ArgminMul<Array1<Complex<$t>>, Array1<Complex<$t>>> for Array1<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
+                self * other
+            }
+        }
+
+        impl ArgminMul<Array2<Complex<$t>>, Array2<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
+                self * other
+            }
+        }
+
+        impl ArgminMul<Complex<$t>, Array2<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &Complex<$t>) -> Array2<Complex<$t>> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<$t, Array2<Complex<$t>>> for Array2<Complex<$t>> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Array2<Complex<$t>> {
+                self * *other
+            }
+        }
+
+        impl ArgminMul<Array2<Complex<$t>>, Array2<Complex<$t>>> for Complex<$t> {
+            #[inline]
+            fn mul(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
+                *self * other
+            }
+        }
+    };
+}
+
+make_mul!(i8);
+make_mul!(u8);
+make_mul!(i16);
+make_mul!(u16);
+make_mul!(i32);
+make_mul!(u32);
+make_mul!(i64);
+make_mul!(u64);
+make_mul!(f32);
+make_mul!(f64);
+make_complex_mul!(f32);
+make_complex_mul!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_mul_vec_scalar_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = array![2 as $t, 8 as $t, 16 as $t];
+                    let res = <Array1<$t> as ArgminMul<$t, Array1<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_vec_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = array![2 as $t, 8 as $t, 16 as $t];
+                    let res = <$t as ArgminMul<Array1<$t>, Array1<$t>>>::mul(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_vec_vec_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = array![2 as $t, 3 as $t, 4 as $t];
+                    let target = array![2 as $t, 12 as $t, 32 as $t];
+                    let res = <Array1<$t> as ArgminMul<Array1<$t>, Array1<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_ $t>]() {
+                    let a = array![1 as $t, 4 as $t];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminMul<Array1<$t>, Array1<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_2_ $t>]() {
+                    let a = array![];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminMul<Array1<$t>, Array1<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_3_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![];
+                    <Array1<$t> as ArgminMul<Array1<$t>, Array1<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_mat_mat_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![
+                        [2 as $t, 3 as $t, 4 as $t],
+                        [3 as $t, 4 as $t, 5 as $t]
+                    ];
+                    let target = array![
+                        [2 as $t, 12 as $t, 32 as $t],
+                        [6 as $t, 20 as $t, 45 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminMul<Array2<$t>, Array2<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_mat_mat_panic_2_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![
+                        [41 as $t, 38 as $t],
+                    ];
+                    <Array2<$t> as ArgminMul<Array2<$t>, Array2<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_mat_mat_panic_3_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![[]];
+                    <Array2<$t> as ArgminMul<Array2<$t>, Array2<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_1_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = array![
+                        [2 as $t, 8 as $t, 16 as $t],
+                        [4 as $t, 10 as $t, 18 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminMul<$t, Array2<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_2_ $t>]() {
+                    let b = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let a = 2 as $t;
+                    let target = array![
+                        [2 as $t, 8 as $t, 16 as $t],
+                        [4 as $t, 10 as $t, 18 as $t]
+                    ];
+                    let res = <$t as ArgminMul<Array2<$t>, Array2<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/mul_vec.rs
+++ b/src/core/math/mul_vec.rs
@@ -1,0 +1,300 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMul;
+use num_complex::Complex;
+
+macro_rules! make_mul {
+    ($t:ty) => {
+        impl ArgminMul<$t, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Vec<$t> {
+                self.iter().map(|a| a * other).collect()
+            }
+        }
+
+        impl ArgminMul<Vec<$t>, Vec<$t>> for $t {
+            #[inline]
+            fn mul(&self, other: &Vec<$t>) -> Vec<$t> {
+                other.iter().map(|a| a * self).collect()
+            }
+        }
+
+        impl ArgminMul<Vec<$t>, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn mul(&self, other: &Vec<$t>) -> Vec<$t> {
+                let n1 = self.len();
+                let n2 = other.len();
+                assert!(n1 > 0);
+                assert!(n2 > 0);
+                assert_eq!(n1, n2);
+                self.iter().zip(other.iter()).map(|(a, b)| a * b).collect()
+            }
+        }
+
+        impl ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn mul(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                let or = other.len();
+                assert!(sr > 0);
+                // implicitly, or > 0
+                assert_eq!(sr, or);
+                let sc = self[0].len();
+                self.iter()
+                    .zip(other.iter())
+                    .map(|(a, b)| {
+                        assert_eq!(a.len(), sc);
+                        assert_eq!(b.len(), sc);
+                        <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b)
+                    })
+                    .collect()
+            }
+        }
+
+        impl ArgminMul<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn mul(&self, other: &$t) -> Vec<Vec<$t>> {
+                self.iter().map(|a| a.mul(other)).collect()
+            }
+        }
+
+        impl ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>> for $t {
+            #[inline]
+            fn mul(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                other.iter().map(|a| a.mul(self)).collect()
+            }
+        }
+    };
+}
+
+make_mul!(isize);
+make_mul!(usize);
+make_mul!(i8);
+make_mul!(u8);
+make_mul!(i16);
+make_mul!(u16);
+make_mul!(i32);
+make_mul!(u32);
+make_mul!(i64);
+make_mul!(u64);
+make_mul!(f32);
+make_mul!(f64);
+make_mul!(Complex<isize>);
+make_mul!(Complex<usize>);
+make_mul!(Complex<i8>);
+make_mul!(Complex<u8>);
+make_mul!(Complex<i16>);
+make_mul!(Complex<u16>);
+make_mul!(Complex<i32>);
+make_mul!(Complex<u32>);
+make_mul!(Complex<i64>);
+make_mul!(Complex<u64>);
+make_mul!(Complex<f32>);
+make_mul!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_mul_vec_scalar_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = vec![2 as $t, 8 as $t, 16 as $t];
+                    let res = <Vec<$t> as ArgminMul<$t, Vec<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = 2 as $t;
+                    let target = vec![2 as $t, 8 as $t, 16 as $t];
+                    let res = <$t as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_vec_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 8 as $t];
+                    let b = vec![2 as $t, 3 as $t, 4 as $t];
+                    let target = vec![2 as $t, 12 as $t, 32 as $t];
+                    let res = <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_2_ $t>]() {
+                    let a = vec![];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_vec_vec_panic_3_ $t>]() {
+                    let a = vec![41 as $t, 38 as $t, 34 as $t];
+                    let b = vec![];
+                    <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![2 as $t, 3 as $t, 4 as $t],
+                        vec![3 as $t, 4 as $t, 5 as $t]
+                    ];
+                    let target = vec![
+                        vec![2 as $t, 12 as $t, 32 as $t],
+                        vec![6 as $t, 20 as $t, 45 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                        vec![40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                    ];
+                    <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_mul_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![];
+                    <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = vec![
+                        vec![2 as $t, 8 as $t, 16 as $t],
+                        vec![4 as $t, 10 as $t, 18 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminMul<$t, Vec<Vec<$t>>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_2_ $t>]() {
+                    let b = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let a = 2 as $t;
+                    let target = vec![
+                        vec![2 as $t, 8 as $t, 16 as $t],
+                        vec![4 as $t, 10 as $t, 18 as $t]
+                    ];
+                    let res = <$t as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/norm.rs
+++ b/src/core/math/norm.rs
@@ -1,0 +1,111 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminNorm;
+use num_complex::Complex;
+
+macro_rules! make_norm_unsigned {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for $t {
+            #[inline]
+            fn norm(&self) -> $t {
+                *self
+            }
+        }
+    };
+}
+
+macro_rules! make_norm {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for $t {
+            #[inline]
+            fn norm(&self) -> $t {
+                (*self).abs()
+            }
+        }
+    };
+}
+
+macro_rules! make_norm_complex {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for Complex<$t> {
+            #[inline]
+            fn norm(&self) -> $t {
+                (*self).re.hypot((*self).im)
+            }
+        }
+    };
+}
+
+make_norm!(isize);
+make_norm_unsigned!(usize);
+make_norm!(i8);
+make_norm!(i16);
+make_norm!(i32);
+make_norm!(i64);
+make_norm_unsigned!(u8);
+make_norm_unsigned!(u16);
+make_norm_unsigned!(u32);
+make_norm_unsigned!(u64);
+make_norm!(f32);
+make_norm!(f64);
+
+make_norm_complex!(f32);
+make_norm_complex!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_ $t>]() {
+                    let a = 8 as $t;
+                    let res = <$t as ArgminNorm<$t>>::norm(&a);
+                    assert!(((a - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_signed_ $t>]() {
+                    let a = -8 as $t;
+                    let res = <$t as ArgminNorm<$t>>::norm(&a);
+                    assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(isize);
+    make_test_signed!(i8);
+    make_test_signed!(i16);
+    make_test_signed!(i32);
+    make_test_signed!(i64);
+    make_test_signed!(f32);
+    make_test_signed!(f64);
+}

--- a/src/core/math/norm_ndarray.rs
+++ b/src/core/math/norm_ndarray.rs
@@ -1,0 +1,126 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminNorm;
+use ndarray::Array1;
+use num::integer::Roots;
+use num_complex::Complex;
+
+macro_rules! make_norm_float {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for Array1<$t> {
+            #[inline]
+            fn norm(&self) -> $t {
+                self.iter().map(|a| a.powi(2)).sum::<$t>().sqrt()
+            }
+        }
+    };
+}
+
+macro_rules! make_norm_complex_float {
+    ($t:ty) => {
+        impl ArgminNorm<Complex<$t>> for Array1<Complex<$t>> {
+            #[inline]
+            fn norm(&self) -> Complex<$t> {
+                self.iter().map(|a| a.powf(2.0)).sum::<Complex<$t>>().sqrt()
+            }
+        }
+
+        impl ArgminNorm<$t> for Array1<Complex<$t>> {
+            #[inline]
+            fn norm(&self) -> $t {
+                self.iter()
+                    .map(|a| a.powf(2.0))
+                    .sum::<Complex<$t>>()
+                    .sqrt()
+                    .norm()
+            }
+        }
+    };
+}
+
+macro_rules! make_norm_integer {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for Array1<$t> {
+            #[inline]
+            fn norm(&self) -> $t {
+                self.iter().map(|a| a.pow(2)).sum::<$t>().sqrt()
+            }
+        }
+    };
+}
+
+make_norm_integer!(isize);
+make_norm_integer!(usize);
+make_norm_integer!(i8);
+make_norm_integer!(i16);
+make_norm_integer!(i32);
+make_norm_integer!(i64);
+make_norm_integer!(u8);
+make_norm_integer!(u16);
+make_norm_integer!(u32);
+make_norm_integer!(u64);
+make_norm_float!(f32);
+make_norm_float!(f64);
+make_norm_complex_float!(f32);
+make_norm_complex_float!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{array, Array1};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_ $t>]() {
+                    let a = array![4 as $t, 3 as $t];
+                    let res = <Array1<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_signed_ $t>]() {
+                    let a = array![-4 as $t, -3 as $t];
+                    let res = <Array1<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(isize);
+    make_test_signed!(i8);
+    make_test_signed!(i16);
+    make_test_signed!(i32);
+    make_test_signed!(i64);
+    make_test_signed!(f32);
+    make_test_signed!(f64);
+}

--- a/src/core/math/norm_vec.rs
+++ b/src/core/math/norm_vec.rs
@@ -1,0 +1,113 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminNorm;
+use num::integer::Roots;
+use num_complex::Complex;
+
+macro_rules! make_norm_float {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for Vec<$t> {
+            #[inline]
+            fn norm(&self) -> $t {
+                self.iter().map(|a| a.powi(2)).sum::<$t>().sqrt()
+            }
+        }
+    };
+}
+
+macro_rules! make_norm_complex_float {
+    ($t:ty) => {
+        impl ArgminNorm<Complex<$t>> for Vec<Complex<$t>> {
+            #[inline]
+            fn norm(&self) -> Complex<$t> {
+                self.iter().map(|a| a.powf(2.0)).sum::<Complex<$t>>().sqrt()
+            }
+        }
+    };
+}
+
+macro_rules! make_norm_integer {
+    ($t:ty) => {
+        impl ArgminNorm<$t> for Vec<$t> {
+            #[inline]
+            fn norm(&self) -> $t {
+                self.iter().map(|a| a.pow(2)).sum::<$t>().sqrt()
+            }
+        }
+    };
+}
+
+make_norm_integer!(isize);
+make_norm_integer!(usize);
+make_norm_integer!(i8);
+make_norm_integer!(i16);
+make_norm_integer!(i32);
+make_norm_integer!(i64);
+make_norm_integer!(u8);
+make_norm_integer!(u16);
+make_norm_integer!(u32);
+make_norm_integer!(u64);
+make_norm_float!(f32);
+make_norm_float!(f64);
+make_norm_complex_float!(f32);
+make_norm_complex_float!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_ $t>]() {
+                    let a = vec![4 as $t, 3 as $t];
+                    let res = <Vec<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_signed_ $t>]() {
+                    let a = vec![-4 as $t, -3 as $t];
+                    let res = <Vec<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(isize);
+    make_test_signed!(i8);
+    make_test_signed!(i16);
+    make_test_signed!(i32);
+    make_test_signed!(i64);
+    make_test_signed!(f32);
+    make_test_signed!(f64);
+}

--- a/src/core/math/random.rs
+++ b/src/core/math/random.rs
@@ -1,0 +1,47 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminRandom;
+use num_complex::Complex;
+
+macro_rules! make_random {
+    ($t:ty) => {
+        impl ArgminRandom for $t {
+            #[inline]
+            fn random(min: &Self, max: &Self) -> $t {
+                rand::thread_rng().gen_range(min, max) as $t
+            }
+        }
+    };
+}
+
+make_random!(f32);
+make_random!(f64);
+make_random!(i8);
+make_random!(i16);
+make_random!(i32);
+make_random!(i64);
+make_random!(u8);
+make_random!(u16);
+make_random!(u32);
+make_random!(u64);
+make_random!(isize);
+make_random!(usize);
+make_random!(Complex<f32>);
+make_random!(Complex<f64>);
+make_random!(Complex<i8>);
+make_random!(Complex<i16>);
+make_random!(Complex<i32>);
+make_random!(Complex<i64>);
+make_random!(Complex<u8>);
+make_random!(Complex<u16>);
+make_random!(Complex<u32>);
+make_random!(Complex<u64>);
+make_random!(Complex<isize>);
+make_random!(Complex<usize>);
+
+// TODO:  tests!!!

--- a/src/core/math/random_vec.rs
+++ b/src/core/math/random_vec.rs
@@ -1,0 +1,37 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminRandom;
+use rand::distributions::uniform::SampleUniform;
+use rand::Rng;
+
+impl<T> ArgminRandom for Vec<T>
+where
+    T: SampleUniform + std::cmp::PartialOrd + Clone,
+{
+    fn rand_from_range(min: &Self, max: &Self) -> Vec<T> {
+        assert!(!min.is_empty());
+        assert_eq!(min.len(), max.len());
+
+        let mut rng = rand::thread_rng();
+
+        min.iter()
+            .zip(max.iter())
+            .map(|(a, b)| {
+                // Do not require a < b:
+
+                if a == b {
+                    a.clone()
+                } else if a < b {
+                    rng.gen_range(a, b)
+                } else {
+                    rng.gen_range(b, a)
+                }
+            })
+            .collect()
+    }
+}

--- a/src/core/math/scaledadd.rs
+++ b/src/core/math/scaledadd.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::{ArgminAdd, ArgminMul, ArgminScaledAdd};
+
+// This is a very generic implementation. Once the specialization feature is stable, impls for
+// types, which allow efficient execution of scaled adds can be made.
+impl<T, U, W> ArgminScaledAdd<T, U, W> for W
+where
+    U: ArgminMul<T, T>,
+    W: ArgminAdd<T, W>,
+{
+    #[inline]
+    fn scaled_add(&self, factor: &U, vec: &T) -> W {
+        self.add(&factor.mul(vec))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledadd_ $t>]() {
+                    let a = 2 as $t;
+                    let b = 4 as $t;
+                    let c = 10 as $t;
+                    let res = <$t as ArgminScaledAdd<$t, $t, $t>>::scaled_add(&a, &b, &c);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledadd_ndarray.rs
+++ b/src/core/math/scaledadd_ndarray.rs
@@ -1,0 +1,166 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledAdd;
+    use ndarray::{array, Array1, Array2};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    let res = <Array1<$t> as ArgminScaledAdd<Array1<$t>, $t, Array1<$t>>>::scaled_add(&a, &b, &c);
+                    let target = array![9 as $t, 12 as $t, 15 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_1_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t];
+                    <Array1<$t> as ArgminScaledAdd<Array1<$t>, $t, Array1<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_2_ $t>]() {
+                    let a = array![1 as $t, 2 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledAdd<Array1<$t>, $t, Array1<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_vec_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    let res = <Array1<$t> as ArgminScaledAdd<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_add(&a, &b, &c);
+                    let target = array![13 as $t, 12 as $t, 9 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_1_ $t>]() {
+                    let a = array![1 as $t, 2 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledAdd<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_2_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![3 as $t, 2 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledAdd<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_3_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t];
+                    <Array1<$t> as ArgminScaledAdd<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_mat_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t],
+                        [3 as $t, 4 as $t],
+                    ];
+                    let b = array![
+                        [4 as $t, 3 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let c = array![
+                        [1 as $t, 2 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let res = <Array2<$t> as ArgminScaledAdd<Array2<$t>, Array2<$t>, Array2<$t>>>::scaled_add(&a, &b, &c);
+                    let target = array![
+                        [5 as $t, 8 as $t],
+                        [7 as $t, 5 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_scalar_ $t>]() {
+                    let a = array![
+                        [1 as $t, 2 as $t],
+                        [3 as $t, 4 as $t],
+                    ];
+                    let b = 2 as $t;
+                    let c = array![
+                        [1 as $t, 2 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let res = <Array2<$t> as ArgminScaledAdd<Array2<$t>, $t, Array2<$t>>>::scaled_add(&a, &b, &c);
+                    let target = array![
+                        [3 as $t, 6 as $t],
+                        [7 as $t, 6 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    // make_test!(isize);
+    // make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledadd_vec.rs
+++ b/src/core/math/scaledadd_vec.rs
@@ -1,0 +1,283 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledAdd;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res = a.scaled_add(&b, &c);
+                    let target = vec![9 as $t, 12 as $t, 15 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_1_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_2_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_vec_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res = a.scaled_add(&b, &c);
+                    let target = vec![13 as $t, 12 as $t, 9 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_1_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_2_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![3 as $t, 2 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_3_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let res = a.scaled_add(&b, &c);
+                    let target = vec![
+                        vec![5 as $t, 8 as $t],
+                        vec![7 as $t, 5 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_4_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_5_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_mat_mat_panic_6_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_add(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_scalar_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = 2 as $t;
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let res = a.scaled_add(&b, &c);
+                    let target = vec![
+                        vec![3 as $t, 6 as $t],
+                        vec![7 as $t, 6 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledsub.rs
+++ b/src/core/math/scaledsub.rs
@@ -1,0 +1,55 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::{ArgminMul, ArgminScaledSub, ArgminSub};
+
+// This is a very generic implementation. Once the specialization feature is stable, impls for
+// types, which allow efficient execution of scaled subs can be made.
+impl<T, U, W> ArgminScaledSub<T, U, W> for W
+where
+    U: ArgminMul<T, T>,
+    W: ArgminSub<T, W>,
+{
+    #[inline]
+    fn scaled_sub(&self, factor: &U, vec: &T) -> W {
+        self.sub(&factor.mul(vec))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledsub_ $t>]() {
+                    let a = 100 as $t;
+                    let b = 2 as $t;
+                    let c = 29 as $t;
+                    let res = <$t as ArgminScaledSub<$t, $t, $t>>::scaled_sub(&a, &b, &c);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledsub_ndarray.rs
+++ b/src/core/math/scaledsub_ndarray.rs
@@ -1,0 +1,164 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledSub;
+    use ndarray::{array, Array1, Array2};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_ $t>]() {
+                    let a = array![10 as $t, 20 as $t, 30 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    let res = <Array1<$t> as ArgminScaledSub<Array1<$t>, $t, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = array![2 as $t, 10 as $t, 18 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_1_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t];
+                    <Array1<$t> as ArgminScaledSub<Array1<$t>, $t, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_2_ $t>]() {
+                    let a = array![1 as $t, 2 as $t];
+                    let b = 2 as $t;
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledSub<Array1<$t>, $t, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_vec_ $t>]() {
+                    let a = array![20 as $t, 20 as $t, 30 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    let res = <Array1<$t> as ArgminScaledSub<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = array![8 as $t, 10 as $t, 24 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_1_ $t>]() {
+                    let a = array![1 as $t, 2 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledSub<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_2_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![3 as $t, 2 as $t];
+                    let c = array![4 as $t, 5 as $t, 6 as $t];
+                    <Array1<$t> as ArgminScaledSub<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_3_ $t>]() {
+                    let a = array![1 as $t, 2 as $t, 3 as $t];
+                    let b = array![3 as $t, 2 as $t, 1 as $t];
+                    let c = array![4 as $t, 5 as $t];
+                    <Array1<$t> as ArgminScaledSub<Array1<$t>, Array1<$t>, Array1<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_mat_ $t>]() {
+                    let a = array![
+                        [10 as $t, 20 as $t],
+                        [30 as $t, 40 as $t],
+                    ];
+                    let b = array![
+                        [4 as $t, 3 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let c = array![
+                        [1 as $t, 2 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let res = <Array2<$t> as ArgminScaledSub<Array2<$t>, Array2<$t>, Array2<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = array![
+                        [6 as $t, 14 as $t],
+                        [26 as $t, 39 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_scalar_ $t>]() {
+                    let a = array![
+                        [10 as $t, 20 as $t],
+                        [30 as $t, 40 as $t],
+                    ];
+                    let b = 2 as $t;
+                    let c = array![
+                        [1 as $t, 2 as $t],
+                        [2 as $t, 1 as $t],
+                    ];
+                    let res = <Array2<$t> as ArgminScaledSub<Array2<$t>, $t, Array2<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = array![
+                        [8 as $t, 16 as $t],
+                        [26 as $t, 38 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledsub_vec.rs
+++ b/src/core/math/scaledsub_vec.rs
@@ -1,0 +1,283 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledSub;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_ $t>]() {
+                    let a = vec![10 as $t, 20 as $t, 30 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res = a.scaled_sub(&b, &c);
+                    let target = vec![2 as $t, 10 as $t, 18 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_1_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_2_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t];
+                    let b = 2 as $t;
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_vec_ $t>]() {
+                    let a = vec![15 as $t, 20 as $t, 30 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    let res = a.scaled_sub(&b, &c);
+                    let target = vec![3 as $t, 10 as $t, 24 as $t];
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_1_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_2_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![3 as $t, 2 as $t];
+                    let c = vec![4 as $t, 5 as $t, 6 as $t];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_3_ $t>]() {
+                    let a = vec![1 as $t, 2 as $t, 3 as $t];
+                    let b = vec![3 as $t, 2 as $t, 1 as $t];
+                    let c = vec![4 as $t, 5 as $t];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![10 as $t, 20 as $t],
+                        vec![30 as $t, 40 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let res = a.scaled_sub(&b, &c);
+                    let target = vec![
+                        vec![6 as $t, 14 as $t],
+                        vec![26 as $t, 39 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_4_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_5_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                    ];
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_mat_mat_panic_6_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![3 as $t, 4 as $t],
+                    ];
+                    let b = vec![
+                        vec![4 as $t, 3 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let c = vec![
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    a.scaled_sub(&b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_scalar_ $t>]() {
+                    let a = vec![
+                        vec![10 as $t, 20 as $t],
+                        vec![30 as $t, 40 as $t],
+                    ];
+                    let b = 2 as $t;
+                    let c = vec![
+                        vec![1 as $t, 2 as $t],
+                        vec![2 as $t, 1 as $t],
+                    ];
+                    let res = a.scaled_sub(&b, &c);
+                    let target = vec![
+                        vec![8 as $t, 16 as $t],
+                        vec![26 as $t, 38 as $t],
+                    ];
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/sub.rs
+++ b/src/core/math/sub.rs
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminSub;
+use num_complex::Complex;
+
+macro_rules! make_sub {
+    ($t:ty) => {
+        impl ArgminSub<$t, $t> for $t {
+            #[inline]
+            fn sub(&self, other: &$t) -> $t {
+                self - other
+            }
+        }
+    };
+}
+
+make_sub!(isize);
+make_sub!(usize);
+make_sub!(i8);
+make_sub!(i16);
+make_sub!(i32);
+make_sub!(i64);
+make_sub!(u8);
+make_sub!(u16);
+make_sub!(u32);
+make_sub!(u64);
+make_sub!(f32);
+make_sub!(f64);
+make_sub!(Complex<isize>);
+make_sub!(Complex<usize>);
+make_sub!(Complex<i8>);
+make_sub!(Complex<i16>);
+make_sub!(Complex<i32>);
+make_sub!(Complex<i64>);
+make_sub!(Complex<u8>);
+make_sub!(Complex<u16>);
+make_sub!(Complex<u32>);
+make_sub!(Complex<u64>);
+make_sub!(Complex<f32>);
+make_sub!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_sub_ $t>]() {
+                    let a = 50 as $t;
+                    let b = 8 as $t;
+                    let res = <$t as ArgminSub<$t, $t>>::sub(&a, &b);
+                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/sub_ndarray.rs
+++ b/src/core/math/sub_ndarray.rs
@@ -1,0 +1,226 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminSub;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_sub {
+    ($t:ty) => {
+        impl ArgminSub<$t, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn sub(&self, other: &$t) -> Array1<$t> {
+                self - *other
+            }
+        }
+
+        impl ArgminSub<Array1<$t>, Array1<$t>> for $t {
+            #[inline]
+            fn sub(&self, other: &Array1<$t>) -> Array1<$t> {
+                *self - other
+            }
+        }
+
+        impl ArgminSub<Array1<$t>, Array1<$t>> for Array1<$t> {
+            #[inline]
+            fn sub(&self, other: &Array1<$t>) -> Array1<$t> {
+                self - other
+            }
+        }
+
+        impl ArgminSub<Array2<$t>, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn sub(&self, other: &Array2<$t>) -> Array2<$t> {
+                self - other
+            }
+        }
+
+        impl ArgminSub<$t, Array2<$t>> for Array2<$t> {
+            #[inline]
+            fn sub(&self, other: &$t) -> Array2<$t> {
+                self - *other
+            }
+        }
+    };
+}
+
+make_sub!(i8);
+make_sub!(i16);
+make_sub!(i32);
+make_sub!(i64);
+make_sub!(u8);
+make_sub!(u16);
+make_sub!(u32);
+make_sub!(u64);
+make_sub!(f32);
+make_sub!(f64);
+make_sub!(Complex<f32>);
+make_sub!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_sub_vec_scalar_ $t>]() {
+                    let a = array![36 as $t, 39 as $t, 43 as $t];
+                    let b = 1 as $t;
+                    let target = array![35 as $t, 38 as $t, 42 as $t];
+                    let res = <Array1<$t> as ArgminSub<$t, Array1<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_scalar_vec_ $t>]() {
+                    let a = array![1 as $t, 4 as $t, 8 as $t];
+                    let b = 34 as $t;
+                    let target = array![33 as $t, 30 as $t, 26 as $t];
+                    let res = <$t as ArgminSub<Array1<$t>, Array1<$t>>>::sub(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_vec_vec_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![1 as $t, 4 as $t, 8 as $t];
+                    let target = array![40 as $t, 34 as $t, 26 as $t];
+                    let res = <Array1<$t> as ArgminSub<Array1<$t>, Array1<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![1 as $t, 4 as $t];
+                    <Array1<$t> as ArgminSub<Array1<$t>, Array1<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_2_ $t>]() {
+                    let a = array![];
+                    let b = array![41 as $t, 38 as $t, 34 as $t];
+                    <Array1<$t> as ArgminSub<Array1<$t>, Array1<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_3_ $t>]() {
+                    let a = array![41 as $t, 38 as $t, 34 as $t];
+                    let b = array![];
+                    <Array1<$t> as ArgminSub<Array1<$t>, Array1<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_mat_ $t>]() {
+                    let a = array![
+                        [43 as $t, 46 as $t, 50 as $t],
+                        [44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let target = array![
+                        [42 as $t, 42 as $t, 42 as $t],
+                        [42 as $t, 42 as $t, 42 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminSub<Array2<$t>, Array2<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_scalar_ $t>]() {
+                    let a = array![
+                        [43 as $t, 46 as $t, 50 as $t],
+                        [44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = array![
+                        [41 as $t, 44 as $t, 48 as $t],
+                        [42 as $t, 45 as $t, 49 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminSub<$t, Array2<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_mat_mat_panic_2_ $t>]() {
+                    let a = array![
+                        [41 as $t, 38 as $t],
+                    ];
+                    let b = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    <Array2<$t> as ArgminSub<Array2<$t>, Array2<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_mat_mat_panic_3_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = array![[]];
+                    <Array2<$t> as ArgminSub<Array2<$t>, Array2<$t>>>::sub(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/sub_vec.rs
+++ b/src/core/math/sub_vec.rs
@@ -1,0 +1,280 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminSub;
+use num_complex::Complex;
+
+macro_rules! make_sub {
+    ($t:ty) => {
+        impl ArgminSub<$t, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn sub(&self, other: &$t) -> Vec<$t> {
+                self.iter().map(|a| a - other).collect()
+            }
+        }
+
+        impl ArgminSub<Vec<$t>, Vec<$t>> for $t {
+            #[inline]
+            fn sub(&self, other: &Vec<$t>) -> Vec<$t> {
+                other.iter().map(|a| self - a).collect()
+            }
+        }
+
+        impl ArgminSub<Vec<$t>, Vec<$t>> for Vec<$t> {
+            #[inline]
+            fn sub(&self, other: &Vec<$t>) -> Vec<$t> {
+                let n1 = self.len();
+                let n2 = other.len();
+                assert!(n1 > 0);
+                assert!(n2 > 0);
+                assert_eq!(n1, n2);
+                self.iter().zip(other.iter()).map(|(a, b)| a - b).collect()
+            }
+        }
+
+        impl ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn sub(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                let or = other.len();
+                assert!(sr > 0);
+                // implicitly, or > 0
+                assert_eq!(sr, or);
+                let sc = self[0].len();
+                self.iter()
+                    .zip(other.iter())
+                    .map(|(a, b)| {
+                        assert_eq!(a.len(), sc);
+                        assert_eq!(b.len(), sc);
+                        <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b)
+                    })
+                    .collect()
+            }
+        }
+
+        impl ArgminSub<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+            #[inline]
+            fn sub(&self, other: &$t) -> Vec<Vec<$t>> {
+                let sr = self.len();
+                assert!(sr > 0);
+                let sc = self[0].len();
+                self.iter()
+                    .map(|a| {
+                        assert_eq!(a.len(), sc);
+                        <Vec<$t> as ArgminSub<$t, Vec<$t>>>::sub(&a, &other)
+                    })
+                    .collect()
+            }
+        }
+    };
+}
+
+make_sub!(isize);
+make_sub!(usize);
+make_sub!(i8);
+make_sub!(i16);
+make_sub!(i32);
+make_sub!(i64);
+make_sub!(u8);
+make_sub!(u16);
+make_sub!(u32);
+make_sub!(u64);
+make_sub!(f32);
+make_sub!(f64);
+make_sub!(Complex<isize>);
+make_sub!(Complex<usize>);
+make_sub!(Complex<i8>);
+make_sub!(Complex<i16>);
+make_sub!(Complex<i32>);
+make_sub!(Complex<i64>);
+make_sub!(Complex<u8>);
+make_sub!(Complex<u16>);
+make_sub!(Complex<u32>);
+make_sub!(Complex<u64>);
+make_sub!(Complex<f32>);
+make_sub!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_sub_vec_scalar_ $t>]() {
+                    let a = vec![100 as $t, 40 as $t, 76 as $t];
+                    let b = 34 as $t;
+                    let target = vec![66 as $t, 6 as $t, 42 as $t];
+                    let res = <Vec<$t> as ArgminSub<$t, Vec<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_scalar_vec_ $t>]() {
+                    let a = vec![1 as $t, 4 as $t, 58 as $t];
+                    let b = 100 as $t;
+                    let target = vec![99 as $t, 96 as $t, 42 as $t];
+                    let res = <$t as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_vec_vec_ $t>]() {
+                    let a = vec![43 as $t, 46 as $t, 50 as $t];
+                    let b = vec![1 as $t, 4 as $t, 8 as $t];
+                    let target = vec![42 as $t, 42 as $t, 42 as $t];
+                    let res = <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_ $t>]() {
+                    let a = vec![41 as $t, 38 as $t, 34 as $t];
+                    let b = vec![1 as $t, 4 as $t];
+                    <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_2_ $t>]() {
+                    let a = vec![];
+                    let b = vec![41 as $t, 38 as $t, 34 as $t];
+                    <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_vec_vec_panic_3_ $t>]() {
+                    let a = vec![41 as $t, 38 as $t, 34 as $t];
+                    let b = vec![];
+                    <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_mat_ $t>]() {
+                    let a = vec![
+                        vec![43 as $t, 46 as $t, 50 as $t],
+                        vec![44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let target = vec![
+                        vec![42 as $t, 42 as $t, 42 as $t],
+                        vec![42 as $t, 42 as $t, 42 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_scalar_ $t>]() {
+                    let a = vec![
+                        vec![43 as $t, 46 as $t, 50 as $t],
+                        vec![44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = vec![
+                        vec![41 as $t, 44 as $t, 48 as $t],
+                        vec![42 as $t, 45 as $t, 49 as $t]
+                    ];
+                    let res = <Vec<Vec<$t>> as ArgminSub<$t, Vec<Vec<$t>>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_mat_mat_panic_1_ $t>]() {
+                    let a = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                        vec![40 as $t, 37 as $t, 33 as $t]
+                    ];
+                    let b = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 9 as $t]
+                    ];
+                    <Vec<Vec<$t>> as ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_mat_mat_panic_2_ $t>]() {
+                    let a = vec![
+                        vec![41 as $t, 38 as $t, 34 as $t],
+                    ];
+                    let b = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    <Vec<Vec<$t>> as ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>>>::sub(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_sub_mat_mat_panic_3_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t, 8 as $t],
+                        vec![2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = vec![];
+                    <Vec<Vec<$t>> as ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>>>::sub(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/transpose.rs
+++ b/src/core/math/transpose.rs
@@ -1,0 +1,77 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminTranspose;
+use num_complex::Complex;
+
+macro_rules! make_transpose {
+    ($t:ty) => {
+        impl ArgminTranspose for $t {
+            #[inline]
+            fn t(self) -> $t {
+                self
+            }
+        }
+    };
+}
+
+make_transpose!(isize);
+make_transpose!(usize);
+make_transpose!(i8);
+make_transpose!(i16);
+make_transpose!(i32);
+make_transpose!(i64);
+make_transpose!(u8);
+make_transpose!(u16);
+make_transpose!(u32);
+make_transpose!(u64);
+make_transpose!(f32);
+make_transpose!(f64);
+make_transpose!(Complex<isize>);
+make_transpose!(Complex<usize>);
+make_transpose!(Complex<i8>);
+make_transpose!(Complex<i16>);
+make_transpose!(Complex<i32>);
+make_transpose!(Complex<i64>);
+make_transpose!(Complex<u8>);
+make_transpose!(Complex<u16>);
+make_transpose!(Complex<u32>);
+make_transpose!(Complex<u64>);
+make_transpose!(Complex<f32>);
+make_transpose!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_transpose_ $t>]() {
+                    let a = 8 as $t;
+                    let res = <$t as ArgminTranspose>::t(a);
+                    assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/transpose_ndarray.rs
+++ b/src/core/math/transpose_ndarray.rs
@@ -1,0 +1,120 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// Note: This is not really the preferred way I think. Maybe this should also be implemented for
+// ArrayViews, which would probably make it more efficient.
+
+use crate::core::math::ArgminTranspose;
+use ndarray::{Array1, Array2};
+use num_complex::Complex;
+
+macro_rules! make_add {
+    ($t:ty) => {
+        impl ArgminTranspose for Array1<$t> {
+            #[inline]
+            fn t(self) -> Array1<$t> {
+                self.reversed_axes()
+            }
+        }
+
+        impl ArgminTranspose for Array2<$t> {
+            #[inline]
+            fn t(self) -> Array2<$t> {
+                self.reversed_axes()
+            }
+        }
+    };
+}
+
+make_add!(i8);
+make_add!(i16);
+make_add!(i32);
+make_add!(i64);
+make_add!(u8);
+make_add!(u16);
+make_add!(u32);
+make_add!(u64);
+make_add!(f32);
+make_add!(f64);
+make_add!(Complex<f32>);
+make_add!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                // not sure if this is such a smart test :D
+                #[test]
+                fn [<test_transpose_ $t>]() {
+                    let a = array![1 as $t, 4 as $t];
+                    let target = array![1 as $t, 4 as $t];
+                    let res = <Array1<$t> as ArgminTranspose>::t(a);
+                    for i in 0..2 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_1_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t],
+                        [8 as $t, 7 as $t]
+                    ];
+                    let target = array![
+                        [1 as $t, 8 as $t],
+                        [4 as $t, 7 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminTranspose>::t(a);
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_2_ $t>]() {
+                    let a = array![
+                        [1 as $t, 4 as $t],
+                        [8 as $t, 7 as $t],
+                        [3 as $t, 6 as $t]
+                    ];
+                    let target = array![
+                        [1 as $t, 8 as $t, 3 as $t],
+                        [4 as $t, 7 as $t, 6 as $t]
+                    ];
+                    let res = <Array2<$t> as ArgminTranspose>::t(a);
+                    for i in 0..2 {
+                        for j in 0..3 {
+                            assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/transpose_vec.rs
+++ b/src/core/math/transpose_vec.rs
@@ -1,0 +1,124 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// Note: This is not really the preferred way I think. Maybe this should also be implemented for
+// ArrayViews, which would probably make it more efficient.
+
+use crate::core::math::ArgminTranspose;
+use num_complex::Complex;
+
+macro_rules! make_transpose {
+    ($t:ty) => {
+        impl ArgminTranspose for Vec<Vec<$t>> {
+            fn t(self) -> Self {
+                let n1 = self.len();
+                let n2 = self[0].len();
+                // let mut out: Vec<Vec<$t>> = vec![vec![0; n1]; n2];
+                let mut v = Vec::with_capacity(n1);
+                unsafe {
+                    v.set_len(n1);
+                }
+                let mut out = vec![v; n2];
+                for i in 0..n1 {
+                    for j in 0..n2 {
+                        out[j][i] = self[i][j];
+                    }
+                }
+                out
+            }
+        }
+    };
+}
+
+make_transpose!(isize);
+make_transpose!(usize);
+make_transpose!(i8);
+make_transpose!(u8);
+make_transpose!(i16);
+make_transpose!(u16);
+make_transpose!(i32);
+make_transpose!(u32);
+make_transpose!(i64);
+make_transpose!(u64);
+make_transpose!(f32);
+make_transpose!(f64);
+make_transpose!(Complex<isize>);
+make_transpose!(Complex<usize>);
+make_transpose!(Complex<i8>);
+make_transpose!(Complex<u8>);
+make_transpose!(Complex<i16>);
+make_transpose!(Complex<u16>);
+make_transpose!(Complex<i32>);
+make_transpose!(Complex<u32>);
+make_transpose!(Complex<i64>);
+make_transpose!(Complex<u64>);
+make_transpose!(Complex<f32>);
+make_transpose!(Complex<f64>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_transpose_2d_1_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t],
+                        vec![8 as $t, 7 as $t]
+                    ];
+                    let target = vec![
+                        vec![1 as $t, 8 as $t],
+                        vec![4 as $t, 7 as $t]
+                    ];
+                    let res = a.t();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((target[i][j] - res[i][j]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_2_ $t>]() {
+                    let a = vec![
+                        vec![1 as $t, 4 as $t],
+                        vec![8 as $t, 7 as $t],
+                        vec![3 as $t, 6 as $t]
+                    ];
+                    let target = vec![
+                        vec![1 as $t, 8 as $t, 3 as $t],
+                        vec![4 as $t, 7 as $t, 6 as $t]
+                    ];
+                    let res = a.t();
+                    for i in 0..2 {
+                        for j in 0..3 {
+                            assert!(((target[i][j] - res[i][j]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/weighteddot.rs
+++ b/src/core/math/weighteddot.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDot;
+use crate::core::math::ArgminWeightedDot;
+
+impl<T, U, V> ArgminWeightedDot<T, U, V> for T
+where
+    Self: ArgminDot<T, U>,
+    V: ArgminDot<T, T>,
+{
+    #[inline]
+    fn weighted_dot(&self, w: &V, v: &T) -> U {
+        self.dot(&w.dot(v))
+    }
+}
+
+#[cfg(test)]
+mod tests_vec {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_ $t>]() {
+                    let a = vec![2 as $t, 1 as $t, 2 as $t];
+                    let b = vec![1 as $t, 2 as $t, 1 as $t];
+                    let w = vec![
+                        vec![8 as $t, 1 as $t, 6 as $t],
+                        vec![3 as $t, 5 as $t, 7 as $t],
+                        vec![4 as $t, 9 as $t, 2 as $t],
+                    ];
+                    let res: $t = a.weighted_dot(&w, &b);
+                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}
+
+#[cfg(feature = "ndarrayl")]
+#[cfg(test)]
+mod tests_ndarray {
+    use super::*;
+    use ndarray::array;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_ $t>]() {
+                    let a = array![2 as $t, 1 as $t, 2 as $t];
+                    let b = array![1 as $t, 2 as $t, 1 as $t];
+                    let w = array![
+                        [8 as $t, 1 as $t, 6 as $t],
+                        [3 as $t, 5 as $t, 7 as $t],
+                        [4 as $t, 9 as $t, 2 as $t],
+                    ];
+                    let res: $t = a.weighted_dot(&w, &b);
+                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/zero.rs
+++ b/src/core/math/zero.rs
@@ -1,0 +1,111 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::{ArgminZero, ArgminZeroLike};
+use num_complex::Complex;
+
+macro_rules! make_zero {
+    ($t:ty) => {
+        impl ArgminZero for $t {
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn zero() -> $t {
+                0 as $t
+            }
+        }
+        impl ArgminZeroLike for $t {
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn zero_like(&self) -> $t {
+                0 as $t
+            }
+        }
+    };
+}
+
+macro_rules! make_complex_zero {
+    ($t:ty) => {
+        impl ArgminZero for Complex<$t> {
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn zero() -> Complex<$t> {
+                Complex::new(0 as $t, 0 as $t)
+            }
+        }
+        impl ArgminZeroLike for Complex<$t> {
+            #[allow(clippy::cast_lossless)]
+            #[inline]
+            fn zero_like(&self) -> Complex<$t> {
+                Complex::new(0 as $t, 0 as $t)
+            }
+        }
+    };
+}
+
+make_zero!(f32);
+make_zero!(f64);
+make_zero!(i8);
+make_zero!(i16);
+make_zero!(i32);
+make_zero!(i64);
+make_zero!(u8);
+make_zero!(u16);
+make_zero!(u32);
+make_zero!(u64);
+make_zero!(isize);
+make_zero!(usize);
+make_complex_zero!(f32);
+make_complex_zero!(f64);
+make_complex_zero!(i8);
+make_complex_zero!(i16);
+make_complex_zero!(i32);
+make_complex_zero!(i64);
+make_complex_zero!(u8);
+make_complex_zero!(u16);
+make_complex_zero!(u32);
+make_complex_zero!(u64);
+make_complex_zero!(isize);
+make_complex_zero!(usize);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_zero_ $t>]() {
+                    let a = <$t as ArgminZero>::zero();
+                    assert!(((0 as $t - a) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_ $t>]() {
+                    let a = (42 as $t).zero_like();
+                    assert!(((0 as $t - a) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/zero_ndarray.rs
+++ b/src/core/math/zero_ndarray.rs
@@ -1,0 +1,121 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::{ArgminZero, ArgminZeroLike};
+use num::Zero;
+
+impl<T> ArgminZeroLike for ndarray::Array1<T>
+where
+    T: Zero + ArgminZero + Clone,
+{
+    #[inline]
+    fn zero_like(&self) -> ndarray::Array1<T> {
+        ndarray::Array1::zeros(self.raw_dim())
+    }
+
+    // #[inline]
+    // fn zero() -> ndarray::Array1<T> {
+    //     ndarray::Array1::zeros(0)
+    // }
+}
+
+impl<T> ArgminZeroLike for ndarray::Array2<T>
+where
+    T: Zero + ArgminZero + Clone,
+{
+    #[inline]
+    fn zero_like(&self) -> ndarray::Array2<T> {
+        ndarray::Array2::zeros(self.raw_dim())
+    }
+
+    // #[inline]
+    // fn zero() -> ndarray::Array2<T> {
+    //     ndarray::Array2::zeros((0, 0))
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{array, Array1, Array2};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            // item! {
+            //     #[test]
+            //     fn [<test_zero_ $t>]() {
+            //         let a = <Array1<$t> as ArgminZero>::zero();
+            //         let b: Array1<$t> = array![];
+            //         assert_eq!(a, b);
+            //     }
+            // }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_ $t>]() {
+                    let t: Array1<$t> = array![];
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_2_ $t>]() {
+                    let a = (array![42 as $t, 42 as $t, 42 as $t, 42 as $t]).zero_like();
+                    for i in 0..4 {
+                        assert!(((0 as $t - a[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            // item! {
+            //     #[test]
+            //     fn [<test_2d_zero_ $t>]() {
+            //         let a = <Array2<$t> as ArgminZero>::zero();
+            //         let b: Array2<$t> = Array2::zeros((0, 0));
+            //         assert_eq!(a, b);
+            //     }
+            // }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_ $t>]() {
+                    let t: Array2<$t> = Array2::zeros((0, 0));
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_2_ $t>]() {
+                    let a = (array![[42 as $t, 42 as $t], [42 as $t, 42 as $t]]).zero_like();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((0 as $t - a[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/zero_vec.rs
+++ b/src/core/math/zero_vec.rs
@@ -1,0 +1,85 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminZeroLike;
+
+impl<T> ArgminZeroLike for Vec<T>
+where
+    T: ArgminZeroLike + Clone,
+{
+    #[inline]
+    fn zero_like(&self) -> Vec<T> {
+        if !self.is_empty() {
+            vec![self[0].zero_like(); self.len()]
+        } else {
+            vec![]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_zero_like_ $t>]() {
+                    let t: Vec<$t> = vec![];
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_2_ $t>]() {
+                    let a = (vec![42 as $t; 4]).zero_like();
+                    for i in 0..4 {
+                        assert!(((0 as $t - a[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_ $t>]() {
+                    let t: Vec<Vec<$t>> = vec![];
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_2_ $t>]() {
+                    let a = (vec![vec![42 as $t; 2]; 2]).zero_like();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((0 as $t - a[i][j]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,328 @@
+// Copyright 2018-2020-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Argmin Optimizaton toolbox core
+//!
+//! This crate contains the core functionality of argmin. If you just want to run an optimization
+//! method, this is *not* what you are looking for. However, if you want to implement your own
+//! solver based on the argmin architecture, you should find all necessary tools here.
+
+// I really do not like the a..=b syntax
+#![allow(clippy::range_plus_one)]
+
+/// Macros
+#[macro_use]
+pub mod macros;
+/// Error handling
+mod errors;
+/// Executor
+pub mod executor;
+/// iteration state
+mod iterstate;
+/// Key value datastructure
+mod kv;
+/// Math utilities
+mod math;
+/// Phony Operator
+// #[cfg(test)]
+mod nooperator;
+/// Observers;
+mod observers;
+/// Wrapper around operators which keeps track of function evaluation counts
+mod opwrapper;
+/// Definition of the return type of the solvers
+mod result;
+/// Serialization of `ArgminSolver`s
+mod serialization;
+/// Definition of termination reasons
+mod termination;
+
+pub use errors::*;
+pub use executor::*;
+pub use failure::Error;
+pub use iterstate::*;
+pub use kv::ArgminKV;
+pub use math::*;
+pub use nooperator::*;
+pub use observers::*;
+pub use opwrapper::*;
+pub use result::ArgminResult;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+pub use serialization::*;
+pub use termination::TerminationReason;
+
+/// This trait needs to be implemented for every operator/cost function.
+///
+/// It is required to implement the `apply` method, all others are optional and provide a default
+/// implementation which is essentially returning an error which indicates that the method has not
+/// been implemented. Those methods (`gradient` and `modify`) only need to be implemented if the
+/// uses solver requires it.
+pub trait ArgminOp: Clone + Send + Sync + Serialize {
+    // TODO: Once associated type defaults are stable, it hopefully will be possible to define
+    // default types for `Hessian` and `Jacobian`.
+    /// Type of the parameter vector
+    type Param: Clone + Serialize + DeserializeOwned;
+    /// Output of the operator
+    type Output: Clone + Serialize + DeserializeOwned;
+    /// Type of Hessian
+    type Hessian: Clone + Serialize + DeserializeOwned;
+    /// Type of Jacobian
+    type Jacobian: Clone + Serialize + DeserializeOwned;
+
+    /// Applies the operator/cost function to parameters
+    fn apply(&self, _param: &Self::Param) -> Result<Self::Output, Error> {
+        Err(ArgminError::NotImplemented {
+            text: "Method `apply` of ArgminOp trait not implemented!".to_string(),
+        }
+        .into())
+    }
+
+    /// Computes the gradient at the given parameters
+    fn gradient(&self, _param: &Self::Param) -> Result<Self::Param, Error> {
+        Err(ArgminError::NotImplemented {
+            text: "Method `gradient` of ArgminOp trait not implemented!".to_string(),
+        }
+        .into())
+    }
+
+    /// Computes the Hessian at the given parameters
+    fn hessian(&self, _param: &Self::Param) -> Result<Self::Hessian, Error> {
+        Err(ArgminError::NotImplemented {
+            text: "Method `hessian` of ArgminOp trait not implemented!".to_string(),
+        }
+        .into())
+    }
+
+    /// Computes the Hessian at the given parameters
+    fn jacobian(&self, _param: &Self::Param) -> Result<Self::Jacobian, Error> {
+        Err(ArgminError::NotImplemented {
+            text: "Method `jacobian` of ArgminOp trait not implemented!".to_string(),
+        }
+        .into())
+    }
+
+    /// Modifies a parameter vector. Comes with a variable that indicates the "degree" of the
+    /// modification.
+    fn modify(&self, _param: &Self::Param, _extent: f64) -> Result<Self::Param, Error> {
+        Err(ArgminError::NotImplemented {
+            text: "Method `modify` of ArgminOp trait not implemented!".to_string(),
+        }
+        .into())
+    }
+}
+
+/// Solver
+///
+/// Every solver needs to implement this trait.
+pub trait Solver<O: ArgminOp>: Serialize {
+    /// Name of the solver
+    const NAME: &'static str = "UNDEFINED";
+
+    /// Computes one iteration of the algorithm.
+    fn next_iter(
+        &mut self,
+        op: &mut OpWrapper<O>,
+        state: &IterState<O>,
+    ) -> Result<ArgminIterData<O>, Error>;
+
+    /// Initializes the algorithm
+    ///
+    /// This is executed before any iterations are performed. It can be used to perform
+    /// precomputations. The default implementation corresponds to doing nothing.
+    fn init(
+        &mut self,
+        _op: &mut OpWrapper<O>,
+        _state: &IterState<O>,
+    ) -> Result<Option<ArgminIterData<O>>, Error> {
+        Ok(None)
+    }
+
+    /// Checks whether basic termination reasons apply.
+    ///
+    /// Terminate if
+    ///
+    /// 1) algorithm was terminated somewhere else in the Executor
+    /// 2) iteration count exceeds maximum number of iterations
+    /// 3) cost is lower than target cost
+    ///
+    /// This can be overwritten in a `Solver` implementation; however it is not advised.
+    fn terminate_internal(&mut self, state: &IterState<O>) -> TerminationReason {
+        let solver_terminate = self.terminate(state);
+        if solver_terminate.terminated() {
+            return solver_terminate;
+        }
+        if state.get_iter() >= state.get_max_iters() {
+            return TerminationReason::MaxItersReached;
+        }
+        if state.get_cost() <= state.get_target_cost() {
+            return TerminationReason::TargetCostReached;
+        }
+        TerminationReason::NotTerminated
+    }
+
+    /// Checks whether the algorithm must be terminated
+    fn terminate(&mut self, _state: &IterState<O>) -> TerminationReason {
+        TerminationReason::NotTerminated
+    }
+}
+
+/// The datastructure which is returned by the `next_iter` method of the `Solver` trait.
+///
+/// TODO: Rename to IterResult?
+#[derive(Clone, Serialize, Debug, Default)]
+pub struct ArgminIterData<O: ArgminOp> {
+    /// Current parameter vector
+    param: Option<O::Param>,
+    /// Current cost function value
+    cost: Option<f64>,
+    /// Current gradient
+    grad: Option<O::Param>,
+    /// Current Hessian
+    hessian: Option<O::Hessian>,
+    /// Current Jacobian
+    jacobian: Option<O::Jacobian>,
+    population: Option<Vec<(O::Param, f64)>>,
+    /// terminationreason
+    termination_reason: Option<TerminationReason>,
+    /// Key value pairs which are used to provide additional information for the Observers
+    kv: ArgminKV,
+}
+
+// TODO: Many clones are necessary in the getters.. maybe a complete "deconstruct" method would be
+// better?
+impl<O: ArgminOp> ArgminIterData<O> {
+    /// Constructor
+    pub fn new() -> Self {
+        ArgminIterData {
+            param: None,
+            cost: None,
+            grad: None,
+            hessian: None,
+            jacobian: None,
+            termination_reason: None,
+            population: None,
+            kv: make_kv!(),
+        }
+    }
+
+    /// Set parameter vector
+    pub fn param(mut self, param: O::Param) -> Self {
+        self.param = Some(param);
+        self
+    }
+
+    /// Set cost function value
+    pub fn cost(mut self, cost: f64) -> Self {
+        self.cost = Some(cost);
+        self
+    }
+
+    /// Set gradient
+    pub fn grad(mut self, grad: O::Param) -> Self {
+        self.grad = Some(grad);
+        self
+    }
+
+    /// Set Hessian
+    pub fn hessian(mut self, hessian: O::Hessian) -> Self {
+        self.hessian = Some(hessian);
+        self
+    }
+
+    /// Set Jacobian
+    pub fn jacobian(mut self, jacobian: O::Jacobian) -> Self {
+        self.jacobian = Some(jacobian);
+        self
+    }
+
+    /// Set Population
+    pub fn population(mut self, population: Vec<(O::Param, f64)>) -> Self {
+        self.population = Some(population);
+        self
+    }
+
+    /// Adds an `ArgminKV`
+    pub fn kv(mut self, kv: ArgminKV) -> Self {
+        self.kv = kv;
+        self
+    }
+
+    /// Set termination reason
+    pub fn termination_reason(mut self, reason: TerminationReason) -> Self {
+        self.termination_reason = Some(reason);
+        self
+    }
+
+    /// Get parameter vector
+    pub fn get_param(&self) -> Option<O::Param> {
+        self.param.clone()
+    }
+
+    /// Get cost function value
+    pub fn get_cost(&self) -> Option<f64> {
+        self.cost
+    }
+
+    /// Get gradient
+    pub fn get_grad(&self) -> Option<O::Param> {
+        self.grad.clone()
+    }
+
+    /// Get Hessian
+    pub fn get_hessian(&self) -> Option<O::Hessian> {
+        self.hessian.clone()
+    }
+
+    /// Get Jacobian
+    pub fn get_jacobian(&self) -> Option<O::Jacobian> {
+        self.jacobian.clone()
+    }
+
+    /// Get reference to population
+    pub fn get_population(&self) -> Option<&Vec<(O::Param, f64)>> {
+        match &self.population {
+            Some(population) => Some(&population),
+            None => None,
+        }
+    }
+
+    /// Get termination reason
+    pub fn get_termination_reason(&self) -> Option<TerminationReason> {
+        self.termination_reason
+    }
+
+    /// Return KV
+    pub fn get_kv(&self) -> ArgminKV {
+        self.kv.clone()
+    }
+}
+
+/// Defines a common interface for line search methods.
+pub trait ArgminLineSearch<P>: Serialize {
+    /// Set the search direction
+    fn set_search_direction(&mut self, direction: P);
+
+    /// Set the initial step length
+    fn set_init_alpha(&mut self, step_length: f64) -> Result<(), Error>;
+}
+
+/// Defines a common interface to methods which calculate approximate steps for trust region
+/// methods.
+pub trait ArgminTrustRegion: Clone + Serialize {
+    /// Set the initial step length
+    fn set_radius(&mut self, radius: f64);
+}
+//
+/// Common interface for beta update methods (Nonlinear-CG)
+pub trait ArgminNLCGBetaUpdate<T>: Serialize {
+    /// Update beta
+    /// Parameter 1: \nabla f_k
+    /// Parameter 2: \nabla f_{k+1}
+    /// Parameter 3: p_k
+    fn update(&self, nabla_f_k: &T, nabla_f_k_p_1: &T, p_k: &T) -> f64;
+}

--- a/src/core/nooperator.rs
+++ b/src/core/nooperator.rs
@@ -1,0 +1,128 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::{ArgminOp, Error};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display};
+
+/// Fake Operators for testing
+
+/// No-op operator with free choice of the types
+#[derive(
+    Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Copy,
+)]
+pub struct NoOperator<T, U, H, J> {
+    /// Fake parameter
+    param: std::marker::PhantomData<T>,
+    /// Fake output
+    output: std::marker::PhantomData<U>,
+    /// Fake Hessian
+    hessian: std::marker::PhantomData<H>,
+    /// Fake Jacobian
+    jacobian: std::marker::PhantomData<J>,
+}
+
+impl<T, U, H, J> NoOperator<T, U, H, J> {
+    /// Constructor
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        NoOperator {
+            param: std::marker::PhantomData,
+            output: std::marker::PhantomData,
+            hessian: std::marker::PhantomData,
+            jacobian: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, U, H, J> Display for NoOperator<T, U, H, J> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "NoOperator")
+    }
+}
+
+impl<T, U, H, J> ArgminOp for NoOperator<T, U, H, J>
+where
+    T: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
+    U: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
+    H: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
+    J: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
+{
+    type Param = T;
+    type Output = U;
+    type Hessian = H;
+    type Jacobian = J;
+
+    /// Do nothing, really.
+    fn apply(&self, _p: &Self::Param) -> Result<Self::Output, Error> {
+        Ok(Self::Output::default())
+    }
+
+    /// Do nothing, really.
+    fn gradient(&self, _p: &Self::Param) -> Result<Self::Param, Error> {
+        Ok(Self::Param::default())
+    }
+
+    /// Do nothing, really.
+    fn hessian(&self, _p: &Self::Param) -> Result<Self::Hessian, Error> {
+        Ok(Self::Hessian::default())
+    }
+
+    /// Do nothing, really.
+    fn modify(&self, _p: &Self::Param, _t: f64) -> Result<Self::Param, Error> {
+        Ok(Self::Param::default())
+    }
+}
+
+/// Minimal No-op operator which does nothing, really.
+#[derive(
+    Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Copy,
+)]
+pub struct MinimalNoOperator {}
+
+/// No-op operator with fixed types (See `ArgminOp` impl on `MinimalNoOperator`)
+impl MinimalNoOperator {
+    /// Constructor
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        MinimalNoOperator {}
+    }
+}
+
+impl Display for MinimalNoOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "MinimalNoOperator")
+    }
+}
+
+impl ArgminOp for MinimalNoOperator {
+    type Param = Vec<f64>;
+    type Output = f64;
+    type Hessian = Vec<Vec<f64>>;
+    type Jacobian = Vec<f64>;
+
+    /// Do nothing, really.
+    fn apply(&self, _p: &Self::Param) -> Result<Self::Output, Error> {
+        unimplemented!()
+    }
+
+    /// Do nothing, really.
+    fn gradient(&self, _p: &Self::Param) -> Result<Self::Param, Error> {
+        unimplemented!()
+    }
+
+    /// Do nothing, really.
+    fn hessian(&self, _p: &Self::Param) -> Result<Self::Hessian, Error> {
+        unimplemented!()
+    }
+
+    /// Do nothing, really.
+    fn modify(&self, _p: &Self::Param, _t: f64) -> Result<Self::Param, Error> {
+        unimplemented!()
+    }
+}

--- a/src/core/observers/file.rs
+++ b/src/core/observers/file.rs
@@ -1,0 +1,95 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Output parameter vectors to file
+
+use crate::core::{ArgminKV, ArgminOp, Error, IterState, Observe};
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+/// Different kinds of serializers
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum WriteToFileSerializer {
+    /// Bincode
+    Bincode,
+    /// JSON
+    JSON,
+}
+
+impl Default for WriteToFileSerializer {
+    fn default() -> Self {
+        WriteToFileSerializer::Bincode
+    }
+}
+
+/// Write parameter vectors to file
+#[derive(Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct WriteToFile<O> {
+    /// Directory
+    dir: String,
+    /// File prefix
+    prefix: String,
+    /// Chosen serializer
+    serializer: WriteToFileSerializer,
+    _param: std::marker::PhantomData<O>,
+}
+
+impl<O: ArgminOp> WriteToFile<O> {
+    /// Create a new `WriteToFile` struct
+    pub fn new(dir: &str, prefix: &str) -> Self {
+        WriteToFile {
+            dir: dir.to_string(),
+            prefix: prefix.to_string(),
+            serializer: WriteToFileSerializer::Bincode,
+            _param: std::marker::PhantomData,
+        }
+    }
+
+    /// Set serializer
+    pub fn serializer(mut self, serializer: WriteToFileSerializer) -> Self {
+        self.serializer = serializer;
+        self
+    }
+}
+
+impl<O: ArgminOp> Observe<O> for WriteToFile<O> {
+    fn observe_iter(&mut self, state: &IterState<O>, _kv: &ArgminKV) -> Result<(), Error> {
+        let param = state.get_param();
+        let iter = state.get_iter();
+        let dir = Path::new(&self.dir);
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)?
+        }
+
+        let mut fname = self.prefix.clone();
+        fname.push_str("_");
+        fname.push_str(&iter.to_string());
+        fname.push_str(".arp");
+        let fname = dir.join(fname);
+
+        let f = BufWriter::new(File::create(fname)?);
+        match self.serializer {
+            WriteToFileSerializer::Bincode => {
+                bincode::serialize_into(f, &param)?;
+            }
+            WriteToFileSerializer::JSON => {
+                serde_json::to_writer_pretty(f, &param)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    send_sync_test!(write_to_file, WriteToFile<Vec<f64>>);
+}

--- a/src/core/observers/mod.rs
+++ b/src/core/observers/mod.rs
@@ -1,0 +1,138 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Observers
+//!
+//! Observers are called after an iteration of a solver was performed and enable the user to observe
+//! the current state of the optimization. This can be used for logging or writing the current
+//! parameter vector to disk.
+
+pub mod file;
+pub mod slog_logger;
+#[cfg(feature = "visualizer")]
+pub mod visualizer;
+
+use crate::core::{ArgminKV, ArgminOp, Error, IterState};
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+use std::sync::{Arc, Mutex};
+
+pub use file::*;
+pub use slog_logger::*;
+#[cfg(feature = "visualizer")]
+pub use visualizer::*;
+
+/// Defines the interface every Observer needs to expose
+pub trait Observe<O: ArgminOp>: Send + Sync {
+    /// Called once at the beginning of the execution of the solver.
+    ///
+    /// Parameters:
+    ///
+    /// `name`: Name of the solver
+    /// `kv`: Key-Value storage of initial configurations defined by the `Solver`
+    fn observe_init(&self, _name: &str, _kv: &ArgminKV) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Called at every iteration of the solver
+    ///
+    /// Parameters
+    ///
+    /// `state`: Current state of the solver. See documentation of `IterState` for details.
+    /// `kv`: Key-Value store of relevant variables defined by the `Solver`
+    fn observe_iter(&mut self, _state: &IterState<O>, _kv: &ArgminKV) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Container for observers which acts just like a single `Observe`r by implementing `Observe` on
+/// it.
+#[derive(Clone, Default)]
+pub struct Observer<O> {
+    /// Vector of `Observe`rs with the corresponding `ObserverMode`
+    observers: Vec<(Arc<Mutex<dyn Observe<O>>>, ObserverMode)>,
+}
+
+impl<O: ArgminOp> Observer<O> {
+    /// Constructor
+    pub fn new() -> Self {
+        Observer { observers: vec![] }
+    }
+
+    /// Push another `Observe` to the `observer` field
+    pub fn push<OBS: Observe<O> + 'static>(
+        &mut self,
+        observer: OBS,
+        mode: ObserverMode,
+    ) -> &mut Self {
+        self.observers.push((Arc::new(Mutex::new(observer)), mode));
+        self
+    }
+}
+
+/// By implementing `Observe` for `Observer` we basically allow a set of `Observer`s to be used
+/// just like a single `Observe`r.
+impl<O: ArgminOp> Observe<O> for Observer<O> {
+    /// Initial observation
+    /// This is called after the initialization in an `Executor` and gets the name of the solver as
+    /// string and a `ArgminKV` which includes some solver-specific information.
+    fn observe_init(&self, msg: &str, kv: &ArgminKV) -> Result<(), Error> {
+        for l in self.observers.iter() {
+            l.0.lock().unwrap().observe_init(msg, kv)?
+        }
+        Ok(())
+    }
+
+    /// This is called after every iteration and gets the current `state` of the solver as well as
+    /// a `KV` which can include solver-specific information
+    /// This respects the `ObserverMode`: Every `Observe`r is only called as often as specified.
+    fn observe_iter(&mut self, state: &IterState<O>, kv: &ArgminKV) -> Result<(), Error> {
+        use ObserverMode::*;
+        for l in self.observers.iter_mut() {
+            let iter = state.get_iter();
+            let observer = &mut l.0.lock().unwrap();
+            match l.1 {
+                Always => observer.observe_iter(state, kv),
+                Every(i) if iter % i == 0 => observer.observe_iter(state, kv),
+                NewBest if state.is_best() => observer.observe_iter(state, kv),
+                Never | Every(_) | NewBest => Ok(()),
+            }?
+        }
+        Ok(())
+    }
+}
+
+/// This is used to indicate how often the observer will observe the status. `Never` deactivates
+/// the observer, `Always` and `Every(i)` will call the observer in every or every ith iteration,
+/// respectively. `NewBest` will call the observer only, if a new best solution is found.
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum ObserverMode {
+    /// Never call the observer
+    Never,
+    /// Call observer in every iteration
+    Always,
+    /// Call observer every N iterations
+    Every(u64),
+    /// Call observer when new best is found
+    NewBest,
+}
+
+impl Default for ObserverMode {
+    /// The default is `Always`
+    fn default() -> ObserverMode {
+        ObserverMode::Always
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::MinimalNoOperator;
+
+    send_sync_test!(observer, Observer<MinimalNoOperator>);
+    send_sync_test!(observermode, ObserverMode);
+}

--- a/src/core/observers/slog_logger.rs
+++ b/src/core/observers/slog_logger.rs
@@ -1,0 +1,157 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Loggers based on the `slog` crate
+
+use crate::core::{ArgminKV, ArgminOp, Error, IterState, Observe};
+use slog;
+use slog::{info, o, Drain, Record, Serializer, KV};
+use slog_async;
+use slog_async::OverflowStrategy;
+use slog_json;
+use slog_term;
+use std::fs::OpenOptions;
+use std::sync::Mutex;
+
+/// A logger based on `slog`
+#[derive(Clone)]
+pub struct ArgminSlogLogger {
+    /// the logger
+    logger: slog::Logger,
+}
+
+impl ArgminSlogLogger {
+    /// Log to the terminal in a blocking way
+    pub fn term() -> Self {
+        ArgminSlogLogger::term_internal(OverflowStrategy::Block)
+    }
+
+    /// Log to the terminal in a non-blocking way (in case of overflow, messages are dropped)
+    pub fn term_noblock() -> Self {
+        ArgminSlogLogger::term_internal(OverflowStrategy::Drop)
+    }
+
+    /// Actual implementation of the logging to the terminal
+    fn term_internal(overflow_strategy: OverflowStrategy) -> Self {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator)
+            .use_original_order()
+            .build()
+            .fuse();
+        let drain = slog_async::Async::new(drain)
+            .overflow_strategy(overflow_strategy)
+            .build()
+            .fuse();
+        ArgminSlogLogger {
+            logger: slog::Logger::root(drain, o!()),
+        }
+    }
+
+    /// Log JSON to a file in a blocking way
+    ///
+    /// If `truncate` is set to `true`, the content of existing log files at `file` will be
+    /// cleared.
+    pub fn file(file: &str, truncate: bool) -> Result<Self, Error> {
+        ArgminSlogLogger::file_internal(file, OverflowStrategy::Block, truncate)
+    }
+
+    /// Log JSON to a file in a non-blocking way (in case of overflow, messages are dropped)
+    ///
+    /// If `truncate` is set to `true`, the content of existing log files at `file` will be
+    /// cleared.
+    pub fn file_noblock(file: &str, truncate: bool) -> Result<Self, Error> {
+        ArgminSlogLogger::file_internal(file, OverflowStrategy::Drop, truncate)
+    }
+
+    /// Actual implementaiton of logging JSON to file
+    fn file_internal(
+        file: &str,
+        overflow_strategy: OverflowStrategy,
+        truncate: bool,
+    ) -> Result<Self, Error> {
+        // Logging to file
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(truncate)
+            .open(file)?;
+        let drain = Mutex::new(slog_json::Json::new(file).build()).map(slog::Fuse);
+        let drain = slog_async::Async::new(drain)
+            .overflow_strategy(overflow_strategy)
+            .build()
+            .fuse();
+        Ok(ArgminSlogLogger {
+            logger: slog::Logger::root(drain, o!()),
+        })
+    }
+}
+
+/// This type is necessary in order to be able to implement `slog::KV` on `ArgminKV`
+pub struct ArgminSlogKV {
+    /// Key value store
+    pub kv: Vec<(&'static str, String)>,
+}
+
+impl KV for ArgminSlogKV {
+    fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
+        for idx in self.kv.clone().iter().rev() {
+            serializer.emit_str(idx.0, &idx.1.to_string())?;
+        }
+        Ok(())
+    }
+}
+
+impl<O: ArgminOp> KV for IterState<O> {
+    fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
+        serializer.emit_str(
+            "modify_func_count",
+            &self.get_modify_func_count().to_string(),
+        )?;
+        serializer.emit_str(
+            "hessian_func_count",
+            &self.get_hessian_func_count().to_string(),
+        )?;
+        serializer.emit_str(
+            "jacobian_func_count",
+            &self.get_jacobian_func_count().to_string(),
+        )?;
+        serializer.emit_str("grad_func_count", &self.get_grad_func_count().to_string())?;
+        serializer.emit_str("cost_func_count", &self.get_cost_func_count().to_string())?;
+        serializer.emit_str("best_cost", &self.get_best_cost().to_string())?;
+        serializer.emit_str("cost", &self.get_cost().to_string())?;
+        serializer.emit_str("iter", &self.get_iter().to_string())?;
+        Ok(())
+    }
+}
+
+impl<'a> From<&'a ArgminKV> for ArgminSlogKV {
+    fn from(i: &'a ArgminKV) -> ArgminSlogKV {
+        ArgminSlogKV { kv: i.kv.clone() }
+    }
+}
+
+impl<O: ArgminOp> Observe<O> for ArgminSlogLogger {
+    /// Log general info
+    fn observe_init(&self, msg: &str, kv: &ArgminKV) -> Result<(), Error> {
+        info!(self.logger, "{}", msg; ArgminSlogKV::from(kv));
+        Ok(())
+    }
+
+    /// This should be used to log iteration data only (because this is what may be saved in a CSV
+    /// file or a database)
+    fn observe_iter(&mut self, state: &IterState<O>, kv: &ArgminKV) -> Result<(), Error> {
+        info!(self.logger, ""; state, ArgminSlogKV::from(kv));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    send_sync_test!(argmin_slog_loggerv, ArgminSlogLogger);
+}

--- a/src/core/observers/visualizer.rs
+++ b/src/core/observers/visualizer.rs
@@ -1,0 +1,196 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Observer which visualizes the progress of the solver
+
+extern crate gnuplot;
+use crate::core::{ArgminKV, ArgminOp, Error, IterState, Observe};
+use std::sync::Mutex;
+
+/// Visualize iterations of a solver for cost functions of type
+/// (x,y) -> cost
+/// , where x and y are real numbers. If the solver is population-based,
+/// The current population is also visualized.
+pub struct Visualizer3d {
+    // Need mutex because `Figure` contains `Cell`
+    /// Figure handle
+    fg: Mutex<gnuplot::Figure>,
+    /// x component of optima
+    optima_x: Vec<f64>,
+    /// y component of optima
+    optima_y: Vec<f64>,
+    /// z component of optima
+    optima_z: Vec<f64>,
+    /// x component of particles
+    particles_x: Vec<f64>,
+    /// y component of particles
+    particles_y: Vec<f64>,
+    /// z component of particles
+    particles_z: Vec<f64>,
+    /// Optional visualized surface of cost function
+    surface: Option<Surface>,
+    /// Optional delay between iterations
+    delay: Option<std::time::Duration>,
+}
+
+impl Visualizer3d {
+    /// Create a new visualizer
+    pub fn new() -> Self {
+        Self {
+            fg: Mutex::new(gnuplot::Figure::new()),
+            optima_x: vec![],
+            optima_y: vec![],
+            optima_z: vec![],
+            particles_x: vec![],
+            particles_y: vec![],
+            particles_z: vec![],
+            surface: None,
+            delay: None,
+        }
+    }
+
+    /// Set delay
+    pub fn delay(mut self, duration: std::time::Duration) -> Self {
+        self.delay = Some(duration);
+        self
+    }
+
+    /// Set surface
+    pub fn surface(mut self, surface: Surface) -> Self {
+        self.surface = Some(surface);
+        self
+    }
+
+    /// Draw
+    fn draw(&mut self) {
+        use gnuplot::*;
+
+        // TODO: unwrap evil
+        let mut figure = self.fg.lock().unwrap();
+
+        figure.clear_axes();
+
+        let options_optima = [Color("#ffff00"), PointSize(2.0)];
+        let options_particles = [Color("#ff0000"), PointSize(2.0)];
+        let axes3d = figure.axes3d();
+
+        // Draw surface before points
+        if let Some(surface) = &self.surface {
+            let window = Some(surface.window);
+            axes3d.surface(
+                surface.zvalues.iter(),
+                surface.width,
+                surface.height,
+                window,
+                &[],
+            );
+        }
+
+        axes3d
+            .points(
+                &self.optima_x,
+                &self.optima_y,
+                &self.optima_z,
+                &options_optima,
+            )
+            .points(
+                &self.particles_x,
+                &self.particles_y,
+                &self.particles_z,
+                &options_particles,
+            )
+            .set_view(30.0, 30.0); // TODO: do not reset view on new iteration
+
+        // TODO: unwrap evil
+        figure.show().unwrap();
+
+        if let Some(delay) = self.delay {
+            std::thread::sleep(delay);
+        };
+    }
+
+    /// TODO
+    fn iteration(&mut self, xy: &Vec<f64>, cost: f64, population: Option<&Vec<(Vec<f64>, f64)>>) {
+        self.optima_x.clear();
+        self.optima_y.clear();
+        self.optima_z.clear();
+        self.optima_x.push(xy[0]);
+        self.optima_y.push(xy[1]);
+        self.optima_z.push(cost);
+
+        self.particles_x.clear();
+        self.particles_y.clear();
+        self.particles_z.clear();
+
+        if let Some(population) = population {
+            for (param, cost) in population {
+                self.particles_x.push(param[0]);
+                self.particles_y.push(param[1]);
+                self.particles_z.push(*cost);
+            }
+        }
+
+        self.draw();
+    }
+}
+
+impl<O> Observe<O> for Visualizer3d
+where
+    O: ArgminOp<Param = Vec<f64>>,
+{
+    fn observe_iter(&mut self, state: &IterState<O>, _kv: &ArgminKV) -> Result<(), Error> {
+        // TODO: get particles from `state` or `kv`
+
+        self.iteration(&state.param, state.best_cost, state.get_population());
+
+        Ok(())
+    }
+}
+
+/// Helper class for visualized surface
+pub struct Surface {
+    /// Window dimenstions
+    window: (f64, f64, f64, f64),
+    /// Width of surface
+    width: usize,
+    /// Height of surface
+    height: usize,
+    /// TODO
+    zvalues: Vec<f64>,
+}
+
+impl Surface {
+    /// Create a new surface
+    pub fn new<O>(op: O, window: (f64, f64, f64, f64), resolution: f64) -> Self
+    where
+        O: ArgminOp<Param = Vec<f64>, Output = f64>,
+    {
+        let width = window.2 - window.0;
+        let height = window.3 - window.1;
+        let num_x = (width / resolution) as usize;
+        let num_y = (height / resolution) as usize;
+
+        let mut zvalues: Vec<f64> = vec![];
+
+        for i in 0..num_y {
+            for j in 0..num_x {
+                let y = height * (i as f64) / num_y as f64 - (0.5 * height);
+                let x = width * (j as f64) / num_x as f64 - (0.5 * width);
+                if let Ok(zvalue) = op.apply(&vec![x, y]) {
+                    zvalues.push(zvalue);
+                }
+            }
+        }
+
+        Self {
+            window: window,
+            width: num_x,
+            height: num_y,
+            zvalues,
+        }
+    }
+}

--- a/src/core/opwrapper.rs
+++ b/src/core/opwrapper.rs
@@ -1,0 +1,149 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::{ArgminOp, Error};
+use serde::{Deserialize, Serialize};
+
+/// This wraps an operator and keeps track of how often the cost, gradient and Hessian have been
+/// computed and how often the modify function has been called. Usually, this is an implementation
+/// detail unless a solver is needed within another solver (such as a line search within a gradient
+/// descent method), then it may be necessary to wrap the operator in an OpWrapper.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct OpWrapper<O: ArgminOp> {
+    /// Operator
+    op: O,
+    /// Number of cost function evaluations
+    pub cost_func_count: u64,
+    /// Number of gradient function evaluations
+    pub grad_func_count: u64,
+    /// Number of Hessian function evaluations
+    pub hessian_func_count: u64,
+    /// Number of Jacobian function evaluations
+    pub jacobian_func_count: u64,
+    /// Number of `modify` function evaluations
+    pub modify_func_count: u64,
+}
+
+impl<O: ArgminOp> OpWrapper<O> {
+    /// Constructor
+    pub fn new(op: &O) -> Self {
+        OpWrapper {
+            op: op.clone(),
+            cost_func_count: 0,
+            grad_func_count: 0,
+            hessian_func_count: 0,
+            jacobian_func_count: 0,
+            modify_func_count: 0,
+        }
+    }
+
+    /// Constructor (moves op)
+    pub fn new_move(op: O) -> Self {
+        OpWrapper {
+            op,
+            cost_func_count: 0,
+            grad_func_count: 0,
+            hessian_func_count: 0,
+            jacobian_func_count: 0,
+            modify_func_count: 0,
+        }
+    }
+
+    /// Calls the `apply` method of `op` and increments `cost_func_count`.
+    pub fn apply(&mut self, param: &O::Param) -> Result<O::Output, Error> {
+        self.cost_func_count += 1;
+        self.op.apply(param)
+    }
+
+    /// Calls the `gradient` method of `op` and increments `gradient_func_count`.
+    pub fn gradient(&mut self, param: &O::Param) -> Result<O::Param, Error> {
+        self.grad_func_count += 1;
+        self.op.gradient(param)
+    }
+
+    /// Calls the `hessian` method of `op` and increments `hessian_func_count`.
+    pub fn hessian(&mut self, param: &O::Param) -> Result<O::Hessian, Error> {
+        self.hessian_func_count += 1;
+        self.op.hessian(param)
+    }
+
+    /// Calls the `jacobian` method of `op` and increments `jacobian_func_count`.
+    pub fn jacobian(&mut self, param: &O::Param) -> Result<O::Jacobian, Error> {
+        self.jacobian_func_count += 1;
+        self.op.jacobian(param)
+    }
+
+    /// Calls the `modify` method of `op` and increments `modify_func_count`.
+    pub fn modify(&mut self, param: &O::Param, extent: f64) -> Result<O::Param, Error> {
+        self.modify_func_count += 1;
+        self.op.modify(param, extent)
+    }
+
+    /// Consumes an operator by increasing the function call counts of `self` by the ones in
+    /// `other`.
+    pub fn consume_op<O2: ArgminOp>(&mut self, other: OpWrapper<O2>) {
+        self.cost_func_count += other.cost_func_count;
+        self.grad_func_count += other.grad_func_count;
+        self.hessian_func_count += other.hessian_func_count;
+        self.jacobian_func_count += other.jacobian_func_count;
+        self.modify_func_count += other.modify_func_count;
+    }
+
+    /// Reset the cost function counts to zero
+    pub fn reset(mut self) -> Self {
+        self.cost_func_count = 0;
+        self.grad_func_count = 0;
+        self.hessian_func_count = 0;
+        self.jacobian_func_count = 0;
+        self.modify_func_count = 0;
+        self
+    }
+
+    /// Returns the operator `op` by taking ownership of `self`.
+    pub fn get_op(self) -> O {
+        self.op
+    }
+
+    /// Returns a clone of the operator `op`.
+    pub fn clone_op(&self) -> O {
+        self.op.clone()
+    }
+
+    /// Creates a new `OpWrapper<O>` from another `OpWrapper<O>` by cloning the `op` and
+    /// initializing all counts with `0`.
+    pub fn new_from_op(op: &OpWrapper<O>) -> Self {
+        Self::new(&op.clone_op())
+    }
+}
+
+/// The OpWrapper<O> should behave just like any other `ArgminOp`
+impl<O: ArgminOp> ArgminOp for OpWrapper<O> {
+    type Param = O::Param;
+    type Output = O::Output;
+    type Hessian = O::Hessian;
+    type Jacobian = O::Jacobian;
+
+    fn apply(&self, param: &Self::Param) -> Result<Self::Output, Error> {
+        self.op.apply(param)
+    }
+
+    fn gradient(&self, param: &Self::Param) -> Result<Self::Param, Error> {
+        self.op.gradient(param)
+    }
+
+    fn hessian(&self, param: &Self::Param) -> Result<Self::Hessian, Error> {
+        self.op.hessian(param)
+    }
+
+    fn jacobian(&self, param: &Self::Param) -> Result<Self::Jacobian, Error> {
+        self.op.jacobian(param)
+    }
+
+    fn modify(&self, param: &Self::Param, extent: f64) -> Result<Self::Param, Error> {
+        self.op.modify(param, extent)
+    }
+}

--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -1,0 +1,90 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # `ArgminResult`
+//!
+//! Return type of the solvers. Includes the final parameter vector, the final cost, the number of
+//! iterations, whether it terminated and the reason of termination.
+
+use crate::core::{ArgminOp, IterState};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+
+/// This is returned by the `Executor` after the solver is run on the operator.
+///
+/// TODO: Think about removing this, as returning the IterState may be much better
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ArgminResult<O: ArgminOp> {
+    /// operator
+    pub operator: O,
+    /// iteration state
+    pub state: IterState<O>,
+}
+
+impl<O: ArgminOp> ArgminResult<O> {
+    /// Constructor
+    pub fn new(operator: O, state: IterState<O>) -> Self {
+        ArgminResult { operator, state }
+    }
+}
+
+impl<O> std::fmt::Display for ArgminResult<O>
+where
+    O: ArgminOp,
+    O::Param: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "ArgminResult:")?;
+        writeln!(f, "    param (best):  {:?}", self.state.get_best_param())?;
+        writeln!(f, "    cost (best):   {}", self.state.get_best_cost())?;
+        writeln!(f, "    iters (best):  {}", self.state.get_last_best_iter())?;
+        writeln!(f, "    iters (best):  {}", self.state.get_last_best_iter())?;
+        writeln!(f, "    iters (total): {}", self.state.get_iter())?;
+        writeln!(
+            f,
+            "    termination: {}",
+            self.state.get_termination_reason()
+        )?;
+        writeln!(f, "    time:        {:?}", self.state.get_time())?;
+        Ok(())
+    }
+}
+
+impl<O: ArgminOp> PartialEq for ArgminResult<O> {
+    fn eq(&self, other: &ArgminResult<O>) -> bool {
+        (self.state.get_cost() - other.state.get_cost()).abs() < std::f64::EPSILON
+    }
+}
+
+impl<O: ArgminOp> Eq for ArgminResult<O> {}
+
+impl<O: ArgminOp> Ord for ArgminResult<O> {
+    fn cmp(&self, other: &ArgminResult<O>) -> Ordering {
+        let t = self.state.get_cost() - other.state.get_cost();
+        if t.abs() < std::f64::EPSILON {
+            Ordering::Equal
+        } else if t > 0.0 {
+            Ordering::Greater
+        } else {
+            Ordering::Less
+        }
+    }
+}
+
+impl<O: ArgminOp> PartialOrd for ArgminResult<O> {
+    fn partial_cmp(&self, other: &ArgminResult<O>) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::MinimalNoOperator;
+
+    send_sync_test!(argmin_result, ArgminResult<MinimalNoOperator>);
+}

--- a/src/core/serialization.rs
+++ b/src/core/serialization.rs
@@ -1,0 +1,194 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::{ArgminError, Error};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+use std::fmt::Display;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::Path;
+
+/// Defines at which intervals a checkpoint is saved.
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Copy)]
+pub enum CheckpointMode {
+    /// Never create checkpoint
+    Never,
+    /// Create checkpoint every N iterations
+    Every(u64),
+    /// Create checkpoint in every iteration
+    Always,
+}
+
+impl Default for CheckpointMode {
+    fn default() -> CheckpointMode {
+        CheckpointMode::Never
+    }
+}
+
+impl Display for CheckpointMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            CheckpointMode::Never => write!(f, "Never"),
+            CheckpointMode::Every(i) => write!(f, "Every({})", i),
+            CheckpointMode::Always => write!(f, "Always"),
+        }
+    }
+}
+
+/// Checkpoint
+///
+/// Defines how often and where a checkpoint is saved.
+#[derive(Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
+pub struct ArgminCheckpoint {
+    mode: CheckpointMode,
+    directory: String,
+    name: String,
+}
+
+impl Default for ArgminCheckpoint {
+    fn default() -> ArgminCheckpoint {
+        ArgminCheckpoint {
+            mode: CheckpointMode::Never,
+            directory: ".checkpoints".to_string(),
+            name: "default".to_string(),
+        }
+    }
+}
+
+impl ArgminCheckpoint {
+    /// Define a new checkpoint
+    pub fn new(directory: &str, mode: CheckpointMode) -> Result<Self, Error> {
+        match mode {
+            CheckpointMode::Every(_) | CheckpointMode::Always => {
+                std::fs::create_dir_all(&directory)?
+            }
+            _ => {}
+        }
+        let name = "solver".to_string();
+        let directory = directory.to_string();
+        Ok(ArgminCheckpoint {
+            mode,
+            directory,
+            name,
+        })
+    }
+
+    /// Set directory of checkpoint
+    #[inline]
+    pub fn set_dir(&mut self, dir: &str) {
+        self.directory = dir.to_string();
+    }
+
+    /// Get directory of checkpoint
+    #[inline]
+    pub fn dir(&self) -> String {
+        self.directory.clone()
+    }
+
+    /// Set name of checkpoint
+    #[inline]
+    pub fn set_name(&mut self, name: &str) {
+        self.name = name.to_string();
+    }
+
+    /// Get name of checkpoint
+    #[inline]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    /// Set mode of checkpoint
+    #[inline]
+    pub fn set_mode(&mut self, mode: CheckpointMode) {
+        self.mode = mode
+    }
+
+    /// Write checkpoint to disk
+    #[inline]
+    pub fn store<T: Serialize>(&self, solver: &T, filename: String) -> Result<(), Error> {
+        let dir = Path::new(&self.directory);
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)?
+        }
+        let fname = dir.join(Path::new(&filename));
+
+        let f = BufWriter::new(File::create(fname)?);
+        bincode::serialize_into(f, solver)?;
+        Ok(())
+    }
+
+    /// Write checkpoint based on the desired `CheckpointMode`
+    #[inline]
+    pub fn store_cond<T: Serialize>(&self, solver: &T, iter: u64) -> Result<(), Error> {
+        let mut filename = self.name();
+        filename.push_str(".arg");
+        match self.mode {
+            CheckpointMode::Always => self.store(solver, filename)?,
+            CheckpointMode::Every(it) if iter % it == 0 => self.store(solver, filename)?,
+            CheckpointMode::Never | CheckpointMode::Every(_) => {}
+        };
+        Ok(())
+    }
+}
+
+/// Load a checkpoint from disk
+pub fn load_checkpoint<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T, Error> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(ArgminError::CheckpointNotFound {
+            text: path.to_str().unwrap().to_string(),
+        }
+        .into());
+    }
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    Ok(bincode::deserialize_from(reader)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::nooperator::MinimalNoOperator;
+    use crate::core::*;
+
+    #[derive(Serialize, Deserialize, Clone, Debug)]
+    pub struct PhonySolver {}
+
+    impl PhonySolver {
+        /// Constructor
+        pub fn new() -> Self {
+            PhonySolver {}
+        }
+    }
+
+    impl<O> Solver<O> for PhonySolver
+    where
+        O: ArgminOp,
+    {
+        fn next_iter(
+            &mut self,
+            _op: &mut OpWrapper<O>,
+            _state: &IterState<O>,
+        ) -> Result<ArgminIterData<O>, Error> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_store() {
+        let op: MinimalNoOperator = MinimalNoOperator::new();
+        let solver = PhonySolver::new();
+        let exec = Executor::new(op, solver, vec![0.0f64, 0.0]);
+        let check = ArgminCheckpoint::new("checkpoints", CheckpointMode::Always).unwrap();
+        check.store_cond(&exec, 20).unwrap();
+
+        let _loaded: Executor<MinimalNoOperator, PhonySolver> =
+            load_checkpoint("checkpoints/solver.arg").unwrap();
+    }
+}

--- a/src/core/termination.rs
+++ b/src/core/termination.rs
@@ -1,0 +1,87 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! # Termination
+//!
+//! Defines reasons for termination.
+//!
+//! TODO:
+//!   * Maybe it is better to define a trait (with `terminated` and `text` methods), because it
+//!     would allow implementers of solvers to define their own `TerminationReason`s. However, this
+//!     would require a lot of work.
+
+use serde::{Deserialize, Serialize};
+
+/// Indicates why the optimization algorithm stopped
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum TerminationReason {
+    /// In case it has not terminated yet
+    NotTerminated,
+    /// Maximum number of iterations reached
+    MaxItersReached,
+    /// Target cost function value reached
+    TargetCostReached,
+    /// Target precision reached
+    TargetPrecisionReached,
+    /// Cost function value did not change
+    NoChangeInCost,
+    /// Acceped stall iter exceeded
+    AcceptedStallIterExceeded,
+    /// Best stall iter exceeded
+    BestStallIterExceeded,
+    /// Condition for Line search met
+    LineSearchConditionMet,
+    /// Target tolerance reached
+    TargetToleranceReached,
+    /// Aborted
+    Aborted,
+}
+
+impl TerminationReason {
+    /// Returns `true` if a solver terminated and `false` otherwise
+    pub fn terminated(self) -> bool {
+        match self {
+            TerminationReason::NotTerminated => false,
+            _ => true,
+        }
+    }
+
+    /// Returns a texual representation of what happened
+    pub fn text(&self) -> &str {
+        match *self {
+            TerminationReason::NotTerminated => "Not terminated",
+            TerminationReason::MaxItersReached => "Maximum number of iterations reached",
+            TerminationReason::TargetCostReached => "Target cost value reached",
+            TerminationReason::TargetPrecisionReached => "Target precision reached",
+            TerminationReason::NoChangeInCost => "No change in cost function value",
+            TerminationReason::AcceptedStallIterExceeded => "Accepted stall iterations exceeded",
+            TerminationReason::BestStallIterExceeded => "Best stall iterations exceeded",
+            TerminationReason::LineSearchConditionMet => "Line search condition met",
+            TerminationReason::TargetToleranceReached => "Target tolerance reached",
+            TerminationReason::Aborted => "Optimization aborted",
+        }
+    }
+}
+
+impl std::fmt::Display for TerminationReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.text())
+    }
+}
+
+impl Default for TerminationReason {
+    fn default() -> Self {
+        TerminationReason::NotTerminated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    send_sync_test!(termination_reason, TerminationReason);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@
 //! # use argmin::prelude::*;
 //! # use argmin::solver::landweber::*;
 //! # use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
-//! # use argmin_core::Error;
+//! # use argmin::core::Error;
 //! # use serde::{Deserialize, Serialize};
 //! #
 //! # #[derive(Clone, Default, Serialize, Deserialize)]
@@ -516,9 +516,12 @@
 // this is just to make sure that it will always stay this way.)
 #![deny(clippy::float_cmp)]
 
-extern crate argmin_core;
 extern crate argmin_testfunctions;
 extern crate rand;
+
+/// Core functionality
+#[macro_use]
+pub mod core;
 
 /// Definition of all relevant traits and types
 pub mod prelude;
@@ -529,8 +532,6 @@ pub mod solver;
 /// Macros
 #[macro_use]
 mod macros;
-
-use argmin_core::*;
 
 /// Testfunctions
 pub mod testfunctions {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,4 +9,4 @@
 //!
 //! Put `argmin::prelude::*` on top of your code to get all relevant traits into scope.
 
-pub use argmin_core::*;
+pub use crate::core::*;

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -183,10 +183,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::MinimalNoOperator;
     use crate::solver::conjugategradient::beta::PolakRibiere;
     use crate::solver::linesearch::MoreThuenteLineSearch;
     use crate::test_trait_impl;
-    use crate::MinimalNoOperator;
 
     test_trait_impl!(
         nonlinear_cg,

--- a/src/solver/linesearch/backtracking.rs
+++ b/src/solver/linesearch/backtracking.rs
@@ -174,8 +174,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::MinimalNoOperator;
     use crate::test_trait_impl;
-    use crate::MinimalNoOperator;
 
     test_trait_impl!(backtrackinglinesearch,
                     BacktrackingLineSearch<MinimalNoOperator, ArmijoCondition>);

--- a/src/solver/linesearch/condition.rs
+++ b/src/solver/linesearch/condition.rs
@@ -10,7 +10,7 @@
 //! [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-use crate::{ArgminDot, ArgminError, Error};
+use crate::core::{ArgminDot, ArgminError, Error};
 use serde::{Deserialize, Serialize};
 
 /// Needs to be implemented by everything that wants to be a LineSearchCondition

--- a/src/solver/linesearch/hagerzhang.rs
+++ b/src/solver/linesearch/hagerzhang.rs
@@ -553,8 +553,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::MinimalNoOperator;
     use crate::test_trait_impl;
-    use crate::MinimalNoOperator;
 
     test_trait_impl!(hagerzhang, HagerZhangLineSearch<MinimalNoOperator>);
 }

--- a/src/solver/linesearch/morethuente.rs
+++ b/src/solver/linesearch/morethuente.rs
@@ -580,8 +580,8 @@ fn cstep(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::MinimalNoOperator;
     use crate::test_trait_impl;
-    use crate::MinimalNoOperator;
 
     test_trait_impl!(morethuente, MoreThuenteLineSearch<MinimalNoOperator>);
 }

--- a/src/solver/particleswarm/mod.rs
+++ b/src/solver/particleswarm/mod.rs
@@ -10,8 +10,8 @@
 //! TODO
 
 use crate::prelude::*;
-use argmin_core::ArgminAdd;
-use argmin_core::ArgminOp;
+// use argmin_core::ArgminAdd;
+// use argmin_core::ArgminOp;
 use serde::{Deserialize, Serialize};
 use std;
 use std::default::Default;


### PR DESCRIPTION
This moves all code from `argmin_core` into the `core` module. This will hopefully substantially improve the development experience. With this PR, the `argmin_core` crate becomes obsolete. 

See discussion in #29.