### PR TITLE
Add nalgebra support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bincode = "1.1.4"
 ctrlc = { version = "3.1.2", optional = true }
 gnuplot = { version = "0.0.37", optional = true}
 paste = "1.0.0"
+nalgebra = { version = "0.21.1", optional = true, features = ["serde-serialize"] }
 ndarray = { version = "0.13", optional = true, features = ["serde-1"] }
 ndarray-linalg = { version = "0.12", optional = true }
 ndarray-rand = {version = "0.11.0", optional = true }
@@ -45,6 +46,7 @@ argmin_testfunctions = "0.1.1"
 
 [features]
 default = []
+nalgebral = ["nalgebra"]
 ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand"]
 visualizer = ["gnuplot"]
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ There are additional features which can be activated in `Cargo.toml`:
 
 ```toml
 [dependencies]
-argmin = { version = "0.3.1", features = ["ctrlc", "ndarrayl"] }
+argmin = { version = "0.3.1", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 ```
 
 These may become default features in the future. Without these features compilation to
@@ -96,13 +96,14 @@ These may become default features in the future. Without these features compilat
 - `ctrlc`: Uses the `ctrlc` crate to properly stop the optimization (and return the current best
    result) after pressing Ctrl+C.
 - `ndarrayl`: Support for `ndarray`, `ndarray-linalg` and `ndarray-rand`.
+- `nalgebral`: Support for [`nalgebra`](https://nalgebra.org)
 
 ### Running the tests
 
-Running the tests requires the `ndarrayl` feature to be enabled
+Running the tests requires the `ndarrayl` and `nalgebral` features to be enabled
 
 ```bash
-cargo test --features "ndarrayl"
+cargo test --features "ndarrayl nalgebral"
 ```
 
 ## Defining a problem

--- a/examples/gaussnewton_nalgebra.rs
+++ b/examples/gaussnewton_nalgebra.rs
@@ -8,7 +8,7 @@
 use argmin::prelude::*;
 use argmin::solver::gaussnewton::GaussNewton;
 
-use nalgebra::{DVector, DMatrix};
+use nalgebra::{DMatrix, DVector};
 
 type Rate = f64;
 type S = f64;
@@ -30,11 +30,12 @@ impl ArgminOp for Problem {
     type Float = f64;
 
     fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
-        Ok(DVector::from_vec(self
-            .data
-            .iter()
-            .map(|(s, rate)| rate - (p[0] * s) / (p[1] + s))
-            .collect()))
+        Ok(DVector::from_vec(
+            self.data
+                .iter()
+                .map(|(s, rate)| rate - (p[0] * s) / (p[1] + s))
+                .collect(),
+        ))
     }
 
     fn jacobian(&self, p: &Self::Param) -> Result<Self::Jacobian, Error> {

--- a/examples/gaussnewton_nalgebra.rs
+++ b/examples/gaussnewton_nalgebra.rs
@@ -1,0 +1,91 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use argmin::prelude::*;
+use argmin::solver::gaussnewton::GaussNewton;
+
+use nalgebra::{DVector, DMatrix};
+
+type Rate = f64;
+type S = f64;
+type Measurement = (S, Rate);
+
+// Example taken from Wikipedia: https://en.wikipedia.org/wiki/Gauss%E2%80%93Newton_algorithm
+// Model used in this example:
+// `rate = (V_{max} * [S]) / (K_M + [S]) `
+// where `V_{max}` and `K_M` are the sought parameters and `[S]` and `rate` is the measured data.
+struct Problem {
+    data: Vec<Measurement>,
+}
+
+impl ArgminOp for Problem {
+    type Param = DVector<f64>;
+    type Output = DVector<f64>;
+    type Hessian = ();
+    type Jacobian = DMatrix<f64>;
+    type Float = f64;
+
+    fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
+        Ok(DVector::from_vec(self
+            .data
+            .iter()
+            .map(|(s, rate)| rate - (p[0] * s) / (p[1] + s))
+            .collect()))
+    }
+
+    fn jacobian(&self, p: &Self::Param) -> Result<Self::Jacobian, Error> {
+        Ok(DMatrix::from_fn(7, 2, |si, i| {
+            if i == 0 {
+                -self.data[si].0 / (p[1] + self.data[si].0)
+            } else {
+                p[0] * self.data[si].0 / (p[1] + self.data[si].0).powi(2)
+            }
+        }))
+    }
+}
+
+fn run() -> Result<(), Error> {
+    // Define cost function
+    // Example taken from Wikipedia: https://en.wikipedia.org/wiki/Gauss%E2%80%93Newton_algorithm
+    let cost = Problem {
+        data: vec![
+            (0.038, 0.050),
+            (0.194, 0.127),
+            (0.425, 0.094),
+            (0.626, 0.2122),
+            (1.253, 0.2729),
+            (2.5, 0.2665),
+            (3.74, 0.3317),
+        ],
+    };
+
+    // Define initial parameter vector
+    let init_param: DVector<f64> = DVector::from_vec(vec![0.9, 0.2]);
+
+    // Set up solver
+    let solver: GaussNewton<f64> = GaussNewton::new();
+
+    // Run solver
+    let res = Executor::new(cost, solver, init_param)
+        .add_observer(ArgminSlogLogger::term(), ObserverMode::Always)
+        .max_iters(10)
+        .run()?;
+
+    // Wait a second (lets the logger flush everything before printing again)
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // Print result
+    println!("{}", res);
+    Ok(())
+}
+
+fn main() {
+    if let Err(ref e) = run() {
+        println!("{}", e);
+        std::process::exit(1);
+    }
+}

--- a/src/core/math/add_nalgebra.rs
+++ b/src/core/math/add_nalgebra.rs
@@ -1,0 +1,230 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminAdd;
+
+use nalgebra::{
+    base::{
+        allocator::{Allocator, SameShapeAllocator},
+        constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint},
+        dimension::Dim,
+        storage::Storage,
+        Scalar,
+    },
+    ClosedAdd, DefaultAllocator, Matrix, MatrixMN, MatrixSum,
+};
+
+impl<N, R, C, S> ArgminAdd<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + ClosedAdd + Copy,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn add(&self, other: &N) -> MatrixMN<N, R, C> {
+        self.add_scalar(*other)
+    }
+}
+
+impl<N, R, C, S> ArgminAdd<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+where
+    N: Scalar + ClosedAdd + Copy,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn add(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        other.add_scalar(*self)
+    }
+}
+
+impl<N, R1, C1, R2, C2, SA, SB> ArgminAdd<Matrix<N, R2, C2, SB>, MatrixSum<N, R1, C1, R2, C2>>
+    for Matrix<N, R1, C1, SA>
+where
+    N: Scalar + ClosedAdd,
+    R1: Dim,
+    C1: Dim,
+    R2: Dim,
+    C2: Dim,
+    SA: Storage<N, R1, C1>,
+    SB: Storage<N, R2, C2>,
+    DefaultAllocator: SameShapeAllocator<N, R1, C1, R2, C2>,
+    ShapeConstraint: SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2>,
+{
+    #[inline]
+    fn add(&self, other: &Matrix<N, R2, C2, SB>) -> MatrixSum<N, R1, C1, R2, C2> {
+        self + other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, DVector, Matrix2x3, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_add_vec_scalar_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 34 as $t;
+                    let target = Vector3::new(35 as $t, 38 as $t, 42 as $t);
+                    let res = <Vector3<$t> as ArgminAdd<$t, Vector3<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_scalar_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 34 as $t;
+                    let target = Vector3::new(35 as $t, 38 as $t, 42 as $t);
+                    let res = <$t as ArgminAdd<Vector3<$t>, Vector3<$t>>>::add(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_vec_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = Vector3::new(41 as $t, 38 as $t, 34 as $t);
+                    let target = Vector3::new(42 as $t, 42 as $t, 42 as $t);
+                    let res = <Vector3<$t> as ArgminAdd<Vector3<$t>, Vector3<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 4 as $t]);
+                    let b = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <DVector<$t> as ArgminAdd<DVector<$t>, DVector<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![]);
+                    let b = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <DVector<$t> as ArgminAdd<DVector<$t>, DVector<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_3_ $t>]() {
+                    let a = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    let b = DVector::from_vec(vec![]);
+                    <DVector<$t> as ArgminAdd<DVector<$t>, DVector<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_mat_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = Matrix2x3::new(
+                        41 as $t, 38 as $t, 34 as $t,
+                        40 as $t, 37 as $t, 33 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        42 as $t, 42 as $t, 42 as $t,
+                        42 as $t, 42 as $t, 42 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminAdd<Matrix2x3<$t>, Matrix2x3<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_scalar_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = 2 as $t;
+                    let target = Matrix2x3::new(
+                        3 as $t, 6 as $t, 10 as $t,
+                        4 as $t, 7 as $t, 11 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminAdd<$t, Matrix2x3<$t>>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_2_ $t>]() {
+                    let a = DMatrix::from_vec(2, 3, vec![
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    ]);
+                    let b = DMatrix::from_vec(1, 2, vec![
+                        41 as $t, 38 as $t,
+                    ]);
+                    <DMatrix<$t> as ArgminAdd<DMatrix<$t>, DMatrix<$t>>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_3_ $t>]() {
+                    let a = DMatrix::from_vec(2, 3, vec![
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    ]);
+                    let b = DMatrix::from_vec(0, 0, vec![]);
+                    <DMatrix<$t> as ArgminAdd<DMatrix<$t>, DMatrix<$t>>>::add(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/conj_nalgebra.rs
+++ b/src/core/math/conj_nalgebra.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminConj;
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim},
+    DefaultAllocator, MatrixMN, SimdComplexField,
+};
+
+impl<N, R, C> ArgminConj for MatrixMN<N, R, C>
+where
+    N: SimdComplexField,
+    R: Dim,
+    C: Dim,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn conj(&self) -> MatrixMN<N, R, C> {
+        self.conjugate()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Vector3;
+    use num_complex::Complex;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_conj_complex_ndarray_ $t>]() {
+                    let a = Vector3::new(
+                        Complex::new(1 as $t, 2 as $t),
+                        Complex::new(4 as $t, -3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    );
+                    let b = Vector3::new(
+                        Complex::new(1 as $t, -2 as $t),
+                        Complex::new(4 as $t, 3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    );
+                    let res = <Vector3<Complex<$t>> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let tmp = b[i] - res[i];
+                        let norm = ((tmp.re * tmp.re + tmp.im * tmp.im) as f64).sqrt();
+                        assert!(norm  < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_conj_ndarray_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let res = <Vector3<$t> as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        let diff = (b[i] as f64 - res[i] as f64).abs();
+                        assert!(diff  < std::f64::EPSILON);
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/div_nalgebra.rs
+++ b/src/core/math/div_nalgebra.rs
@@ -1,0 +1,209 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDiv;
+
+use nalgebra::{
+    base::{
+        allocator::{Allocator, SameShapeAllocator},
+        constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint},
+        dimension::Dim,
+        storage::Storage,
+        MatrixSum, Scalar,
+    },
+    ClosedDiv, DefaultAllocator, Matrix, MatrixMN,
+};
+
+impl<N, R, C, S> ArgminDiv<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + Copy + ClosedDiv,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn div(&self, other: &N) -> MatrixMN<N, R, C> {
+        self / *other
+    }
+}
+
+impl<N, R, C, S> ArgminDiv<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+where
+    N: Scalar + Copy + ClosedDiv,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn div(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        other.map(|entry| *self / entry)
+    }
+}
+
+impl<N, R1, R2, C1, C2, SA, SB> ArgminDiv<Matrix<N, R2, C2, SB>, MatrixSum<N, R1, C1, R2, C2>>
+    for Matrix<N, R1, C1, SA>
+where
+    N: Scalar + ClosedDiv,
+    R1: Dim,
+    R2: Dim,
+    C1: Dim,
+    C2: Dim,
+    SA: Storage<N, R1, C1>,
+    SB: Storage<N, R2, C2>,
+    DefaultAllocator: SameShapeAllocator<N, R1, C1, R2, C2>,
+    ShapeConstraint: SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2>,
+{
+    #[inline]
+    fn div(&self, other: &Matrix<N, R2, C2, SB>) -> MatrixSum<N, R1, C1, R2, C2> {
+        self.component_div(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DMatrix, DVector, Matrix2x3, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_div_vec_scalar_ $t>]() {
+                    let a = Vector3::new(4 as $t, 16 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = Vector3::new(2 as $t, 8 as $t, 4 as $t);
+                    let res = <Vector3<$t> as ArgminDiv<$t, Vector3<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_scalar_vec_ $t>]() {
+                    let a = Vector3::new(2 as $t, 4 as $t, 8 as $t);
+                    let b = 32 as $t;
+                    let target = Vector3::new(16 as $t, 8 as $t, 4 as $t);
+                    let res = <$t as ArgminDiv<Vector3<$t>, Vector3<$t>>>::div(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_vec_vec_ $t>]() {
+                    let a = Vector3::new(4 as $t, 9 as $t, 8 as $t);
+                    let b = Vector3::new(2 as $t, 3 as $t, 4 as $t);
+                    let target = Vector3::new(2 as $t, 3 as $t, 2 as $t);
+                    let res = <Vector3<$t> as ArgminDiv<Vector3<$t>, Vector3<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 4 as $t]);
+                    let b = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <DVector<$t> as ArgminDiv<DVector<$t>, DVector<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![]);
+                    let b = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <DVector<$t> as ArgminDiv<DVector<$t>, DVector<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_3_ $t>]() {
+                    let a = DVector::from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    let b = DVector::from_vec(vec![]);
+                    <DVector<$t> as ArgminDiv<DVector<$t>, DVector<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_mat_mat_ $t>]() {
+                    let a = Matrix2x3::new(
+                        4 as $t, 12 as $t, 8 as $t,
+                        9 as $t, 20 as $t, 45 as $t
+                    );
+                    let b = Matrix2x3::new(
+                        2 as $t, 3 as $t, 4 as $t,
+                        3 as $t, 4 as $t, 5 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        2 as $t, 4 as $t, 2 as $t,
+                        3 as $t, 5 as $t, 9 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminDiv<Matrix2x3<$t>, Matrix2x3<$t>>>::div(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_2_ $t>]() {
+                    let a = DMatrix::from_vec(2, 3, vec![
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    ]);
+                    let b = DMatrix::from_vec(1, 2, vec![
+                        41 as $t, 38 as $t,
+                    ]);
+                    <DMatrix<$t> as ArgminDiv<DMatrix<$t>, DMatrix<$t>>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_3_ $t>]() {
+                    let a = DMatrix::from_vec(2, 3, vec![
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    ]);
+                    let b = DMatrix::from_vec(0, 0, vec![]);
+                    <DMatrix<$t> as ArgminDiv<DMatrix<$t>, DMatrix<$t>>>::div(&a, &b);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/dot_nalgebra.rs
+++ b/src/core/math/dot_nalgebra.rs
@@ -1,0 +1,257 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminDot;
+
+use num::{One, Zero};
+
+use nalgebra::{
+    base::{
+        allocator::Allocator,
+        constraint::{AreMultipliable, DimEq, ShapeConstraint},
+        dimension::Dim,
+        storage::Storage,
+        Scalar,
+    },
+    ClosedAdd, ClosedMul, DefaultAllocator, Matrix, MatrixMN,
+};
+
+impl<N, R1, R2, C1, C2, SA, SB> ArgminDot<Matrix<N, R2, C2, SB>, N> for Matrix<N, R1, C1, SA>
+where
+    N: Scalar + Zero + ClosedAdd + ClosedMul,
+    R1: Dim,
+    R2: Dim,
+    C1: Dim,
+    C2: Dim,
+    SA: Storage<N, R1, C1>,
+    SB: Storage<N, R2, C2>,
+    ShapeConstraint: DimEq<R1, R2> + DimEq<C1, C2>,
+{
+    #[inline]
+    fn dot(&self, other: &Matrix<N, R2, C2, SB>) -> N {
+        self.dot(other)
+    }
+}
+
+impl<N, R, C, S> ArgminDot<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + Copy + ClosedMul,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn dot(&self, other: &N) -> MatrixMN<N, R, C> {
+        self * *other
+    }
+}
+
+impl<N, R, C, S> ArgminDot<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+where
+    N: Scalar + Copy + ClosedMul,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn dot(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        other * *self
+    }
+}
+
+impl<N, R1, R2, C1, C2, SA, SB> ArgminDot<Matrix<N, R2, C2, SB>, MatrixMN<N, R1, C2>>
+    for Matrix<N, R1, C1, SA>
+where
+    N: Scalar + Zero + One + ClosedAdd + ClosedMul,
+    R1: Dim,
+    R2: Dim,
+    C1: Dim,
+    C2: Dim,
+    SA: Storage<N, R1, C1>,
+    SB: Storage<N, R2, C2>,
+    DefaultAllocator: Allocator<N, R1, C2>,
+    ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
+{
+    #[inline]
+    fn dot(&self, other: &Matrix<N, R2, C2, SB>) -> MatrixMN<N, R1, C2> {
+        self * other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Matrix3, RowVector3, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_vec_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = Vector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res: $t = <Vector3<$t> as ArgminDot<Vector3<$t>, $t>>::dot(&a, &b);
+                    assert!((((res - 32 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_vec_scalar_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = 2 as $t;
+                    let product: Vector3<$t> =
+                        <Vector3<$t> as ArgminDot<$t, Vector3<$t>>>::dot(&a, &b);
+                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scalar_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = 2 as $t;
+                    let product: Vector3<$t> =
+                        <$t as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&b, &a);
+                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = RowVector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = Matrix3::new(
+                        4 as $t, 5 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        12 as $t, 15 as $t, 18 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Vector3<$t> as ArgminDot<RowVector3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_2_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        7 as $t, 8 as $t, 9 as $t
+                    );
+                    let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let res = Vector3::new(14 as $t, 32 as $t, 50 as $t);
+                    let product: Vector3<$t> =
+                        <Matrix3<$t> as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_mat_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let b = Matrix3::new(
+                        3 as $t, 2 as $t, 1 as $t,
+                        6 as $t, 5 as $t, 4 as $t,
+                        2 as $t, 4 as $t, 3 as $t
+                    );
+                    let res = Matrix3::new(
+                        21 as $t, 24 as $t, 18 as $t,
+                        54 as $t, 57 as $t, 42 as $t,
+                        23 as $t, 20 as $t, 14 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Matrix3<$t> as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_primitive_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let res = Matrix3::new(
+                        2 as $t, 4 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        6 as $t, 4 as $t, 2 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Matrix3<$t> as ArgminDot<$t, Matrix3<$t>>>::dot(&a, &(2 as $t));
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_primitive_mat_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let res = Matrix3::new(
+                        2 as $t, 4 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        6 as $t, 4 as $t, 2 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <$t as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&(2 as $t), &a);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - product[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/eye_nalgebra.rs
+++ b/src/core/math/eye_nalgebra.rs
@@ -1,0 +1,110 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminEye;
+
+use num::{One, Zero};
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim},
+    DefaultAllocator, MatrixMN, Scalar,
+};
+
+impl<N, R, C> ArgminEye for MatrixMN<N, R, C>
+where
+    N: Scalar + Zero + One,
+    R: Dim,
+    C: Dim,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn eye_like(&self) -> MatrixMN<N, R, C> {
+        assert!(self.is_square());
+        Self::identity_generic(R::from_usize(self.nrows()), C::from_usize(self.ncols()))
+    }
+
+    #[inline]
+    fn eye(n: usize) -> MatrixMN<N, R, C> {
+        Self::identity_generic(R::from_usize(n), C::from_usize(n))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Matrix2x3, Matrix3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_eye_ $t>]() {
+                    let e: Matrix3<$t> = <Matrix3<$t> as ArgminEye>::eye(3);
+                    let res = Matrix3::new(
+                        1 as $t, 0 as $t, 0 as $t,
+                        0 as $t, 1 as $t, 0 as $t,
+                        0 as $t, 0 as $t, 1 as $t
+                    );
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - e[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_eye_like_ $t>]() {
+                    let a = Matrix3::new(
+                        0 as $t, 2 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 7 as $t,
+                        9 as $t, 8 as $t, 1 as $t
+                    );
+                    let e: Matrix3<$t> = a.eye_like();
+                    let res = Matrix3::new(
+                        1 as $t, 0 as $t, 0 as $t,
+                        0 as $t, 1 as $t, 0 as $t,
+                        0 as $t, 0 as $t, 1 as $t
+                    );
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert!((((res[(i, j)] - e[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                #[allow(unused)]
+                fn [<test_eye_like_panic_ $t>]() {
+                    let a = Matrix2x3::new(
+                        0 as $t, 2 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 7 as $t,
+                    );
+                    let e: Matrix2x3<$t> = a.eye_like();
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/inv_nalgebra.rs
+++ b/src/core/math/inv_nalgebra.rs
@@ -1,0 +1,66 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::{errors::ArgminError, math::ArgminInv, Error};
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim, storage::Storage},
+    ComplexField, DefaultAllocator, MatrixN, SquareMatrix,
+};
+
+impl<N, D, S> ArgminInv<MatrixN<N, D>> for SquareMatrix<N, D, S>
+where
+    N: ComplexField,
+    D: Dim,
+    S: Storage<N, D, D>,
+    DefaultAllocator: Allocator<N, D, D>,
+{
+    #[inline]
+    fn inv(&self) -> Result<MatrixN<N, D>, Error> {
+        match self.clone_owned().try_inverse() {
+            Some(m) => Ok(m),
+            None => Err(ArgminError::InvalidParameter {
+                text: "ArgminInv: non-invertible matrix".to_string(),
+            }
+            .into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Matrix2;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_inv_ $t>]() {
+                    let a = Matrix2::new(
+                        2 as $t, 5 as $t,
+                        1 as $t, 3 as $t,
+                    );
+                    let target = Matrix2::new(
+                        3 as $t, -5 as $t,
+                        -1 as $t, 2 as $t,
+                    );
+                    let res = <Matrix2<$t> as ArgminInv<Matrix2<$t>>>::inv(&a).unwrap();
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -20,6 +20,8 @@
 //! * Implement tests for Complex<T> impls
 
 mod add;
+#[cfg(feature = "nalgebral")]
+mod add_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod add_ndarray;
 mod add_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -43,6 +43,8 @@ mod dot_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod dot_ndarray;
 mod dot_vec;
+#[cfg(feature = "nalgebral")]
+mod eye_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod eye_ndarray;
 mod eye_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -40,6 +40,8 @@ mod dot_vec;
 #[cfg(feature = "ndarrayl")]
 mod eye_ndarray;
 mod eye_vec;
+#[cfg(feature = "nalgebral")]
+mod inv_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod inv_ndarray;
 mod mul;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -71,6 +71,8 @@ mod scaledadd_nalgebra;
 mod scaledadd_ndarray;
 mod scaledadd_vec;
 mod scaledsub;
+#[cfg(feature = "nalgebral")]
+mod scaledsub_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod scaledsub_ndarray;
 mod scaledsub_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -71,6 +71,8 @@ mod sub_nalgebra;
 mod sub_ndarray;
 mod sub_vec;
 mod transpose;
+#[cfg(feature = "nalgebral")]
+mod transpose_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod transpose_ndarray;
 mod transpose_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -26,6 +26,8 @@ mod add_nalgebra;
 mod add_ndarray;
 mod add_vec;
 mod conj;
+#[cfg(feature = "nalgebral")]
+mod conj_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod conj_ndarray;
 mod conj_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -65,6 +65,8 @@ mod scaledsub;
 mod scaledsub_ndarray;
 mod scaledsub_vec;
 mod sub;
+#[cfg(feature = "nalgebral")]
+mod sub_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod sub_ndarray;
 mod sub_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -223,10 +223,10 @@ pub trait ArgminNorm<U> {
 }
 
 // Suboptimal: self is moved. ndarray however offers array views...
-/// Transposing a type
-pub trait ArgminTranspose {
+/// Return the transpose (`U`) of `self`
+pub trait ArgminTranspose<U> {
     /// Transpose
-    fn t(self) -> Self;
+    fn t(self) -> U;
 }
 
 /// Compute the inverse (`T`) of `self`

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -90,6 +90,8 @@ mod transpose_ndarray;
 mod transpose_vec;
 mod weighteddot;
 mod zero;
+#[cfg(feature = "nalgebral")]
+mod zero_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod zero_ndarray;
 mod zero_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -65,6 +65,8 @@ mod norm_nalgebra;
 mod norm_ndarray;
 mod norm_vec;
 mod scaledadd;
+#[cfg(feature = "nalgebral")]
+mod scaledadd_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod scaledadd_ndarray;
 mod scaledadd_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -45,6 +45,8 @@ mod inv_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod inv_ndarray;
 mod mul;
+#[cfg(feature = "nalgebral")]
+mod mul_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod mul_ndarray;
 mod mul_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -32,6 +32,8 @@ mod div;
 mod div_ndarray;
 mod div_vec;
 mod dot;
+#[cfg(feature = "nalgebral")]
+mod dot_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod dot_ndarray;
 mod dot_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -51,6 +51,8 @@ mod mul_nalgebra;
 mod mul_ndarray;
 mod mul_vec;
 mod norm;
+#[cfg(feature = "nalgebral")]
+mod norm_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod norm_ndarray;
 mod norm_vec;

--- a/src/core/math/mod.rs
+++ b/src/core/math/mod.rs
@@ -32,6 +32,8 @@ mod conj_nalgebra;
 mod conj_ndarray;
 mod conj_vec;
 mod div;
+#[cfg(feature = "nalgebral")]
+mod div_nalgebra;
 #[cfg(feature = "ndarrayl")]
 mod div_ndarray;
 mod div_vec;

--- a/src/core/math/mul_nalgebra.rs
+++ b/src/core/math/mul_nalgebra.rs
@@ -1,0 +1,192 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminMul;
+
+use nalgebra::{
+    base::{
+        allocator::{Allocator, SameShapeAllocator},
+        constraint::{SameNumberOfColumns, SameNumberOfRows, ShapeConstraint},
+        dimension::Dim,
+        storage::Storage,
+        MatrixSum, Scalar,
+    },
+    ClosedMul, DefaultAllocator, Matrix, MatrixMN,
+};
+
+impl<N, R, C, S> ArgminMul<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + Copy + ClosedMul,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn mul(&self, other: &N) -> MatrixMN<N, R, C> {
+        self * *other
+    }
+}
+
+impl<N, R, C, S> ArgminMul<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+where
+    N: Scalar + Copy + ClosedMul,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn mul(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        other * *self
+    }
+}
+
+impl<N, R1, R2, C1, C2, SA, SB> ArgminMul<Matrix<N, R2, C2, SB>, MatrixSum<N, R1, C1, R2, C2>>
+    for Matrix<N, R1, C1, SA>
+where
+    N: Scalar + ClosedMul,
+    R1: Dim,
+    R2: Dim,
+    C1: Dim,
+    C2: Dim,
+    SA: Storage<N, R1, C1>,
+    SB: Storage<N, R2, C2>,
+    DefaultAllocator: SameShapeAllocator<N, R1, C1, R2, C2>,
+    ShapeConstraint: SameNumberOfRows<R1, R2> + SameNumberOfColumns<C1, C2>,
+{
+    #[inline]
+    fn mul(&self, other: &Matrix<N, R2, C2, SB>) -> MatrixSum<N, R1, C1, R2, C2> {
+        self.component_mul(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Matrix2x3, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_mul_vec_scalar_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = Vector3::new(2 as $t, 8 as $t, 16 as $t);
+                    let res = <Vector3<$t> as ArgminMul<$t, Vector3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = Vector3::new(2 as $t, 8 as $t, 16 as $t);
+                    let res = <$t as ArgminMul<Vector3<$t>, Vector3<$t>>>::mul(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_vec_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = Vector3::new(2 as $t, 3 as $t, 4 as $t);
+                    let target = Vector3::new(2 as $t, 12 as $t, 32 as $t);
+                    let res = <Vector3<$t> as ArgminMul<Vector3<$t>, Vector3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_mat_mat_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = Matrix2x3::new(
+                        2 as $t, 3 as $t, 4 as $t,
+                        3 as $t, 4 as $t, 5 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        2 as $t, 12 as $t, 32 as $t,
+                        6 as $t, 20 as $t, 45 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminMul<Matrix2x3<$t>, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                        assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_1_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = 2 as $t;
+                    let target = Matrix2x3::new(
+                        2 as $t, 8 as $t, 16 as $t,
+                        4 as $t, 10 as $t, 18 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminMul<$t, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_2_ $t>]() {
+                    let b = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let a = 2 as $t;
+                    let target = Matrix2x3::new(
+                        2 as $t, 8 as $t, 16 as $t,
+                        4 as $t, 10 as $t, 18 as $t
+                    );
+                    let res = <$t as ArgminMul<Matrix2x3<$t>, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/norm_nalgebra.rs
+++ b/src/core/math/norm_nalgebra.rs
@@ -1,0 +1,67 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::ArgminNorm;
+
+use nalgebra::{
+    base::{dimension::Dim, storage::Storage},
+    Matrix, SimdComplexField,
+};
+
+impl<N, R, C, S> ArgminNorm<N::SimdRealField> for Matrix<N, R, C, S>
+where
+    N: SimdComplexField,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+{
+    #[inline]
+    fn norm(&self) -> N::SimdRealField {
+        self.norm()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::Vector2;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_ $t>]() {
+                    let a = Vector2::new(4 as $t, 3 as $t);
+                    let res = <Vector2<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_signed_ $t>]() {
+                    let a = Vector2::new(-4 as $t, -3 as $t);
+                    let res = <Vector2<$t> as ArgminNorm<$t>>::norm(&a);
+                    let target = 5 as $t;
+                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(f32);
+    make_test_signed!(f64);
+}

--- a/src/core/math/scaledadd_nalgebra.rs
+++ b/src/core/math/scaledadd_nalgebra.rs
@@ -1,0 +1,164 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledAdd;
+    use nalgebra::{DVector, Matrix2, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = 2 as $t;
+                    let c = Vector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = <Vector3<$t> as ArgminScaledAdd<Vector3<$t>, $t, Vector3<$t>>>::scaled_add(&a, &b, &c);
+                    let target = Vector3::new(9 as $t, 12 as $t, 15 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_1_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = 2 as $t;
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t]);
+                    <DVector<$t> as ArgminScaledAdd<DVector<$t>, $t, DVector<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t]);
+                    let b = 2 as $t;
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledAdd<DVector<$t>, $t, DVector<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_vec_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = Vector3::new(3 as $t, 2 as $t, 1 as $t);
+                    let c = Vector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = <Vector3<$t> as ArgminScaledAdd<Vector3<$t>, Vector3<$t>, Vector3<$t>>>::scaled_add(&a, &b, &c);
+                    let target = Vector3::new(13 as $t, 12 as $t, 9 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_1_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t, 1 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledAdd<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledAdd<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledadd_vec_vec_panic_3_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t, 1 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t]);
+                    <DVector<$t> as ArgminScaledAdd<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_add(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_mat_ $t>]() {
+                    let a = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        3 as $t, 4 as $t,
+                    );
+                    let b = Matrix2::new(
+                        4 as $t, 3 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let c = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let res = <Matrix2<$t> as ArgminScaledAdd<Matrix2<$t>, Matrix2<$t>, Matrix2<$t>>>::scaled_add(&a, &b, &c);
+                    let target = Matrix2::new(
+                        5 as $t, 8 as $t,
+                        7 as $t, 5 as $t,
+                    );
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledadd_mat_scalar_ $t>]() {
+                    let a = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        3 as $t, 4 as $t,
+                    );
+                    let b = 2 as $t;
+                    let c = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let res = <Matrix2<$t> as ArgminScaledAdd<Matrix2<$t>, $t, Matrix2<$t>>>::scaled_add(&a, &b, &c);
+                    let target = Matrix2::new(
+                        3 as $t, 6 as $t,
+                        7 as $t, 6 as $t,
+                    );
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/scaledsub_nalgebra.rs
+++ b/src/core/math/scaledsub_nalgebra.rs
@@ -1,0 +1,164 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#[cfg(test)]
+mod tests {
+    use crate::core::math::ArgminScaledSub;
+    use nalgebra::{DVector, Matrix2, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_ $t>]() {
+                    let a = Vector3::new(10 as $t, 20 as $t, 30 as $t);
+                    let b = 2 as $t;
+                    let c = Vector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = <Vector3<$t> as ArgminScaledSub<Vector3<$t>, $t, Vector3<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = Vector3::new(2 as $t, 10 as $t, 18 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_1_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = 2 as $t;
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t]);
+                    <DVector<$t> as ArgminScaledSub<DVector<$t>, $t, DVector<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t]);
+                    let b = 2 as $t;
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledSub<DVector<$t>, $t, DVector<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_vec_vec_ $t>]() {
+                    let a = Vector3::new(20 as $t, 20 as $t, 30 as $t);
+                    let b = Vector3::new(3 as $t, 2 as $t, 1 as $t);
+                    let c = Vector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = <Vector3<$t> as ArgminScaledSub<Vector3<$t>, Vector3<$t>, Vector3<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = Vector3::new(8 as $t, 10 as $t, 24 as $t);
+                    for i in 0..3 {
+                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_1_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t, 1 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledSub<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_2_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t, 6 as $t]);
+                    <DVector<$t> as ArgminScaledSub<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_scaledsub_vec_vec_panic_3_ $t>]() {
+                    let a = DVector::from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = DVector::from_vec(vec![3 as $t, 2 as $t, 1 as $t]);
+                    let c = DVector::from_vec(vec![4 as $t, 5 as $t]);
+                    <DVector<$t> as ArgminScaledSub<DVector<$t>, DVector<$t>, DVector<$t>>>::scaled_sub(&a, &b, &c);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_mat_ $t>]() {
+                    let a = Matrix2::new(
+                        10 as $t, 20 as $t,
+                        30 as $t, 40 as $t,
+                    );
+                    let b = Matrix2::new(
+                        4 as $t, 3 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let c = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let res = <Matrix2<$t> as ArgminScaledSub<Matrix2<$t>, Matrix2<$t>, Matrix2<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = Matrix2::new(
+                        6 as $t, 14 as $t,
+                        26 as $t, 39 as $t,
+                    );
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scaledsub_mat_scalar_ $t>]() {
+                    let a = Matrix2::new(
+                        10 as $t, 20 as $t,
+                        30 as $t, 40 as $t,
+                    );
+                    let b = 2 as $t;
+                    let c = Matrix2::new(
+                        1 as $t, 2 as $t,
+                        2 as $t, 1 as $t,
+                    );
+                    let res = <Matrix2<$t> as ArgminScaledSub<Matrix2<$t>, $t, Matrix2<$t>>>::scaled_sub(&a, &b, &c);
+                    let target = Matrix2::new(
+                        8 as $t, 16 as $t,
+                        26 as $t, 38 as $t
+                    );
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/sub_nalgebra.rs
+++ b/src/core/math/sub_nalgebra.rs
@@ -1,0 +1,163 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::ops::Sub;
+
+use crate::core::math::ArgminSub;
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim, storage::Storage, Scalar},
+    ClosedSub, DefaultAllocator, Matrix, MatrixMN,
+};
+
+impl<N, R, C, S> ArgminSub<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + Copy + Sub<Output = N>,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn sub(&self, other: &N) -> MatrixMN<N, R, C> {
+        self.map(|entry| entry - *other)
+    }
+}
+
+impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+where
+    N: Scalar + Copy + Sub<Output = N>,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn sub(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        other.map(|entry| *self - entry)
+    }
+}
+
+impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+where
+    N: Scalar + ClosedSub,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn sub(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+        self - other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{Matrix2x3, Vector3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_sub_vec_scalar_ $t>]() {
+                    let a = Vector3::new(36 as $t, 39 as $t, 43 as $t);
+                    let b = 1 as $t;
+                    let target = Vector3::new(35 as $t, 38 as $t, 42 as $t);
+                    let res = <Vector3<$t> as ArgminSub<$t, Vector3<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_scalar_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 34 as $t;
+                    let target = Vector3::new(33 as $t, 30 as $t, 26 as $t);
+                    let res = <$t as ArgminSub<Vector3<$t>, Vector3<$t>>>::sub(&b, &a);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_vec_vec_ $t>]() {
+                    let a = Vector3::new(41 as $t, 38 as $t, 34 as $t);
+                    let b = Vector3::new(1 as $t, 4 as $t, 8 as $t);
+                    let target =Vector3::new(40 as $t, 34 as $t, 26 as $t);
+                    let res = <Vector3<$t> as ArgminSub<Vector3<$t>, Vector3<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_mat_ $t>]() {
+                    let a = Matrix2x3::new(
+                        43 as $t, 46 as $t, 50 as $t,
+                        44 as $t, 47 as $t, 51 as $t
+                    );
+                    let b = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        42 as $t, 42 as $t, 42 as $t,
+                        42 as $t, 42 as $t, 42 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminSub<Matrix2x3<$t>, Matrix2x3<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_scalar_ $t>]() {
+                    let a = Matrix2x3::new(
+                        43 as $t, 46 as $t, 50 as $t,
+                        44 as $t, 47 as $t, 51 as $t
+                    );
+                    let b = 2 as $t;
+                    let target = Matrix2x3::new(
+                        41 as $t, 44 as $t, 48 as $t,
+                        42 as $t, 45 as $t, 49 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminSub<$t, Matrix2x3<$t>>>::sub(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert!(((target[(j, i)] - res[(j, i)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/transpose.rs
+++ b/src/core/math/transpose.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 
 macro_rules! make_transpose {
     ($t:ty) => {
-        impl ArgminTranspose for $t {
+        impl ArgminTranspose<$t> for $t {
             #[inline]
             fn t(self) -> $t {
                 self
@@ -55,7 +55,7 @@ mod tests {
                 #[test]
                 fn [<test_transpose_ $t>]() {
                     let a = 8 as $t;
-                    let res = <$t as ArgminTranspose>::t(a);
+                    let res = <$t as ArgminTranspose<$t>>::t(a);
                     assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
                 }
             }

--- a/src/core/math/transpose_nalgebra.rs
+++ b/src/core/math/transpose_nalgebra.rs
@@ -32,7 +32,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nalgebra::{RowVector2, Vector2, Matrix2, Matrix3x2, Matrix2x3};
+    use nalgebra::{Matrix2, Matrix2x3, Matrix3x2, RowVector2, Vector2};
     use paste::item;
 
     macro_rules! make_test {

--- a/src/core/math/transpose_nalgebra.rs
+++ b/src/core/math/transpose_nalgebra.rs
@@ -1,0 +1,105 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// Note: This is not really the preferred way I think. Maybe this should also be implemented for
+// ArrayViews, which would probably make it more efficient.
+
+use crate::core::math::ArgminTranspose;
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim, storage::Storage, Scalar},
+    DefaultAllocator, Matrix, MatrixMN,
+};
+
+impl<N, R, C, S> ArgminTranspose<MatrixMN<N, C, R>> for Matrix<N, R, C, S>
+where
+    N: Scalar,
+    R: Dim,
+    C: Dim,
+    S: Storage<N, R, C>,
+    DefaultAllocator: Allocator<N, C, R>,
+{
+    #[inline]
+    fn t(self) -> MatrixMN<N, C, R> {
+        self.transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{RowVector2, Vector2, Matrix2, Matrix3x2, Matrix2x3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_transpose_ $t>]() {
+                    let a = Vector2::new(1 as $t, 4 as $t);
+                    let target = RowVector2::new(1 as $t, 4 as $t);
+                    let res = <Vector2<$t> as ArgminTranspose<RowVector2<$t>>>::t(a);
+                    for i in 0..2 {
+                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_1_ $t>]() {
+                    let a = Matrix2::new(
+                        1 as $t, 4 as $t,
+                        8 as $t, 7 as $t
+                    );
+                    let target = Matrix2::new(
+                        1 as $t, 8 as $t,
+                        4 as $t, 7 as $t
+                    );
+                    let res = <Matrix2<$t> as ArgminTranspose<Matrix2<$t>>>::t(a);
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_2_ $t>]() {
+                    let a = Matrix3x2::new(
+                        1 as $t, 4 as $t,
+                        8 as $t, 7 as $t,
+                        3 as $t, 6 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        1 as $t, 8 as $t, 3 as $t,
+                        4 as $t, 7 as $t, 6 as $t
+                    );
+                    let res = <Matrix3x2<$t> as ArgminTranspose<Matrix2x3<$t>>>::t(a);
+                    for i in 0..2 {
+                        for j in 0..3 {
+                            assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/transpose_ndarray.rs
+++ b/src/core/math/transpose_ndarray.rs
@@ -14,14 +14,14 @@ use num_complex::Complex;
 
 macro_rules! make_add {
     ($t:ty) => {
-        impl ArgminTranspose for Array1<$t> {
+        impl ArgminTranspose<Array1<$t>> for Array1<$t> {
             #[inline]
             fn t(self) -> Array1<$t> {
                 self.reversed_axes()
             }
         }
 
-        impl ArgminTranspose for Array2<$t> {
+        impl ArgminTranspose<Array2<$t>> for Array2<$t> {
             #[inline]
             fn t(self) -> Array2<$t> {
                 self.reversed_axes()
@@ -57,7 +57,7 @@ mod tests {
                 fn [<test_transpose_ $t>]() {
                     let a = array![1 as $t, 4 as $t];
                     let target = array![1 as $t, 4 as $t];
-                    let res = <Array1<$t> as ArgminTranspose>::t(a);
+                    let res = <Array1<$t> as ArgminTranspose<Array1<$t>>>::t(a);
                     for i in 0..2 {
                         assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
                     }
@@ -75,7 +75,7 @@ mod tests {
                         [1 as $t, 8 as $t],
                         [4 as $t, 7 as $t]
                     ];
-                    let res = <Array2<$t> as ArgminTranspose>::t(a);
+                    let res = <Array2<$t> as ArgminTranspose<Array2<$t>>>::t(a);
                     for i in 0..2 {
                         for j in 0..2 {
                             assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);
@@ -96,7 +96,7 @@ mod tests {
                         [1 as $t, 8 as $t, 3 as $t],
                         [4 as $t, 7 as $t, 6 as $t]
                     ];
-                    let res = <Array2<$t> as ArgminTranspose>::t(a);
+                    let res = <Array2<$t> as ArgminTranspose<Array2<$t>>>::t(a);
                     for i in 0..2 {
                         for j in 0..3 {
                             assert!(((target[(i, j)] - res[(i, j)]) as f64).abs() < std::f64::EPSILON);

--- a/src/core/math/transpose_vec.rs
+++ b/src/core/math/transpose_vec.rs
@@ -13,7 +13,7 @@ use num_complex::Complex;
 
 macro_rules! make_transpose {
     ($t:ty) => {
-        impl ArgminTranspose for Vec<Vec<$t>> {
+        impl ArgminTranspose<Vec<Vec<$t>>> for Vec<Vec<$t>> {
             fn t(self) -> Self {
                 let n1 = self.len();
                 let n2 = self[0].len();

--- a/src/core/math/weighteddot.rs
+++ b/src/core/math/weighteddot.rs
@@ -92,3 +92,41 @@ mod tests_ndarray {
     make_test!(f32);
     make_test!(f64);
 }
+
+#[cfg(feature = "nalgebral")]
+#[cfg(test)]
+mod tests_nalgebra {
+    use super::*;
+    use nalgebra::{Vector3, Matrix3};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_ $t>]() {
+                    let a = Vector3::new(2 as $t, 1 as $t, 2 as $t);
+                    let b = Vector3::new(1 as $t, 2 as $t, 1 as $t);
+                    let w = Matrix3::new(
+                        8 as $t, 1 as $t, 6 as $t,
+                        3 as $t, 5 as $t, 7 as $t,
+                        4 as $t, 9 as $t, 2 as $t,
+                    );
+                    let res: $t = a.weighted_dot(&w, &b);
+                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/core/math/weighteddot.rs
+++ b/src/core/math/weighteddot.rs
@@ -97,7 +97,7 @@ mod tests_ndarray {
 #[cfg(test)]
 mod tests_nalgebra {
     use super::*;
-    use nalgebra::{Vector3, Matrix3};
+    use nalgebra::{Matrix3, Vector3};
     use paste::item;
 
     macro_rules! make_test {

--- a/src/core/math/zero_nalgebra.rs
+++ b/src/core/math/zero_nalgebra.rs
@@ -1,0 +1,96 @@
+// Copyright 2018-2020 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::core::math::{ArgminZero, ArgminZeroLike};
+
+use num::Zero;
+
+use nalgebra::{
+    base::{allocator::Allocator, dimension::Dim},
+    DefaultAllocator, MatrixMN, Scalar,
+};
+
+impl<N, R, C> ArgminZeroLike for MatrixMN<N, R, C>
+where
+    N: Scalar + Zero + ArgminZero,
+    R: Dim,
+    C: Dim,
+    DefaultAllocator: Allocator<N, R, C>,
+{
+    #[inline]
+    fn zero_like(&self) -> MatrixMN<N, R, C> {
+        Self::zeros_generic(R::from_usize(self.nrows()), C::from_usize(self.ncols()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::{DVector, Matrix2, Vector2, Vector4};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_zero_like_ $t>]() {
+                    let t: DVector<$t> = DVector::from_vec(vec![]);
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_2_ $t>]() {
+                    let a = Vector4::new(42 as $t, 42 as $t, 42 as $t, 42 as $t).zero_like();
+                    for i in 0..4 {
+                        assert!(((0 as $t - a[i]) as f64).abs() < std::f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_ $t>]() {
+                    let t: Vector2<$t> = Vector2::zeros();
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_2_ $t>]() {
+                    let a = Matrix2::new(
+                      42 as $t, 42 as $t,
+                      42 as $t, 42 as $t
+                    ).zero_like();
+
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert!(((0 as $t - a[(i, j)]) as f64).abs() < std::f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    make_test!(isize);
+    make_test!(usize);
+    make_test!(i8);
+    make_test!(u8);
+    make_test!(i16);
+    make_test!(u16);
+    make_test!(i32);
+    make_test!(u32);
+    make_test!(i64);
+    make_test!(u64);
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -55,8 +55,7 @@ impl<L, F: ArgminFloat> GaussNewtonLS<L, F> {
 impl<O, L, F> Solver<O> for GaussNewtonLS<L, F>
 where
     O: ArgminOp<Float = F>,
-    O::Param: Default
-        + std::fmt::Debug
+    O::Param: std::fmt::Debug
         + ArgminScaledSub<O::Param, O::Float, O::Param>
         + ArgminSub<O::Param, O::Param>
         + ArgminMul<O::Float, O::Param>,
@@ -66,7 +65,6 @@ where
         + ArgminDot<O::Jacobian, O::Jacobian>
         + ArgminDot<O::Output, O::Param>
         + ArgminDot<O::Param, O::Param>,
-    O::Hessian: Default,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<LineSearchOP<O>>>,
     F: ArgminFloat,
 {
@@ -134,7 +132,7 @@ pub struct LineSearchOP<O> {
 impl<O> ArgminOp for LineSearchOP<O>
 where
     O: ArgminOp,
-    O::Jacobian: ArgminTranspose + ArgminDot<O::Output, O::Param>,
+    O::Jacobian: ArgminTranspose<O::Jacobian> + ArgminDot<O::Output, O::Param>,
     O::Output: ArgminNorm<O::Float>,
 {
     type Param = O::Param;

--- a/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -61,7 +61,7 @@ where
         + ArgminSub<O::Param, O::Param>
         + ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,
-    O::Jacobian: ArgminTranspose
+    O::Jacobian: ArgminTranspose<O::Jacobian>
         + ArgminInv<O::Jacobian>
         + ArgminDot<O::Jacobian, O::Jacobian>
         + ArgminDot<O::Output, O::Param>

--- a/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/src/solver/gaussnewton/gaussnewton_method.rs
@@ -78,7 +78,7 @@ where
         + ArgminSub<O::Param, O::Param>
         + ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,
-    O::Jacobian: ArgminTranspose
+    O::Jacobian: ArgminTranspose<O::Jacobian>
         + ArgminInv<O::Jacobian>
         + ArgminDot<O::Jacobian, O::Jacobian>
         + ArgminDot<O::Output, O::Param>

--- a/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/src/solver/gaussnewton/gaussnewton_method.rs
@@ -73,8 +73,7 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
 impl<O, F> Solver<O> for GaussNewton<F>
 where
     O: ArgminOp<Float = F>,
-    O::Param:
-          ArgminScaledSub<O::Param, O::Float, O::Param>
+    O::Param: ArgminScaledSub<O::Param, O::Float, O::Param>
         + ArgminSub<O::Param, O::Param>
         + ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,

--- a/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/src/solver/gaussnewton/gaussnewton_method.rs
@@ -73,8 +73,8 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
 impl<O, F> Solver<O> for GaussNewton<F>
 where
     O: ArgminOp<Float = F>,
-    O::Param: Default
-        + ArgminScaledSub<O::Param, O::Float, O::Param>
+    O::Param:
+          ArgminScaledSub<O::Param, O::Float, O::Param>
         + ArgminSub<O::Param, O::Param>
         + ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,
@@ -83,7 +83,6 @@ where
         + ArgminDot<O::Jacobian, O::Jacobian>
         + ArgminDot<O::Output, O::Param>
         + ArgminDot<O::Param, O::Param>,
-    O::Hessian: Default,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Gauss-Newton method";

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -80,7 +80,7 @@ where
         + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<O::Float, O::Hessian>
-        + ArgminTranspose
+        + ArgminTranspose<O::Hessian>
         + ArgminEye,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -61,7 +61,7 @@ where
         + ArgminScaledAdd<O::Param, F, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>
-        + ArgminTranspose,
+        + ArgminTranspose<O::Param>,
     O::Hessian: Clone
         + Default
         + Serialize
@@ -71,7 +71,7 @@ where
         + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>
-        + ArgminTranspose
+        + ArgminTranspose<O::Hessian>
         + ArgminEye,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,


### PR DESCRIPTION
This PR adds support for the [`nalgebra`](https://nalgebra.org) crate. This allows using static matrices with `argmin`. It also means that operations that panicked before now result in a compilation error (e.g., multiplying incompatible static matrices). 

Not all math traits were implemented; only the ones that were implemented for `ndarray` are now implemented for `nalgebra`. A usage example was also added for the Gauss-Newton solver.

The implementations of `argmin`'s math traits use a lof of generic code to support all the matrices provided by `nalgebra` (both static and dynamic ones). However, the disadvantage is that any change in `nalgabra`'s definitions of matrices or the functions they support will break the implementations in `argmin`.

NB: Thank you for providing and maintaining such a great optimization crate with support for many solvers. It saved us a lot of time :) 
