### PR TITLE
[fix] simulated anneal always accepts first iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## argmin unreleased (xx xxxxxx xxxx)
+
+- Fixed simulated annealing always accepting the first iteration (#153, @dariogoetz)
+
 ## argmin v0.4.7 (14 August 2021)
 
 - Moved to Github actions (#130, @stefan-k)

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -234,17 +234,23 @@ where
     const NAME: &'static str = "Simulated Annealing";
     fn init(
         &mut self,
-        _op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        op: &mut OpWrapper<O>,
+        state: &IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
-        Ok(Some(ArgminIterData::new().kv(make_kv!(
-            "initial_temperature" => self.init_temp;
-            "stall_iter_accepted_limit" => self.stall_iter_accepted_limit;
-            "stall_iter_best_limit" => self.stall_iter_best_limit;
-            "reanneal_fixed" => self.reanneal_fixed;
-            "reanneal_accepted" => self.reanneal_accepted;
-            "reanneal_best" => self.reanneal_best;
-        ))))
+        let cost = op.apply(&state.get_param())?;
+        Ok(Some(
+            ArgminIterData::new()
+                .param(state.get_param())
+                .cost(cost)
+                .kv(make_kv!(
+                    "initial_temperature" => self.init_temp;
+                    "stall_iter_accepted_limit" => self.stall_iter_accepted_limit;
+                    "stall_iter_best_limit" => self.stall_iter_best_limit;
+                    "reanneal_fixed" => self.reanneal_fixed;
+                    "reanneal_accepted" => self.reanneal_accepted;
+                    "reanneal_best" => self.reanneal_best;
+                )),
+        ))
     }
 
     /// Perform one iteration of SA algorithm


### PR DESCRIPTION
This addresses #150 

It appears to me that the initial `ArgminIterData` returned by the simulated anneal solver's `init` method does not contain values for `param` and `cost`. Hence the `executor`'s state is not being updated upon calling the `solver`'s `init` method. This leads to the state having infinity as starting cost, which makes any first solution preferable.

I have added param and corresponding initial cost to the solver's init method.
