### PR TITLE
Remove unnecessary semi-colon in macro

### DIFF
--- a/src/core/macros.rs
+++ b/src/core/macros.rs
@@ -31,7 +31,7 @@ macro_rules! check_param {
         }
     };
     ($param:expr, $msg:expr) => {
-        check_param!($param, $msg, NotInitialized);
+        check_param!($param, $msg, NotInitialized)
     };
 }
 


### PR DESCRIPTION
This produces a warning in rustc 1.56.1