### PR TITLE
Fix counting of sub problem function counts

### DIFF
--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -225,8 +225,7 @@ where
         if self.state.get_iter() < self.state.get_max_iters() && !self.state.terminated() {
             self.state.termination_reason(TerminationReason::Aborted);
         }
-
-        Ok(ArgminResult::new(self.op.get_op(), self.state))
+        Ok(ArgminResult::new(self.op, self.state))
     }
 
     /// Attaches a observer which implements `ArgminLog` to the solver.

--- a/src/core/opwrapper.rs
+++ b/src/core/opwrapper.rs
@@ -12,7 +12,7 @@ use std::default::Default;
 /// This wraps an operator and keeps track of how often the cost, gradient and Hessian have been
 /// computed and how often the modify function has been called. Usually, this is an implementation
 /// detail unless a solver is needed within another solver (such as a line search within a gradient
-/// descent method), then it may be necessary to wrap the operator in an OpWrapper.
+/// descent method).
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct OpWrapper<O: ArgminOp> {
     /// Operator
@@ -30,23 +30,10 @@ pub struct OpWrapper<O: ArgminOp> {
 }
 
 impl<O: ArgminOp> OpWrapper<O> {
-    /// Constructor
+    /// Construct an `OpWrapper` from an operator
     pub fn new(op: O) -> Self {
         OpWrapper {
             op: Some(op),
-            cost_func_count: 0,
-            grad_func_count: 0,
-            hessian_func_count: 0,
-            jacobian_func_count: 0,
-            modify_func_count: 0,
-        }
-    }
-
-    /// Construct struct from other `OpWrapper`. Takes the operator from `op` (replaces it with
-    /// `None`) and crates a new `OpWrapper`
-    pub fn new_from_wrapper(op: &mut OpWrapper<O>) -> Self {
-        OpWrapper {
-            op: op.take_op(),
             cost_func_count: 0,
             grad_func_count: 0,
             hessian_func_count: 0,
@@ -123,34 +110,5 @@ impl<O: ArgminOp> OpWrapper<O> {
     /// Returns the operator `op` by taking ownership of `self`.
     pub fn get_op(self) -> O {
         self.op.unwrap()
-    }
-}
-
-/// The OpWrapper<O> should behave just like any other `ArgminOp`
-impl<O: ArgminOp> ArgminOp for OpWrapper<O> {
-    type Param = O::Param;
-    type Output = O::Output;
-    type Hessian = O::Hessian;
-    type Jacobian = O::Jacobian;
-    type Float = O::Float;
-
-    fn apply(&self, param: &Self::Param) -> Result<Self::Output, Error> {
-        self.op.as_ref().unwrap().apply(param)
-    }
-
-    fn gradient(&self, param: &Self::Param) -> Result<Self::Param, Error> {
-        self.op.as_ref().unwrap().gradient(param)
-    }
-
-    fn hessian(&self, param: &Self::Param) -> Result<Self::Hessian, Error> {
-        self.op.as_ref().unwrap().hessian(param)
-    }
-
-    fn jacobian(&self, param: &Self::Param) -> Result<Self::Jacobian, Error> {
-        self.op.as_ref().unwrap().jacobian(param)
-    }
-
-    fn modify(&self, param: &Self::Param, extent: Self::Float) -> Result<Self::Param, Error> {
-        self.op.as_ref().unwrap().modify(param, extent)
     }
 }

--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -90,19 +90,19 @@ use std::cmp::Ordering;
 #[derive(Clone)]
 pub struct ArgminResult<O: ArgminOp> {
     /// operator
-    pub operator: O,
+    pub operator: OpWrapper<O>,
     /// iteration state
     pub state: IterState<O>,
 }
 
 impl<O: ArgminOp> ArgminResult<O> {
     /// Constructor
-    pub fn new(operator: O, state: IterState<O>) -> Self {
+    pub fn new(operator: OpWrapper<O>, state: IterState<O>) -> Self {
         ArgminResult { operator, state }
     }
 
     /// Return handle to operator
-    pub fn operator(&self) -> &O {
+    pub fn operator(&self) -> &OpWrapper<O> {
         &self.operator
     }
 

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -97,7 +97,7 @@ where
         + ArgminDot<O::Param, O::Float>
         + ArgminNorm<O::Float>,
     O::Hessian: Default,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     B: ArgminNLCGBetaUpdate<O::Param, O::Float>,
     F: ArgminFloat,
 {
@@ -137,7 +137,7 @@ where
         let ArgminResult {
             operator: line_op,
             state: line_state,
-        } = Executor::new(OpWrapper::new_from_wrapper(op), self.linesearch.clone(), xk)
+        } = Executor::new(op.take_op().unwrap(), self.linesearch.clone(), xk)
             .grad(grad.clone())
             .cost(cur_cost)
             .ctrlc(false)

--- a/src/solver/gradientdescent/steepestdescent.rs
+++ b/src/solver/gradientdescent/steepestdescent.rs
@@ -52,7 +52,7 @@ where
         + ArgminSub<O::Param, O::Param>
         + ArgminNorm<O::Float>,
     O::Hessian: Default,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Steepest Descent";
@@ -78,15 +78,11 @@ where
                     cost: next_cost,
                     ..
                 },
-        } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
-            self.linesearch.clone(),
-            param_new,
-        )
-        .grad(new_grad)
-        .cost(new_cost)
-        .ctrlc(false)
-        .run()?;
+        } = Executor::new(op.take_op().unwrap(), self.linesearch.clone(), param_new)
+            .grad(new_grad)
+            .cost(new_cost)
+            .ctrlc(false)
+            .run()?;
 
         // Get back operator and function evaluation counts
         op.consume_op(line_op);

--- a/src/solver/newton/newton_cg.rs
+++ b/src/solver/newton/newton_cg.rs
@@ -88,7 +88,7 @@ where
         + Default
         + ArgminInv<O::Hessian>
         + ArgminDot<O::Param, O::Param>,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat + Default + ArgminDiv<O::Float, O::Float> + ArgminNorm<O::Float> + ArgminConj,
 {
     const NAME: &'static str = "Newton-CG";
@@ -149,15 +149,11 @@ where
                     cost: next_cost,
                     ..
                 },
-        } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
-            self.linesearch.clone(),
-            param,
-        )
-        .grad(grad)
-        .cost(state.get_cost())
-        .ctrlc(false)
-        .run()?;
+        } = Executor::new(op.take_op().unwrap(), self.linesearch.clone(), param)
+            .grad(grad)
+            .cost(state.get_cost())
+            .ctrlc(false)
+            .run()?;
 
         op.consume_op(line_op);
 

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -82,7 +82,7 @@ where
         + ArgminMul<O::Float, O::Hessian>
         + ArgminTranspose<O::Hessian>
         + ArgminEye,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "BFGS";
@@ -126,7 +126,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -73,7 +73,7 @@ where
         + ArgminMul<F, O::Hessian>
         + ArgminTranspose<O::Hessian>
         + ArgminEye,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "DFP";
@@ -119,7 +119,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -83,7 +83,8 @@ where
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
     O::Hessian: Clone + Default + Serialize + DeserializeOwned,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
+    // L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "L-BFGS";
@@ -149,7 +150,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -97,7 +97,7 @@ where
         + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>,
-    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
+    L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "SR1";
@@ -145,7 +145,7 @@ where
                     ..
                 },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.linesearch.clone(),
             param.clone(),
         )

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -121,7 +121,7 @@ where
         + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>,
-    R: ArgminTrustRegion<F> + Solver<OpWrapper<O>>,
+    R: ArgminTrustRegion<F> + Solver<O>,
     F: ArgminFloat + ArgminNorm<O::Float>,
 {
     const NAME: &'static str = "SR1 Trust Region";
@@ -164,9 +164,8 @@ where
             operator: sub_op,
             state: IterState { param: sk, .. },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.subproblem.clone(),
-            // xk.clone(),
             xk.zero_like(),
         )
         .cost(cost)

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -105,7 +105,7 @@ where
         + ArgminZeroLike
         + ArgminMul<F, O::Param>,
     O::Hessian: Default + Clone + Debug + Serialize + ArgminDot<O::Param, O::Param>,
-    R: ArgminTrustRegion<F> + Solver<OpWrapper<O>>,
+    R: ArgminTrustRegion<F> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Trust region";
@@ -148,7 +148,7 @@ where
             operator: sub_op,
             state: IterState { param: pk, .. },
         } = Executor::new(
-            OpWrapper::new_from_wrapper(op),
+            op.take_op().unwrap(),
             self.subproblem.clone(),
             param.clone(),
         )
@@ -157,8 +157,7 @@ where
         .ctrlc(false)
         .run()?;
 
-        // Operator must be consumed again, otherwise the operator, which moved into the subproblem
-        // executor as well as the function evaluation counts are lost.
+        // Consume intermediate operator again. This takes care of the function evaluation counts.
         op.consume_op(sub_op);
 
         let new_param = pk.add(&param);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -141,5 +141,8 @@ fn test_lbfgs_func_count() {
     assert!(res.state.cost_func_count <= 7);
     // The following value is 5 in scipy.optimize, but the convergence
     // criteria is different
-    assert!(res.state.grad_func_count <= 6);
+    // assert!(res.state.grad_func_count <= 6);
+    // NOTE: Changed to 11, because LBFGS now correctly includes the number of evaluations
+    // performed in the linesearch.
+    assert!(res.state.grad_func_count <= 11);
 }


### PR DESCRIPTION
The function evaluation counts of sub problems were not correctly added to the function evaluation counts of the main solver. This was fixed by removing one unnecessary layer of `OpWrapper` when setting up subproblems. This allowed for simplifying the `OpWrapper` implementation as well.

Addresses #154 