### PR TITLE
No reexport of modcholesky crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ slog = "2.4.1"
 slog-term = "2.4.0"
 slog-async = "2.3.0"
 slog-json = "2.3.0"
-modcholesky = "0.1.2"
 ndarray = { version = "0.13", optional = true, features = ["serde-1"] }
 ndarray-linalg = { version = "0.12", optional = true }
 ndarray-rand = {version = "0.11.0", optional = true }

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -132,14 +132,6 @@ pub use crate::core::math::minmax_vec::*;
 
 use crate::core::Error;
 
-/// Modified Cholesky decompositions
-pub mod modcholesky {
-    //! Modified Cholesky decompositions
-    //!
-    //! Reexport of `modcholesky` crate.
-    pub use modcholesky::*;
-}
-
 /// Dot/scalar product of `T` and `self`
 pub trait ArgminDot<T, U> {
     /// Dot/scalar product of `T` and `self`


### PR DESCRIPTION
Reexporting the `modcholesky` crate is not necessary. 