### PR TITLE
Remove extern crate definitions from examples

### DIFF
--- a/examples/backtracking.rs
+++ b/examples/backtracking.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::{ArmijoCondition, BacktrackingLineSearch};
 use argmin_testfunctions::{sphere, sphere_derivative};

--- a/examples/bfgs.rs
+++ b/examples/bfgs.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;

--- a/examples/brent.rs
+++ b/examples/brent.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
 use argmin::prelude::*;
 use argmin::solver::brent::Brent;
 

--- a/examples/checkpoint_3.rs
+++ b/examples/checkpoint_3.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;

--- a/examples/conjugategradient.rs
+++ b/examples/conjugategradient.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
 use argmin::prelude::*;
 use argmin::solver::conjugategradient::ConjugateGradient;
 

--- a/examples/dfp.rs
+++ b/examples/dfp.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::DFP;

--- a/examples/gaussnewton.rs
+++ b/examples/gaussnewton.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::gaussnewton::GaussNewton;
 // use argmin::solver::linesearch::MoreThuenteLineSearch;

--- a/examples/gaussnewton_linesearch.rs
+++ b/examples/gaussnewton_linesearch.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::gaussnewton::GaussNewtonLS;
 use argmin::solver::linesearch::MoreThuenteLineSearch;

--- a/examples/goldensectionsearch.rs
+++ b/examples/goldensectionsearch.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
 use argmin::prelude::*;
 use argmin::solver::goldensectionsearch::GoldenSectionSearch;
 

--- a/examples/hagerzhang.rs
+++ b/examples/hagerzhang.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::HagerZhangLineSearch;
 use argmin_testfunctions::{sphere, sphere_derivative};

--- a/examples/landweber.rs
+++ b/examples/landweber.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::core::Error;
 use argmin::prelude::*;
 use argmin::solver::landweber::*;

--- a/examples/lbfgs.rs
+++ b/examples/lbfgs.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::LBFGS;

--- a/examples/morethuente.rs
+++ b/examples/morethuente.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin_testfunctions::{sphere, sphere_derivative};

--- a/examples/neldermead.rs
+++ b/examples/neldermead.rs
@@ -5,9 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::neldermead::NelderMead;
 use argmin_testfunctions::rosenbrock;

--- a/examples/newton.rs
+++ b/examples/newton.rs
@@ -5,9 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::newton::Newton;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};

--- a/examples/newton_cg.rs
+++ b/examples/newton_cg.rs
@@ -5,9 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::newton::NewtonCG;

--- a/examples/nonlinear_cg.rs
+++ b/examples/nonlinear_cg.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::conjugategradient::NonlinearConjugateGradient;
 use argmin::solver::conjugategradient::PolakRibiere;

--- a/examples/particleswarm.rs
+++ b/examples/particleswarm.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::particleswarm::*;
 

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate rand;
-extern crate rand_xorshift;
 use argmin::prelude::*;
 use argmin::solver::simulatedannealing::{SATempFunc, SimulatedAnnealing};
 use argmin_testfunctions::rosenbrock;

--- a/examples/sr1.rs
+++ b/examples/sr1.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::SR1;

--- a/examples/sr1_trustregion.rs
+++ b/examples/sr1_trustregion.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::quasinewton::SR1TrustRegion;
 #[allow(unused_imports)]

--- a/examples/steepestdescent.rs
+++ b/examples/steepestdescent.rs
@@ -7,8 +7,6 @@
 
 #![allow(unused_imports)]
 
-extern crate argmin;
-extern crate argmin_testfunctions;
 use argmin::prelude::*;
 use argmin::solver::gradientdescent::SteepestDescent;
 use argmin::solver::linesearch::HagerZhangLineSearch;

--- a/examples/trustregion_nd.rs
+++ b/examples/trustregion_nd.rs
@@ -5,9 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate ndarray;
 use argmin::prelude::*;
 #[allow(unused_imports)]
 use argmin::solver::trustregion::{CauchyPoint, Dogleg, Steihaug, TrustRegion};

--- a/examples/writers.rs
+++ b/examples/writers.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate argmin;
-extern crate argmin_testfunctions;
-extern crate finitediff;
-extern crate ndarray;
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::BFGS;


### PR DESCRIPTION
`extern crate <crate>` was removed in Rust a while ago, but as far as I remember it was still necessary in examples. Apparently examples now work without it, therefore it is better to remove it as it may cause problems when used in actual projects (#115).