### PR TITLE
Remove `Clone` trait bound from `ArgminOp`

### DIFF
--- a/examples/backtracking.rs
+++ b/examples/backtracking.rs
@@ -11,7 +11,6 @@ use argmin::prelude::*;
 use argmin::solver::linesearch::{ArmijoCondition, BacktrackingLineSearch};
 use argmin_testfunctions::{sphere, sphere_derivative};
 
-#[derive(Clone, Default)]
 struct Sphere {}
 
 impl ArgminOp for Sphere {

--- a/examples/bfgs.rs
+++ b/examples/bfgs.rs
@@ -16,7 +16,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/brent.rs
+++ b/examples/brent.rs
@@ -10,7 +10,6 @@ use argmin::prelude::*;
 use argmin::solver::brent::Brent;
 
 /// Test function generalise from Wikipedia example
-#[derive(Clone, Default)]
 struct TestFunc {
     zero1: f64,
     zero2: f64,

--- a/examples/checkpoint_3.rs
+++ b/examples/checkpoint_3.rs
@@ -12,7 +12,7 @@ use argmin::prelude::*;
 use argmin::solver::landweber::*;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 struct Rosenbrock {}
 
 impl ArgminOp for Rosenbrock {
@@ -33,13 +33,12 @@ impl ArgminOp for Rosenbrock {
 fn run() -> Result<(), Error> {
     // define inital parameter vector
     let init_param: Vec<f64> = vec![1.2, 1.2];
-    let operator = Rosenbrock {};
 
     let iters = 35;
     let solver = Landweber::new(0.001);
 
-    let res = Executor::from_checkpoint(".checkpoints/landweber_exec.arg", &operator)
-        .unwrap_or(Executor::new(operator, solver, init_param))
+    let res = Executor::from_checkpoint(".checkpoints/landweber_exec.arg", Rosenbrock {})
+        .unwrap_or_else(|_| Executor::new(Rosenbrock {}, solver, init_param))
         .max_iters(iters)
         .checkpoint_dir(".checkpoints")
         .checkpoint_name("landweber_exec")

--- a/examples/conjugategradient.rs
+++ b/examples/conjugategradient.rs
@@ -9,7 +9,6 @@ extern crate argmin;
 use argmin::prelude::*;
 use argmin::solver::conjugategradient::ConjugateGradient;
 
-#[derive(Clone, Default)]
 struct MyProblem {}
 
 impl ArgminOp for MyProblem {

--- a/examples/dfp.rs
+++ b/examples/dfp.rs
@@ -16,7 +16,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/gaussnewton.rs
+++ b/examples/gaussnewton.rs
@@ -20,7 +20,6 @@ type Measurement = (S, Rate);
 // Model used in this example:
 // `rate = (V_{max} * [S]) / (K_M + [S]) `
 // where `V_{max}` and `K_M` are the sought parameters and `[S]` and `rate` is the measured data.
-#[derive(Clone, Default)]
 struct Problem {
     data: Vec<Measurement>,
 }

--- a/examples/gaussnewton_linesearch.rs
+++ b/examples/gaussnewton_linesearch.rs
@@ -20,7 +20,6 @@ type Measurement = (S, Rate);
 // Model used in this example:
 // `rate = (V_{max} * [S]) / (K_M + [S]) `
 // where `V_{max}` and `K_M` are the sought parameters and `[S]` and `rate` is the measured data.
-#[derive(Clone, Default)]
 struct Problem {
     data: Vec<Measurement>,
 }

--- a/examples/hagerzhang.rs
+++ b/examples/hagerzhang.rs
@@ -11,7 +11,6 @@ use argmin::prelude::*;
 use argmin::solver::linesearch::HagerZhangLineSearch;
 use argmin_testfunctions::{sphere, sphere_derivative};
 
-#[derive(Clone, Default)]
 struct Sphere {}
 
 impl ArgminOp for Sphere {

--- a/examples/landweber.rs
+++ b/examples/landweber.rs
@@ -12,7 +12,6 @@ use argmin::prelude::*;
 use argmin::solver::landweber::*;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {}
 
 impl ArgminOp for Rosenbrock {

--- a/examples/lbfgs.rs
+++ b/examples/lbfgs.rs
@@ -16,7 +16,7 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/lbfgs.rs
+++ b/examples/lbfgs.rs
@@ -16,7 +16,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,
@@ -53,7 +52,7 @@ fn run() -> Result<(), Error> {
 
     // Run solver
     let res = Executor::new(cost, solver, init_param)
-        // .add_observer(ArgminSlogLogger::term(), ObserverMode::Always)
+        .add_observer(ArgminSlogLogger::term(), ObserverMode::Always)
         .max_iters(100)
         .run()?;
 

--- a/examples/morethuente.rs
+++ b/examples/morethuente.rs
@@ -11,7 +11,6 @@ use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin_testfunctions::{sphere, sphere_derivative};
 
-#[derive(Clone, Default)]
 struct Sphere {}
 
 impl ArgminOp for Sphere {

--- a/examples/neldermead.rs
+++ b/examples/neldermead.rs
@@ -13,7 +13,6 @@ use argmin::solver::neldermead::NelderMead;
 use argmin_testfunctions::rosenbrock;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/newton.rs
+++ b/examples/newton.rs
@@ -13,7 +13,6 @@ use argmin::solver::newton::Newton;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/newton_cg.rs
+++ b/examples/newton_cg.rs
@@ -14,7 +14,6 @@ use argmin::solver::newton::NewtonCG;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/nonlinear_cg.rs
+++ b/examples/nonlinear_cg.rs
@@ -13,7 +13,6 @@ use argmin::solver::conjugategradient::PolakRibiere;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {}
 
 impl ArgminOp for Rosenbrock {

--- a/examples/particleswarm.rs
+++ b/examples/particleswarm.rs
@@ -12,7 +12,6 @@ use argmin::solver::particleswarm::*;
 
 use argmin_testfunctions::himmelblau;
 
-#[derive(Default, Clone)]
 struct Himmelblau {}
 
 impl ArgminOp for Himmelblau {
@@ -35,11 +34,7 @@ fn run() -> Result<(), Error> {
     #[cfg(feature = "visualizer")]
     let visualizer = Visualizer3d::new()
         .delay(std::time::Duration::from_secs(1))
-        .surface(Surface::new::<Himmelblau>(
-            cost_function.clone(),
-            (-4.0, -4.0, 4.0, 4.0),
-            0.1,
-        ));
+        .surface(Surface::new(Himmelblau {}, (-4.0, -4.0, 4.0, 4.0), 0.1));
 
     {
         let solver = ParticleSwarm::new((vec![-4.0, -4.0], vec![4.0, 4.0]), 100, 0.5, 0.0, 0.5)?;

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -18,7 +18,6 @@ use std::default::Default;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-#[derive(Clone)]
 struct Rosenbrock {
     /// Parameter a, usually 1.0
     a: f64,

--- a/examples/sr1.rs
+++ b/examples/sr1.rs
@@ -16,7 +16,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/sr1_trustregion.rs
+++ b/examples/sr1_trustregion.rs
@@ -17,7 +17,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/steepestdescent.rs
+++ b/examples/steepestdescent.rs
@@ -15,7 +15,6 @@ use argmin::solver::linesearch::HagerZhangLineSearch;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/trustregion_nd.rs
+++ b/examples/trustregion_nd.rs
@@ -14,7 +14,6 @@ use argmin::solver::trustregion::{CauchyPoint, Dogleg, Steihaug, TrustRegion};
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 use ndarray::{Array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/examples/writers.rs
+++ b/examples/writers.rs
@@ -16,7 +16,6 @@ use argmin_testfunctions::rosenbrock;
 use finitediff::*;
 use ndarray::{array, Array1, Array2};
 
-#[derive(Clone, Default)]
 struct Rosenbrock {
     a: f64,
     b: f64,

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -48,7 +48,7 @@ where
         let state = IterState::new(init_param);
         Executor {
             solver,
-            op: OpWrapper::new(&op),
+            op: OpWrapper::new(op),
             state,
             observers: Observer::new(),
             checkpoint: ArgminCheckpoint::default(),
@@ -57,7 +57,7 @@ where
     }
 
     /// Create a new executor from a checkpoint
-    pub fn from_checkpoint<P: AsRef<Path>>(path: P, op: &O) -> Result<Self, Error>
+    pub fn from_checkpoint<P: AsRef<Path>>(path: P, op: O) -> Result<Self, Error>
     where
         Self: Sized + DeserializeOwned,
     {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -62,7 +62,7 @@ pub use termination::TerminationReason;
 /// implementation which is essentially returning an error which indicates that the method has not
 /// been implemented. Those methods (`gradient` and `modify`) only need to be implemented if the
 /// uses solver requires it.
-pub trait ArgminOp: Clone {
+pub trait ArgminOp {
     // TODO: Once associated type defaults are stable, it hopefully will be possible to define
     // default types for `Hessian` and `Jacobian`.
     /// Type of the parameter vector

--- a/src/core/opwrapper.rs
+++ b/src/core/opwrapper.rs
@@ -16,7 +16,7 @@ use std::default::Default;
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct OpWrapper<O: ArgminOp> {
     /// Operator
-    op: Option<O>,
+    pub op: Option<O>,
     /// Number of cost function evaluations
     pub cost_func_count: u64,
     /// Number of gradient function evaluations
@@ -31,9 +31,9 @@ pub struct OpWrapper<O: ArgminOp> {
 
 impl<O: ArgminOp> OpWrapper<O> {
     /// Constructor
-    pub fn new(op: &O) -> Self {
+    pub fn new(op: O) -> Self {
         OpWrapper {
-            op: Some(op.clone()),
+            op: Some(op),
             cost_func_count: 0,
             grad_func_count: 0,
             hessian_func_count: 0,
@@ -86,7 +86,8 @@ impl<O: ArgminOp> OpWrapper<O> {
 
     /// Consumes an operator by increasing the function call counts of `self` by the ones in
     /// `other`.
-    pub fn consume_op<O2: ArgminOp>(&mut self, other: OpWrapper<O2>) {
+    pub fn consume_op(&mut self, other: OpWrapper<O>) {
+        self.op = other.op;
         self.cost_func_count += other.cost_func_count;
         self.grad_func_count += other.grad_func_count;
         self.hessian_func_count += other.hessian_func_count;
@@ -107,17 +108,6 @@ impl<O: ArgminOp> OpWrapper<O> {
     /// Returns the operator `op` by taking ownership of `self`.
     pub fn get_op(self) -> O {
         self.op.unwrap()
-    }
-
-    /// Returns a clone of the operator `op`.
-    pub fn clone_op(&self) -> O {
-        self.op.as_ref().unwrap().clone()
-    }
-
-    /// Creates a new `OpWrapper<O>` from another `OpWrapper<O>` by cloning the `op` and
-    /// initializing all counts with `0`.
-    pub fn new_from_op(op: &OpWrapper<O>) -> Self {
-        Self::new(&op.clone_op())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
 //! use argmin::prelude::*;
 //!
 //! /// First, create a struct for your problem
-//! #[derive(Clone, Default)]
 //! struct Rosenbrock {
 //!     a: f64,
 //!     b: f64,
@@ -187,7 +186,6 @@
 //! use argmin::solver::linesearch::MoreThuenteLineSearch;
 //! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! #
-//! # #[derive(Clone, Default)]
 //! # struct Rosenbrock {
 //! #     a: f64,
 //! #     b: f64,
@@ -272,7 +270,6 @@
 //! # use argmin::solver::linesearch::MoreThuenteLineSearch;
 //! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! #
-//! # #[derive(Clone, Default)]
 //! # struct Rosenbrock {
 //! #     a: f64,
 //! #     b: f64,
@@ -351,7 +348,7 @@
 //! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 //! # use argmin::core::Error;
 //! #
-//! # #[derive(Clone, Default)]
+//! # #[derive(Default)]
 //! # struct Rosenbrock {}
 //! #
 //! # impl ArgminOp for Rosenbrock {
@@ -372,13 +369,12 @@
 //! # fn run() -> Result<(), Error> {
 //! #     // define inital parameter vector
 //! #     let init_param: Vec<f64> = vec![1.2, 1.2];
-//! #     let operator = Rosenbrock {};
 //! #
 //! #     let iters = 35;
 //! #     let solver = Landweber::new(0.001);
 //! #
-//! let res = Executor::from_checkpoint(".checkpoints/optim.arg", &operator)
-//!     .unwrap_or(Executor::new(operator, solver, init_param))
+//! let res = Executor::from_checkpoint(".checkpoints/optim.arg", Rosenbrock {})
+//!     .unwrap_or(Executor::new(Rosenbrock {}, solver, init_param))
 //!     .max_iters(iters)
 //!     .checkpoint_dir(".checkpoints")
 //!     .checkpoint_name("optim")

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -135,7 +135,7 @@ where
         let ArgminResult {
             operator: line_op,
             state: line_state,
-        } = Executor::new(OpWrapper::new_from_op(&op), self.linesearch.clone(), xk)
+        } = Executor::new(OpWrapper::new_from_wrapper(op), self.linesearch.clone(), xk)
             .grad(grad.clone())
             .cost(cur_cost)
             .ctrlc(false)

--- a/src/solver/gradientdescent/steepestdescent.rs
+++ b/src/solver/gradientdescent/steepestdescent.rs
@@ -77,7 +77,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new_from_wrapper(op),
             self.linesearch.clone(),
             param_new,
         )
@@ -86,7 +86,7 @@ where
         .ctrlc(false)
         .run()?;
 
-        // hack
+        // Get back operator and function evaluation counts
         op.consume_op(line_op);
 
         Ok(ArgminIterData::new().param(next_param).cost(next_cost))

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -5,15 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-// pub mod brent;
-// pub mod conjugategradient;
-// pub mod gaussnewton;
-// pub mod gradientdescent;
-// pub mod landweber;
+pub mod brent;
+pub mod conjugategradient;
+pub mod gaussnewton;
+pub mod gradientdescent;
+pub mod landweber;
 pub mod linesearch;
-// pub mod neldermead;
-// pub mod newton;
-// pub mod particleswarm;
+pub mod neldermead;
+pub mod newton;
+pub mod particleswarm;
 pub mod quasinewton;
-// pub mod simulatedannealing;
+pub mod simulatedannealing;
 pub mod trustregion;

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -5,15 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-pub mod brent;
-pub mod conjugategradient;
-pub mod gaussnewton;
-pub mod gradientdescent;
-pub mod landweber;
+// pub mod brent;
+// pub mod conjugategradient;
+// pub mod gaussnewton;
+// pub mod gradientdescent;
+// pub mod landweber;
 pub mod linesearch;
-pub mod neldermead;
-pub mod newton;
-pub mod particleswarm;
+// pub mod neldermead;
+// pub mod newton;
+// pub mod particleswarm;
 pub mod quasinewton;
-pub mod simulatedannealing;
+// pub mod simulatedannealing;
 pub mod trustregion;

--- a/src/solver/newton/newton_cg.rs
+++ b/src/solver/newton/newton_cg.rs
@@ -102,7 +102,7 @@ where
 
         // Solve CG subproblem
         let cg_op: CGSubProblem<O::Param, O::Hessian> = CGSubProblem::new(hessian.clone());
-        let mut cg_op = OpWrapper::new(&cg_op);
+        let mut cg_op = OpWrapper::new(cg_op);
 
         let mut x_p = param.zero_like();
         let mut x: O::Param = param.zero_like();
@@ -145,11 +145,15 @@ where
                     cost: next_cost,
                     ..
                 },
-        } = Executor::new(OpWrapper::new_from_op(&op), self.linesearch.clone(), param)
-            .grad(grad)
-            .cost(state.get_cost())
-            .ctrlc(false)
-            .run()?;
+        } = Executor::new(
+            OpWrapper::new_from_wrapper(op),
+            self.linesearch.clone(),
+            param,
+        )
+        .grad(grad)
+        .cost(state.get_cost())
+        .ctrlc(false)
+        .run()?;
 
         op.consume_op(line_op);
 

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -127,7 +127,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new_from_wrapper(op),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -115,7 +115,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new_from_wrapper(op),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -152,7 +152,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new(op.op.take().unwrap()),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -152,7 +152,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new(op.op.take().unwrap()),
+            OpWrapper::new_from_wrapper(op),
             self.linesearch.clone(),
             param.clone(),
         )
@@ -161,7 +161,7 @@ where
         .ctrlc(false)
         .run()?;
 
-        // take care of function eval counts
+        // take back operator and take care of function evaluation counts
         op.consume_op(line_op);
 
         if state.get_iter() >= self.m as u64 {

--- a/src/solver/quasinewton/mod.rs
+++ b/src/solver/quasinewton/mod.rs
@@ -14,14 +14,14 @@
 //! [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-pub mod bfgs;
-pub mod dfp;
+// pub mod bfgs;
+// pub mod dfp;
 pub mod lbfgs;
-pub mod sr1;
-pub mod sr1_trustregion;
+// pub mod sr1;
+// pub mod sr1_trustregion;
 
-pub use self::bfgs::*;
-pub use self::dfp::*;
+// pub use self::bfgs::*;
+// pub use self::dfp::*;
 pub use self::lbfgs::*;
-pub use self::sr1::*;
-pub use self::sr1_trustregion::*;
+// pub use self::sr1::*;
+// pub use self::sr1_trustregion::*;

--- a/src/solver/quasinewton/mod.rs
+++ b/src/solver/quasinewton/mod.rs
@@ -14,14 +14,14 @@
 //! [0] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-// pub mod bfgs;
-// pub mod dfp;
+pub mod bfgs;
+pub mod dfp;
 pub mod lbfgs;
-// pub mod sr1;
-// pub mod sr1_trustregion;
+pub mod sr1;
+pub mod sr1_trustregion;
 
-// pub use self::bfgs::*;
-// pub use self::dfp::*;
+pub use self::bfgs::*;
+pub use self::dfp::*;
 pub use self::lbfgs::*;
-// pub use self::sr1::*;
-// pub use self::sr1_trustregion::*;
+pub use self::sr1::*;
+pub use self::sr1_trustregion::*;

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -141,7 +141,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new_from_wrapper(op),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -163,7 +163,7 @@ where
             operator: sub_op,
             state: IterState { param: sk, .. },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new_from_wrapper(op),
             self.subproblem.clone(),
             // xk.clone(),
             xk.zero_like(),

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -147,7 +147,7 @@ where
             operator: sub_op,
             state: IterState { param: pk, .. },
         } = Executor::new(
-            OpWrapper::new(op.op.take().unwrap()),
+            OpWrapper::new_from_wrapper(op),
             self.subproblem.clone(),
             param.clone(),
         )
@@ -156,7 +156,8 @@ where
         .ctrlc(false)
         .run()?;
 
-        // What is happening with the function counts??
+        // Operator must be consumed again, otherwise the operator, which moved into the subproblem
+        // executor as well as the function evaluation counts are lost.
         op.consume_op(sub_op);
 
         let new_param = pk.add(&param);

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -147,7 +147,7 @@ where
             operator: sub_op,
             state: IterState { param: pk, .. },
         } = Executor::new(
-            OpWrapper::new_from_op(&op),
+            OpWrapper::new(op.op.take().unwrap()),
             self.subproblem.clone(),
             param.clone(),
         )
@@ -156,6 +156,7 @@ where
         .ctrlc(false)
         .run()?;
 
+        // What is happening with the function counts??
         op.consume_op(sub_op);
 
         let new_param = pk.add(&param);


### PR DESCRIPTION
The operator is now moved into the executor instead of working with references. The main problem is executors within executors and keeping track of the number of cost/grad/hessian/... evaluations. 