### PR TITLE
Fixed error when using recent nightly compiler 

### DIFF
--- a/src/solver/particleswarm/mod.rs
+++ b/src/solver/particleswarm/mod.rs
@@ -129,7 +129,7 @@ where
 impl<O, P, F> Solver<O> for ParticleSwarm<P, F>
 where
     O: ArgminOp<Output = F, Param = P, Float = F>,
-    O::Param: Position<F> + DeserializeOwned + Serialize,
+    P: Position<F> + DeserializeOwned + Serialize,
     O::Hessian: Clone + Default,
     F: ArgminFloat,
 {

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -70,7 +70,7 @@ where
         + ArgminScaledAdd<O::Param, O::Float, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: Clone
+    H: Clone
         + Default
         + Debug
         + Serialize

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -62,7 +62,7 @@ where
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>
         + ArgminTranspose<O::Param>,
-    O::Hessian: Clone
+    H: Clone
         + Default
         + Serialize
         + DeserializeOwned

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -87,7 +87,7 @@ where
         + ArgminDot<O::Param, O::Hessian>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: Debug
+    H: Debug
         + Clone
         + Default
         + Serialize

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -111,7 +111,7 @@ where
         + ArgminNorm<O::Float>
         + ArgminZeroLike
         + ArgminMul<F, O::Param>,
-    O::Hessian: Debug
+    B: Debug
         + Clone
         + Default
         + Serialize


### PR DESCRIPTION
The latest nightly compilers require type annotations. It was necessary to replace one type with another (equivalent) type. Not sure why though...

Fixes #104 .