### PR TITLE
allow any RNG, improve SA example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ ndarray-rand = {version = "0.14.0", optional = true }
 num = { version = "0.4" }
 num-complex = "0.4"
 rand = { version = "0.8.3", features = ["serde1"] }
-rand_xorshift = { version = "0.3.0", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.4.1", optional = true }
@@ -44,6 +43,7 @@ thiserror = "1.0"
 ndarray-linalg = { version = "0.14", features = ["openblas"] }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
 argmin_testfunctions = "0.1.1"
+rand_xoshiro = { version = "0.6.0", features = ["serde1"] }
 
 [features]
 default = ["slog-logger"]

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -14,7 +14,6 @@ use rand::distributions::Uniform;
 use std::default::Default;
 use std::sync::{Arc, Mutex};
 
-#[derive(Clone)]
 struct Rosenbrock {
     /// Parameter a, usually 1.0
     a: f64,

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -79,8 +79,7 @@ impl ArgminOp for Rosenbrock {
             param_n[idx] += val;
 
             // check if bounds are violated. If yes, project onto bound.
-            param_n[idx] = param_n[idx].min(self.upper_bound[idx]);
-            param_n[idx] = param_n[idx].max(self.lower_bound[idx]);
+            param_n[idx] = param_n[idx].clamp(self.lower_bound[idx], self.upper_bound[idx]);
         }
         Ok(param_n)
     }

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -8,9 +8,9 @@
 use argmin::prelude::*;
 use argmin::solver::simulatedannealing::{SATempFunc, SimulatedAnnealing};
 use argmin_testfunctions::rosenbrock;
+use rand::distributions::Uniform;
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
-use rand::distributions::Uniform;
 use std::default::Default;
 use std::sync::{Arc, Mutex};
 

--- a/examples/simulatedannealing.rs
+++ b/examples/simulatedannealing.rs
@@ -9,11 +9,12 @@ use argmin::prelude::*;
 use argmin::solver::simulatedannealing::{SATempFunc, SimulatedAnnealing};
 use argmin_testfunctions::rosenbrock;
 use rand::prelude::*;
-use rand_xorshift::XorShiftRng;
+use rand_xoshiro::Xoshiro256PlusPlus;
+use rand::distributions::Uniform;
 use std::default::Default;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
+#[derive(Clone)]
 struct Rosenbrock {
     /// Parameter a, usually 1.0
     a: f64,
@@ -26,7 +27,7 @@ struct Rosenbrock {
     /// Random number generator. We use a `Arc<Mutex<_>>` here because `ArgminOperator` requires
     /// `self` to be passed as an immutable reference. This gives us thread safe interior
     /// mutability.
-    rng: Arc<Mutex<XorShiftRng>>,
+    rng: Arc<Mutex<Xoshiro256PlusPlus>>,
 }
 
 impl Default for Rosenbrock {
@@ -45,7 +46,7 @@ impl Rosenbrock {
             b,
             lower_bound,
             upper_bound,
-            rng: Arc::new(Mutex::new(XorShiftRng::from_entropy())),
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
         }
     }
 }
@@ -64,27 +65,23 @@ impl ArgminOp for Rosenbrock {
     /// This function is called by the annealing function
     fn modify(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
         let mut param_n = param.clone();
+        let mut rng = self.rng.lock().unwrap();
+        let distr = Uniform::from(0..param.len());
         // Perform modifications to a degree proportional to the current temperature `temp`.
         for _ in 0..(temp.floor() as u64 + 1) {
             // Compute random index of the parameter vector using the supplied random number
             // generator.
-            let mut rng = self.rng.lock().unwrap();
-            let idx = (*rng).gen_range(0..param.len());
+            let idx = rng.sample(distr);
 
             // Compute random number in [0.1, 0.1].
-            let val = 0.1 * (*rng).gen_range(-1.0..1.0);
+            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1));
 
             // modify previous parameter value at random position `idx` by `val`
-            let tmp = param[idx] + val;
+            param_n[idx] += val;
 
             // check if bounds are violated. If yes, project onto bound.
-            if tmp > self.upper_bound[idx] {
-                param_n[idx] = self.upper_bound[idx];
-            } else if tmp < self.lower_bound[idx] {
-                param_n[idx] = self.lower_bound[idx];
-            } else {
-                param_n[idx] = param[idx] + val;
-            }
+            param_n[idx] = param_n[idx].min(self.upper_bound[idx]);
+            param_n[idx] = param_n[idx].max(self.lower_bound[idx]);
         }
         Ok(param_n)
     }
@@ -98,14 +95,17 @@ fn run() -> Result<(), Error> {
     // Define cost function
     let operator = Rosenbrock::new(1.0, 100.0, lower_bound, upper_bound);
 
-    // definie inital parameter vector
+    // Define initial parameter vector
     let init_param: Vec<f64> = vec![1.0, 1.2];
 
     // Define initial temperature
     let temp = 15.0;
 
+    // Seed RNG
+    let rng = Xoshiro256PlusPlus::from_entropy();
+
     // Set up simulated annealing solver
-    let solver = SimulatedAnnealing::new(temp)?
+    let solver = SimulatedAnnealing::new(temp, rng)?
         // Optional: Define temperature function (defaults to `SATempFunc::TemperatureFast`)
         .temp_func(SATempFunc::Boltzmann)
         /////////////////////////

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -333,5 +333,5 @@ mod tests {
     use super::*;
     use crate::test_trait_impl;
 
-    test_trait_impl!(sa, SimulatedAnnealing<f64>);
+    test_trait_impl!(sa, SimulatedAnnealing<f64, StdRng>);
 }

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -17,7 +17,6 @@
 
 use crate::prelude::*;
 use rand::prelude::*;
-use rand_xorshift::XorShiftRng;
 use serde::{Deserialize, Serialize};
 
 /// Temperature functions for Simulated Annealing.
@@ -57,23 +56,23 @@ impl<F> std::default::Default for SATempFunc<F> {
 ///
 /// [1] S Kirkpatrick, CD Gelatt Jr, MP Vecchi. (1983). "Optimization by Simulated Annealing".
 /// Science 13 May 1983, Vol. 220, Issue 4598, pp. 671-680
-/// DOI: 10.1126/science.220.4598.671  
+/// DOI: 10.1126/science.220.4598.671
 #[derive(Clone, Serialize, Deserialize)]
-pub struct SimulatedAnnealing<F> {
+pub struct SimulatedAnnealing<F, R> {
     /// Initial temperature
     init_temp: F,
     /// which temperature function?
     temp_func: SATempFunc<F>,
-    /// Number of iterations used for the caluclation of temperature. This is needed for
+    /// Number of iterations used for the calculation of temperature. This is needed for
     /// reannealing!
     temp_iter: u64,
     /// Iterations since the last accepted solution
     stall_iter_accepted: u64,
-    /// Stop if stall_iter_accepted exceedes this number
+    /// Stop if stall_iter_accepted exceeds this number
     stall_iter_accepted_limit: u64,
     /// Iterations since the last best solution was found
     stall_iter_best: u64,
-    /// Stop if stall_iter_best exceedes this number
+    /// Stop if stall_iter_best exceeds this number
     stall_iter_best_limit: u64,
     /// Reanneal after this number of iterations is reached
     reanneal_fixed: u64,
@@ -90,10 +89,10 @@ pub struct SimulatedAnnealing<F> {
     /// current temperature
     cur_temp: F,
     /// random number generator
-    rng: XorShiftRng,
+    rng: R,
 }
 
-impl<F> SimulatedAnnealing<F>
+impl<F, R> SimulatedAnnealing<F, R>
 where
     F: ArgminFloat,
 {
@@ -102,7 +101,8 @@ where
     /// Parameter:
     ///
     /// * `init_temp`: initial temperature
-    pub fn new(init_temp: F) -> Result<Self, Error> {
+    /// * `rng`: an RNG (must implement Serialize)
+    pub fn new(init_temp: F, rng: R) -> Result<Self, Error> {
         if init_temp <= F::from_f64(0.0).unwrap() {
             Err(ArgminError::InvalidParameter {
                 text: "Initial temperature must be > 0.".to_string(),
@@ -124,7 +124,7 @@ where
                 reanneal_best: std::u64::MAX,
                 reanneal_iter_best: 0,
                 cur_temp: init_temp,
-                rng: XorShiftRng::from_entropy(),
+                rng,
             })
         }
     }
@@ -225,10 +225,11 @@ where
     }
 }
 
-impl<O, F> Solver<O> for SimulatedAnnealing<F>
+impl<O, F, R> Solver<O> for SimulatedAnnealing<F, R>
 where
     O: ArgminOp<Output = F, Float = F>,
     F: ArgminFloat,
+    R: Rng + Serialize,
 {
     const NAME: &'static str = "Simulated Annealing";
     fn init(
@@ -261,7 +262,6 @@ where
 
         // Make a move
         let new_param = op.modify(&prev_param, self.cur_temp)?;
-        // let new_param = op.modify(&prev_param, self.cur_temp)?;
 
         // Evaluate cost function with new parameter vector
         let new_cost = op.apply(&new_param)?;


### PR DESCRIPTION
Resolves #138.

The old example was overwriting previous `param_n` iterations so I fixed that.

`Rosenbrock` in the example could also allow any RNG if we remove the `Default` implementation.