### PR TITLE
Make use of `slog` a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 keywords = ["optimization", "math", "science"]
 categories = ["science"]
 exclude = [
-	".travis.yml",
-	"push_docs",
+    ".travis.yml",
+    "push_docs",
 ]
 
 [dependencies]
@@ -34,10 +34,10 @@ rand = { version = "0.8.3", features = ["serde1"] }
 rand_xorshift = { version = "0.3.0", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-slog = "2.4.1"
-slog-term = "2.4.0"
-slog-async = "2.3.0"
-slog-json = "2.3.0"
+slog = { version = "2.4.1", optional = true }
+slog-term = { version = "2.4.0", optional = true }
+slog-async = { version = "2.3.0", optional = true }
+slog-json = { version = "2.3.0", optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]
@@ -46,11 +46,12 @@ finitediff = { version = "0.1.4", features = ["ndarray"] }
 argmin_testfunctions = "0.1.1"
 
 [features]
-default = []
+default = ["slog-logger"]
 nalgebral = ["nalgebra"]
 ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand"]
 visualizer = ["gnuplot"]
 wasm-bindgen = ["instant/wasm-bindgen"]
+slog-logger = ["slog", "slog-term", "slog-async", "slog-json"]
 stdweb = ["instant/stdweb"]
 
 [badges]

--- a/examples/sr1_trustregion.rs
+++ b/examples/sr1_trustregion.rs
@@ -39,7 +39,7 @@ impl ArgminOp for Rosenbrock {
     }
 
     fn hessian(&self, p: &Self::Param) -> Result<Self::Hessian, Error> {
-        Ok((*p).forward_hessian(&|x| self.gradient(&x).unwrap()))
+        Ok((*p).forward_hessian(&|x| self.gradient(x).unwrap()))
     }
 }
 

--- a/src/core/iterstate.rs
+++ b/src/core/iterstate.rs
@@ -368,11 +368,22 @@ mod tests {
         assert_eq!(state.get_prev_param(), param);
         assert_eq!(state.get_best_param(), param);
         assert_eq!(state.get_prev_best_param(), param);
-        assert_eq!(state.get_cost(), std::f64::INFINITY);
-        assert_eq!(state.get_prev_cost(), std::f64::INFINITY);
-        assert_eq!(state.get_best_cost(), std::f64::INFINITY);
-        assert_eq!(state.get_prev_best_cost(), std::f64::INFINITY);
-        assert_eq!(state.get_target_cost(), std::f64::NEG_INFINITY);
+
+        assert!(state.get_cost().is_infinite());
+        assert!(state.get_cost().is_sign_positive());
+
+        assert!(state.get_prev_cost().is_infinite());
+        assert!(state.get_prev_cost().is_sign_positive());
+
+        assert!(state.get_best_cost().is_infinite());
+        assert!(state.get_best_cost().is_sign_positive());
+
+        assert!(state.get_prev_best_cost().is_infinite());
+        assert!(state.get_prev_best_cost().is_sign_positive());
+
+        assert!(state.get_target_cost().is_infinite());
+        assert!(state.get_target_cost().is_sign_negative());
+
         assert_eq!(state.get_grad(), None);
         assert_eq!(state.get_prev_grad(), None);
         assert_eq!(state.get_hessian(), None);
@@ -380,7 +391,9 @@ mod tests {
         assert_eq!(state.get_jacobian(), None);
         assert_eq!(state.get_prev_jacobian(), None);
         assert_eq!(state.get_iter(), 0);
-        assert_eq!(state.is_best(), true);
+
+        assert!(state.is_best());
+
         assert_eq!(state.get_max_iters(), std::u64::MAX);
         assert_eq!(state.get_cost_func_count(), 0);
         assert_eq!(state.get_grad_func_count(), 0);
@@ -394,13 +407,15 @@ mod tests {
 
         state.cost(cost);
 
-        assert_eq!(state.get_cost(), cost);
-        assert_eq!(state.get_prev_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_cost().to_ne_bytes(), cost.to_ne_bytes());
+        assert!(state.get_prev_cost().is_infinite());
+        assert!(state.get_prev_cost().is_sign_positive());
 
         state.best_cost(cost);
 
-        assert_eq!(state.get_best_cost(), cost);
-        assert_eq!(state.get_prev_best_cost(), std::f64::INFINITY);
+        assert_eq!(state.get_best_cost().to_ne_bytes(), cost.to_ne_bytes());
+        assert!(state.get_prev_best_cost().is_infinite());
+        assert!(state.get_prev_best_cost().is_sign_positive());
 
         let new_param = vec![2.0, 1.0];
 
@@ -418,23 +433,23 @@ mod tests {
 
         state.cost(new_cost);
 
-        assert_eq!(state.get_cost(), new_cost);
-        assert_eq!(state.get_prev_cost(), cost);
+        assert_eq!(state.get_cost().to_ne_bytes(), new_cost.to_ne_bytes());
+        assert_eq!(state.get_prev_cost().to_ne_bytes(), cost.to_ne_bytes());
 
         state.best_cost(new_cost);
 
-        assert_eq!(state.get_best_cost(), new_cost);
-        assert_eq!(state.get_prev_best_cost(), cost);
+        assert_eq!(state.get_best_cost().to_ne_bytes(), new_cost.to_ne_bytes());
+        assert_eq!(state.get_prev_best_cost().to_ne_bytes(), cost.to_ne_bytes());
 
         state.increment_iter();
 
         assert_eq!(state.get_iter(), 1);
 
-        assert_eq!(state.is_best(), false);
+        assert!(!state.is_best());
 
         state.new_best();
 
-        assert_eq!(state.is_best(), true);
+        assert!(state.is_best());
 
         let grad = vec![1.0, 2.0];
 
@@ -479,7 +494,7 @@ mod tests {
 
         assert_eq!(state.get_iter(), 2);
         assert_eq!(state.get_last_best_iter(), 1);
-        assert_eq!(state.is_best(), false);
+        assert!(!state.is_best());
 
         state.increment_cost_func_count(42);
         assert_eq!(state.get_cost_func_count(), 42);
@@ -496,17 +511,25 @@ mod tests {
         assert_eq!(state.get_iter(), 2);
         assert_eq!(state.get_last_best_iter(), 1);
         assert_eq!(state.get_max_iters(), 42);
-        assert_eq!(state.is_best(), false);
-        assert_eq!(state.get_cost(), new_cost);
-        assert_eq!(state.get_prev_cost(), cost);
+
+        assert!(!state.is_best());
+
+        assert_eq!(state.get_cost().to_ne_bytes(), new_cost.to_ne_bytes());
+        assert_eq!(state.get_prev_cost().to_ne_bytes(), cost.to_ne_bytes());
+        assert_eq!(state.get_prev_cost().to_ne_bytes(), cost.to_ne_bytes());
+
         assert_eq!(state.get_param(), new_param);
         assert_eq!(state.get_prev_param(), param);
-        assert_eq!(state.get_best_cost(), new_cost);
-        assert_eq!(state.get_prev_best_cost(), cost);
+
+        assert_eq!(state.get_best_cost().to_ne_bytes(), new_cost.to_ne_bytes());
+        assert_eq!(state.get_prev_best_cost().to_ne_bytes(), cost.to_ne_bytes());
+
         assert_eq!(state.get_best_param(), new_param);
         assert_eq!(state.get_prev_best_param(), param);
-        assert_eq!(state.get_best_cost(), new_cost);
-        assert_eq!(state.get_prev_best_cost(), cost);
+
+        assert_eq!(state.get_best_cost().to_ne_bytes(), new_cost.to_ne_bytes());
+        assert_eq!(state.get_prev_best_cost().to_ne_bytes(), cost.to_ne_bytes());
+
         assert_eq!(state.get_grad(), Some(new_grad));
         assert_eq!(state.get_prev_grad(), Some(grad));
         assert_eq!(state.get_hessian(), Some(new_hessian));

--- a/src/core/observers/mod.rs
+++ b/src/core/observers/mod.rs
@@ -12,6 +12,7 @@
 //! parameter vector to disk.
 
 pub mod file;
+#[cfg(feature = "slog-logger")]
 pub mod slog_logger;
 #[cfg(feature = "visualizer")]
 pub mod visualizer;
@@ -22,6 +23,7 @@ use std::default::Default;
 use std::sync::{Arc, Mutex};
 
 pub use file::*;
+#[cfg(feature = "slog-logger")]
 pub use slog_logger::*;
 #[cfg(feature = "visualizer")]
 pub use visualizer::*;


### PR DESCRIPTION
See the two commits provided for more context. 

The main crux of this is that I want to use `argmin`, but I don't want to include `slog` in the process. It makes sense then to make it a feature. Given how prolific this feature is throughout the library (it is the default terminal logger, even the file logger just goes to bincode / JSON), I opted to leave it as a default feature. Of course, if users don't want `slog` themselves, then they just have to specify the following in their `Cargo.toml`:

```TOML
[dependencies.argmin]
version = "0.4"
default-features = false
features = ["nalgebral", "ndarrayl"]
```

With whatever features they do want enabled explicitly in the `dependencies.argmin.features` array.
The first commit just cleaned up a bunch of clippy lints. The command I'm using is:

```bash
$ cargo clippy --all-targets --all-features -- -D warnings
```

I'm also on clippy (0.1.54). Hopefully the reasoning in the commit message tracks.