### PR TITLE
No reexport of `argmin_testfunctions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 [dependencies]
 # argmin_testfunctions = { path = "../argmin-testfunctions" }
 # argmin_testfunctions = { git = "https://github.com/argmin-rs/argmin-testfunctions.git", branch = "master"}
-argmin_testfunctions = "0.1.1"
+# argmin_testfunctions = "0.1.1"
 rand = { version = "0.7.2", features = ["serde1"] }
 rand_xorshift = { version = "0.2.0", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -45,6 +45,7 @@ num-complex = "0.2"
 [dev-dependencies]
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
 finitediff = "0.1.2"
+argmin_testfunctions = "0.1.1"
 
 [features]
 default = []

--- a/examples/backtracking.rs
+++ b/examples/backtracking.rs
@@ -6,9 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::{ArmijoCondition, BacktrackingLineSearch};
-use argmin::testfunctions::{sphere, sphere_derivative};
+use argmin_testfunctions::{sphere, sphere_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/bfgs.rs
+++ b/examples/bfgs.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};

--- a/examples/checkpoint_3.rs
+++ b/examples/checkpoint_3.rs
@@ -6,10 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/dfp.rs
+++ b/examples/dfp.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::DFP;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};

--- a/examples/hagerzhang.rs
+++ b/examples/hagerzhang.rs
@@ -6,9 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::HagerZhangLineSearch;
-use argmin::testfunctions::{sphere, sphere_derivative};
+use argmin_testfunctions::{sphere, sphere_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/landweber.rs
+++ b/examples/landweber.rs
@@ -6,10 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/lbfgs.rs
+++ b/examples/lbfgs.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::LBFGS;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};

--- a/examples/morethuente.rs
+++ b/examples/morethuente.rs
@@ -6,9 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
-use argmin::testfunctions::{sphere, sphere_derivative};
+use argmin_testfunctions::{sphere, sphere_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/neldermead.rs
+++ b/examples/neldermead.rs
@@ -6,10 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::neldermead::NelderMead;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/newton.rs
+++ b/examples/newton.rs
@@ -6,10 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::newton::Newton;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/newton_cg.rs
+++ b/examples/newton_cg.rs
@@ -6,11 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::newton::NewtonCG;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/nonlinear_cg.rs
+++ b/examples/nonlinear_cg.rs
@@ -6,11 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::conjugategradient::NonlinearConjugateGradient;
 use argmin::solver::conjugategradient::PolakRibiere;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/particleswarm.rs
+++ b/examples/particleswarm.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::particleswarm::*;
 use serde::{Deserialize, Serialize};

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -6,11 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate rand;
 extern crate rand_xorshift;
 use argmin::prelude::*;
 use argmin::solver::simulatedannealing::{SATempFunc, SimulatedAnnealing};
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use rand::prelude::*;
 use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};

--- a/examples/sr1.rs
+++ b/examples/sr1.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::SR1;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};
@@ -34,11 +35,6 @@ impl ArgminOp for Rosenbrock {
 
     fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
-        // Ok(ndarray::Array1::from_vec(rosenbrock_2d_derivative(
-        //     &p.to_vec(),
-        //     self.a,
-        //     self.b,
-        // )))
     }
 }
 

--- a/examples/sr1_trustregion.rs
+++ b/examples/sr1_trustregion.rs
@@ -6,13 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::quasinewton::SR1TrustRegion;
 #[allow(unused_imports)]
 use argmin::solver::trustregion::{CauchyPoint, Dogleg, Steihaug, TrustRegion};
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};

--- a/examples/steepestdescent.rs
+++ b/examples/steepestdescent.rs
@@ -8,11 +8,12 @@
 #![allow(unused_imports)]
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::gradientdescent::SteepestDescent;
 use argmin::solver::linesearch::HagerZhangLineSearch;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]

--- a/examples/trustregion_nd.rs
+++ b/examples/trustregion_nd.rs
@@ -6,11 +6,12 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate ndarray;
 use argmin::prelude::*;
 #[allow(unused_imports)]
 use argmin::solver::trustregion::{CauchyPoint, Dogleg, Steihaug, TrustRegion};
-use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
+use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 use serde::{Deserialize, Serialize};
 

--- a/examples/writers.rs
+++ b/examples/writers.rs
@@ -6,12 +6,13 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate argmin;
+extern crate argmin_testfunctions;
 extern crate finitediff;
 extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;
-use argmin::testfunctions::rosenbrock;
+use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 use serde::{Deserialize, Serialize};

--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -18,10 +18,11 @@
 //! ```
 //! # #![allow(unused_imports)]
 //! # extern crate argmin;
+//! # extern crate argmin_testfunctions;
 //! # use argmin::prelude::*;
 //! # use argmin::solver::gradientdescent::SteepestDescent;
 //! # use argmin::solver::linesearch::MoreThuenteLineSearch;
-//! # use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+//! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! # use serde::{Deserialize, Serialize};
 //! #
 //! # #[derive(Clone, Default, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 //! # extern crate argmin;
 //! # extern crate argmin_testfunctions;
 //! # extern crate ndarray;
-//! use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
+//! use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 //! use argmin::prelude::*;
 //! use serde::{Serialize, Deserialize};
 //!
@@ -182,10 +182,11 @@
 //! ```rust
 //! # #![allow(unused_imports)]
 //! # extern crate argmin;
+//! # extern crate argmin_testfunctions;
 //! use argmin::prelude::*;
 //! use argmin::solver::gradientdescent::SteepestDescent;
 //! use argmin::solver::linesearch::MoreThuenteLineSearch;
-//! # use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+//! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! # use serde::{Deserialize, Serialize};
 //! #
 //! # #[derive(Clone, Default, Serialize, Deserialize)]
@@ -267,10 +268,11 @@
 //! ```rust
 //! # #![allow(unused_imports)]
 //! # extern crate argmin;
+//! # extern crate argmin_testfunctions;
 //! # use argmin::prelude::*;
 //! # use argmin::solver::gradientdescent::SteepestDescent;
 //! # use argmin::solver::linesearch::MoreThuenteLineSearch;
-//! # use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+//! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! # use serde::{Deserialize, Serialize};
 //! #
 //! # #[derive(Clone, Default, Serialize, Deserialize)]
@@ -346,9 +348,10 @@
 //!
 //! ```rust
 //! # extern crate argmin;
+//! # extern crate argmin_testfunctions;
 //! # use argmin::prelude::*;
 //! # use argmin::solver::landweber::*;
-//! # use argmin::testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+//! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! # use argmin::core::Error;
 //! # use serde::{Deserialize, Serialize};
 //! #
@@ -505,10 +508,6 @@
 //! Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion
 //! in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above,
 //! without any additional terms or conditions.
-// //! argmin = { git = "https://github.com/argmin-rs/argmin.git", branch = "master"}
-// //! argmin = { git = "https://github.com/argmin-rs/argmin.git",
-// //!            branch = "master",
-// //!            features = ["ctrlc", "ndarrayl"] }
 
 #![warn(missing_docs)]
 #![allow(unused_attributes)]
@@ -516,7 +515,6 @@
 // this is just to make sure that it will always stay this way.)
 #![deny(clippy::float_cmp)]
 
-extern crate argmin_testfunctions;
 extern crate rand;
 
 /// Core functionality
@@ -532,14 +530,6 @@ pub mod solver;
 /// Macros
 #[macro_use]
 mod macros;
-
-/// Testfunctions
-pub mod testfunctions {
-    //! # Testfunctions
-    //!
-    //! Reexport of `argmin-testfunctions`.
-    pub use argmin_testfunctions::*;
-}
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
`argmin_testfunctions` is not reexported anymore. This avoids version inconsistencies and it avoids having to bump the `argmin` version whenever a new version of `argmin_testfunctions` is released. 