### PR TITLE
Squash warnings for Nalgebra 0.26.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ctrlc = { version = "3.1.2", optional = true }
 instant = {version = "0.1", features = ["now"] }
 gnuplot = { version = "0.0.37", optional = true}
 paste = "1.0.0"
-nalgebra = { version = "0.26.1", optional = true, features = ["serde-serialize"] }
+nalgebra = { version = "0.26.2", optional = true, features = ["serde-serialize"] }
 ndarray = { version = "0.14", optional = true, features = ["serde-1"] }
 ndarray-linalg = { version = "0.13", optional = true }
 ndarray-rand = {version = "0.13.0", optional = true }

--- a/src/core/math/add_nalgebra.rs
+++ b/src/core/math/add_nalgebra.rs
@@ -15,10 +15,10 @@ use nalgebra::{
         storage::Storage,
         Scalar,
     },
-    ClosedAdd, DefaultAllocator, Matrix, MatrixMN, MatrixSum,
+    ClosedAdd, DefaultAllocator, Matrix, MatrixSum, OMatrix,
 };
 
-impl<N, R, C, S> ArgminAdd<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminAdd<N, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + ClosedAdd + Copy,
     R: Dim,
@@ -27,12 +27,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn add(&self, other: &N) -> MatrixMN<N, R, C> {
+    fn add(&self, other: &N) -> OMatrix<N, R, C> {
         self.add_scalar(*other)
     }
 }
 
-impl<N, R, C, S> ArgminAdd<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+impl<N, R, C, S> ArgminAdd<Matrix<N, R, C, S>, OMatrix<N, R, C>> for N
 where
     N: Scalar + ClosedAdd + Copy,
     R: Dim,
@@ -41,7 +41,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn add(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn add(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         other.add_scalar(*self)
     }
 }

--- a/src/core/math/conj_nalgebra.rs
+++ b/src/core/math/conj_nalgebra.rs
@@ -9,10 +9,10 @@ use crate::core::math::ArgminConj;
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim},
-    DefaultAllocator, MatrixMN, SimdComplexField,
+    DefaultAllocator, OMatrix, SimdComplexField,
 };
 
-impl<N, R, C> ArgminConj for MatrixMN<N, R, C>
+impl<N, R, C> ArgminConj for OMatrix<N, R, C>
 where
     N: SimdComplexField,
     R: Dim,
@@ -20,7 +20,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn conj(&self) -> MatrixMN<N, R, C> {
+    fn conj(&self) -> OMatrix<N, R, C> {
         self.conjugate()
     }
 }

--- a/src/core/math/div_nalgebra.rs
+++ b/src/core/math/div_nalgebra.rs
@@ -15,10 +15,10 @@ use nalgebra::{
         storage::Storage,
         MatrixSum, Scalar,
     },
-    ClosedDiv, DefaultAllocator, Matrix, MatrixMN,
+    ClosedDiv, DefaultAllocator, Matrix, OMatrix,
 };
 
-impl<N, R, C, S> ArgminDiv<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminDiv<N, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + Copy + ClosedDiv,
     R: Dim,
@@ -27,12 +27,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn div(&self, other: &N) -> MatrixMN<N, R, C> {
+    fn div(&self, other: &N) -> OMatrix<N, R, C> {
         self / *other
     }
 }
 
-impl<N, R, C, S> ArgminDiv<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+impl<N, R, C, S> ArgminDiv<Matrix<N, R, C, S>, OMatrix<N, R, C>> for N
 where
     N: Scalar + Copy + ClosedDiv,
     R: Dim,
@@ -41,7 +41,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn div(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn div(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         other.map(|entry| *self / entry)
     }
 }

--- a/src/core/math/dot_nalgebra.rs
+++ b/src/core/math/dot_nalgebra.rs
@@ -17,7 +17,7 @@ use nalgebra::{
         storage::Storage,
         Scalar,
     },
-    ClosedAdd, ClosedMul, DefaultAllocator, Matrix, MatrixMN,
+    ClosedAdd, ClosedMul, DefaultAllocator, Matrix, OMatrix,
 };
 
 impl<N, R1, R2, C1, C2, SA, SB> ArgminDot<Matrix<N, R2, C2, SB>, N> for Matrix<N, R1, C1, SA>
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<N, R, C, S> ArgminDot<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminDot<N, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + Copy + ClosedMul,
     R: Dim,
@@ -46,12 +46,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn dot(&self, other: &N) -> MatrixMN<N, R, C> {
+    fn dot(&self, other: &N) -> OMatrix<N, R, C> {
         self * *other
     }
 }
 
-impl<N, R, C, S> ArgminDot<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+impl<N, R, C, S> ArgminDot<Matrix<N, R, C, S>, OMatrix<N, R, C>> for N
 where
     N: Scalar + Copy + ClosedMul,
     R: Dim,
@@ -60,12 +60,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn dot(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn dot(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         other * *self
     }
 }
 
-impl<N, R1, R2, C1, C2, SA, SB> ArgminDot<Matrix<N, R2, C2, SB>, MatrixMN<N, R1, C2>>
+impl<N, R1, R2, C1, C2, SA, SB> ArgminDot<Matrix<N, R2, C2, SB>, OMatrix<N, R1, C2>>
     for Matrix<N, R1, C1, SA>
 where
     N: Scalar + Zero + One + ClosedAdd + ClosedMul,
@@ -79,7 +79,7 @@ where
     ShapeConstraint: AreMultipliable<R1, C1, R2, C2>,
 {
     #[inline]
-    fn dot(&self, other: &Matrix<N, R2, C2, SB>) -> MatrixMN<N, R1, C2> {
+    fn dot(&self, other: &Matrix<N, R2, C2, SB>) -> OMatrix<N, R1, C2> {
         self * other
     }
 }

--- a/src/core/math/eye_nalgebra.rs
+++ b/src/core/math/eye_nalgebra.rs
@@ -11,10 +11,10 @@ use num::{One, Zero};
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim},
-    DefaultAllocator, MatrixMN, Scalar,
+    DefaultAllocator, OMatrix, Scalar,
 };
 
-impl<N, R, C> ArgminEye for MatrixMN<N, R, C>
+impl<N, R, C> ArgminEye for OMatrix<N, R, C>
 where
     N: Scalar + Zero + One,
     R: Dim,
@@ -22,13 +22,13 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn eye_like(&self) -> MatrixMN<N, R, C> {
+    fn eye_like(&self) -> OMatrix<N, R, C> {
         assert!(self.is_square());
         Self::identity_generic(R::from_usize(self.nrows()), C::from_usize(self.ncols()))
     }
 
     #[inline]
-    fn eye(n: usize) -> MatrixMN<N, R, C> {
+    fn eye(n: usize) -> OMatrix<N, R, C> {
         Self::identity_generic(R::from_usize(n), C::from_usize(n))
     }
 }

--- a/src/core/math/inv_nalgebra.rs
+++ b/src/core/math/inv_nalgebra.rs
@@ -9,10 +9,10 @@ use crate::core::{errors::ArgminError, math::ArgminInv, Error};
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim, storage::Storage},
-    ComplexField, DefaultAllocator, MatrixN, SquareMatrix,
+    ComplexField, DefaultAllocator, OMatrix, SquareMatrix,
 };
 
-impl<N, D, S> ArgminInv<MatrixN<N, D>> for SquareMatrix<N, D, S>
+impl<N, D, S> ArgminInv<OMatrix<N, D, D>> for SquareMatrix<N, D, S>
 where
     N: ComplexField,
     D: Dim,
@@ -20,7 +20,7 @@ where
     DefaultAllocator: Allocator<N, D, D>,
 {
     #[inline]
-    fn inv(&self) -> Result<MatrixN<N, D>, Error> {
+    fn inv(&self) -> Result<OMatrix<N, D, D>, Error> {
         match self.clone_owned().try_inverse() {
             Some(m) => Ok(m),
             None => Err(ArgminError::InvalidParameter {

--- a/src/core/math/mul_nalgebra.rs
+++ b/src/core/math/mul_nalgebra.rs
@@ -15,10 +15,10 @@ use nalgebra::{
         storage::Storage,
         MatrixSum, Scalar,
     },
-    ClosedMul, DefaultAllocator, Matrix, MatrixMN,
+    ClosedMul, DefaultAllocator, Matrix, OMatrix,
 };
 
-impl<N, R, C, S> ArgminMul<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminMul<N, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + Copy + ClosedMul,
     R: Dim,
@@ -27,12 +27,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn mul(&self, other: &N) -> MatrixMN<N, R, C> {
+    fn mul(&self, other: &N) -> OMatrix<N, R, C> {
         self * *other
     }
 }
 
-impl<N, R, C, S> ArgminMul<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+impl<N, R, C, S> ArgminMul<Matrix<N, R, C, S>, OMatrix<N, R, C>> for N
 where
     N: Scalar + Copy + ClosedMul,
     R: Dim,
@@ -41,7 +41,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn mul(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn mul(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         other * *self
     }
 }

--- a/src/core/math/sub_nalgebra.rs
+++ b/src/core/math/sub_nalgebra.rs
@@ -11,10 +11,10 @@ use crate::core::math::ArgminSub;
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim, storage::Storage, Scalar},
-    ClosedSub, DefaultAllocator, Matrix, MatrixMN,
+    ClosedSub, DefaultAllocator, Matrix, OMatrix,
 };
 
-impl<N, R, C, S> ArgminSub<N, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminSub<N, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + Copy + Sub<Output = N>,
     R: Dim,
@@ -23,12 +23,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn sub(&self, other: &N) -> MatrixMN<N, R, C> {
+    fn sub(&self, other: &N) -> OMatrix<N, R, C> {
         self.map(|entry| entry - *other)
     }
 }
 
-impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for N
+impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, OMatrix<N, R, C>> for N
 where
     N: Scalar + Copy + Sub<Output = N>,
     R: Dim,
@@ -37,12 +37,12 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn sub(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn sub(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         other.map(|entry| *self - entry)
     }
 }
 
-impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, MatrixMN<N, R, C>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminSub<Matrix<N, R, C, S>, OMatrix<N, R, C>> for Matrix<N, R, C, S>
 where
     N: Scalar + ClosedSub,
     R: Dim,
@@ -51,7 +51,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn sub(&self, other: &Matrix<N, R, C, S>) -> MatrixMN<N, R, C> {
+    fn sub(&self, other: &Matrix<N, R, C, S>) -> OMatrix<N, R, C> {
         self - other
     }
 }

--- a/src/core/math/transpose_nalgebra.rs
+++ b/src/core/math/transpose_nalgebra.rs
@@ -12,10 +12,10 @@ use crate::core::math::ArgminTranspose;
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim, storage::Storage, Scalar},
-    DefaultAllocator, Matrix, MatrixMN,
+    DefaultAllocator, Matrix, OMatrix,
 };
 
-impl<N, R, C, S> ArgminTranspose<MatrixMN<N, C, R>> for Matrix<N, R, C, S>
+impl<N, R, C, S> ArgminTranspose<OMatrix<N, C, R>> for Matrix<N, R, C, S>
 where
     N: Scalar,
     R: Dim,
@@ -24,7 +24,7 @@ where
     DefaultAllocator: Allocator<N, C, R>,
 {
     #[inline]
-    fn t(self) -> MatrixMN<N, C, R> {
+    fn t(self) -> OMatrix<N, C, R> {
         self.transpose()
     }
 }

--- a/src/core/math/zero_nalgebra.rs
+++ b/src/core/math/zero_nalgebra.rs
@@ -11,10 +11,10 @@ use num::Zero;
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim},
-    DefaultAllocator, MatrixMN, Scalar,
+    DefaultAllocator, OMatrix, Scalar,
 };
 
-impl<N, R, C> ArgminZeroLike for MatrixMN<N, R, C>
+impl<N, R, C> ArgminZeroLike for OMatrix<N, R, C>
 where
     N: Scalar + Zero + ArgminZero,
     R: Dim,
@@ -22,7 +22,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn zero_like(&self) -> MatrixMN<N, R, C> {
+    fn zero_like(&self) -> OMatrix<N, R, C> {
         Self::zeros_generic(R::from_usize(self.nrows()), C::from_usize(self.ncols()))
     }
 }


### PR DESCRIPTION
- Switched to `OMatrix` for the the NAlgebra implementation of the math traits. This will work with both static and dynamic matrices. I confirmed that these work even with `SMatrix`.
- Bumped NAlgebra to the latest released version