### PR TITLE
downgrade ndarray-rand to 0.13 (to match ndarray 0.14), version bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argmin"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Stefan Kroboth <stefan.kroboth@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ paste = "1.0.0"
 nalgebra = { version = "0.26.1", optional = true, features = ["serde-serialize"] }
 ndarray = { version = "0.14", optional = true, features = ["serde-1"] }
 ndarray-linalg = { version = "0.13", optional = true }
-ndarray-rand = {version = "0.14.0", optional = true }
+ndarray-rand = {version = "0.13.0", optional = true }
 num = { version = "0.4" }
 num-complex = "0.3"
 rand = { version = "0.8.3", features = ["serde1"] }

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-argmin = "0.4.2"
+argmin = "0.4.3"
 ```
 
 ### Optional features (recommended)
@@ -87,7 +87,7 @@ There are additional features which can be activated in `Cargo.toml`:
 
 ```toml
 [dependencies]
-argmin = { version = "0.4.2", features = ["ctrlc", "ndarrayl", "nalgebral"] }
+argmin = { version = "0.4.3", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 ```
 
 These may become default features in the future. Without these features compilation to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argmin = "0.4.2"
+//! argmin = "0.4.3"
 //! ```
 //!
 //! ## Optional features (recommended)
@@ -88,7 +88,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argmin = { version = "0.4.2", features = ["ctrlc", "ndarrayl", "nalgebral"] }
+//! argmin = { version = "0.4.3", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 //! ```
 //!
 //! These may become default features in the future. Without these features compilation to


### PR DESCRIPTION
fixes #108 