### PR TITLE
Fix lazy evaluation of gradients in line searches

### DIFF
--- a/src/solver/linesearch/backtracking.rs
+++ b/src/solver/linesearch/backtracking.rs
@@ -121,7 +121,10 @@ where
             cost
         };
 
-        self.init_grad = state.get_grad().unwrap_or(op.gradient(&self.init_param)?);
+        self.init_grad = state
+            .get_grad()
+            .map(Result::Ok)
+            .unwrap_or_else(|| op.gradient(&self.init_param))?;
 
         if self.search_direction.is_none() {
             return Err(ArgminError::NotInitialized {

--- a/src/solver/linesearch/hagerzhang.rs
+++ b/src/solver/linesearch/hagerzhang.rs
@@ -459,7 +459,10 @@ where
             cost
         };
 
-        self.init_grad = state.get_grad().unwrap_or(op.gradient(&self.init_param)?);
+        self.init_grad = state
+            .get_grad()
+            .map(Result::Ok)
+            .unwrap_or_else(|| op.gradient(&self.init_param))?;
 
         self.a_x = self.a_x_init;
         self.b_x = self.b_x_init;

--- a/src/solver/linesearch/morethuente.rs
+++ b/src/solver/linesearch/morethuente.rs
@@ -242,7 +242,8 @@ where
 
         self.init_grad = state
             .get_grad()
-            .unwrap_or_else(|| op.gradient(&self.init_param).unwrap());
+            .map(Result::Ok)
+            .unwrap_or_else(|| op.gradient(&self.init_param))?;
 
         self.dginit = self.init_grad.dot(&self.search_direction);
 


### PR DESCRIPTION
The Backtracking and Hager Zhang line searches always evaluated the gradient, even if it was already present (because of usage of `unwrap_or`). In addition, More Thuente would panic if the gradient computation returns an error (because of usage of `unwrap`). This PR fixes this.

Unrelated: With respect to your usage of dependabot I would recommend using squash & merge in the Github UI to avoid littering your commit history with tons of merge commits. But feel free to ignore this opinion.