### PR TITLE
Exposed stopping criterion tolerance of NewtonCG method to user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .checkpoints/
+checkpoints/
 params/
 .*.swp
 Cargo.lock


### PR DESCRIPTION
This exposes the stopping criterion tolerances of `NewtonCG` to the user. Related to #28.