### PR TITLE
Removed Send and Sync trait bounds from ArgminOp

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -62,7 +62,7 @@ pub use termination::TerminationReason;
 /// implementation which is essentially returning an error which indicates that the method has not
 /// been implemented. Those methods (`gradient` and `modify`) only need to be implemented if the
 /// uses solver requires it.
-pub trait ArgminOp: Clone + Send + Sync + Serialize {
+pub trait ArgminOp: Clone + Serialize {
     // TODO: Once associated type defaults are stable, it hopefully will be possible to define
     // default types for `Hessian` and `Jacobian`.
     /// Type of the parameter vector

--- a/src/core/observers/mod.rs
+++ b/src/core/observers/mod.rs
@@ -27,7 +27,7 @@ pub use slog_logger::*;
 pub use visualizer::*;
 
 /// Defines the interface every Observer needs to expose
-pub trait Observe<O: ArgminOp>: Send + Sync {
+pub trait Observe<O: ArgminOp> {
     /// Called once at the beginning of the execution of the solver.
     ///
     /// Parameters:
@@ -128,11 +128,11 @@ impl Default for ObserverMode {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::MinimalNoOperator;
-
-    send_sync_test!(observer, Observer<MinimalNoOperator>);
-    send_sync_test!(observermode, ObserverMode);
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::core::MinimalNoOperator;
+//
+//     send_sync_test!(observer, Observer<MinimalNoOperator>);
+//     send_sync_test!(observermode, ObserverMode);
+// }


### PR DESCRIPTION
This removes the `Send` and `Sync` trait bounds from `ArgminOp` (for now). 