### PR TITLE
remove `finitediff` from `ndarrayl` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 ndarray-linalg = { version = "0.12", features = ["openblas"] }
-finitediff = "0.1.2"
+finitediff = { version = "0.1.2", features = ["ndarray"] }
 argmin_testfunctions = "0.1.1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ argmin_testfunctions = "0.1.1"
 
 [features]
 default = []
-ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand", "finitediff/ndarray"]
+ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand"]
 visualizer = ["gnuplot"]
 
 [badges]


### PR DESCRIPTION
Without this change, `ndarrayl` feature not working.

`finitediff` is not used in code under the `ndarray` feature