### PR TITLE
Update LineSearchCondition trait to use references

### DIFF
--- a/src/solver/linesearch/backtracking.rs
+++ b/src/solver/linesearch/backtracking.rs
@@ -11,6 +11,7 @@ use crate::prelude::*;
 use crate::solver::linesearch::condition::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 /// The Backtracking line search is a simple method to find a step length which obeys the Armijo
 /// (sufficient decrease) condition.
@@ -171,10 +172,14 @@ where
     fn terminate(&mut self, state: &IterState<O>) -> TerminationReason {
         if self.condition.eval(
             state.get_cost(),
-            state.get_grad().unwrap_or_default(),
+            &state
+                .get_grad()
+                .as_ref()
+                .map(Cow::Borrowed)
+                .unwrap_or_else(|| Cow::Owned(P::default())),
             self.init_cost,
-            self.init_grad.clone(),
-            self.search_direction.clone().unwrap(),
+            &self.init_grad,
+            self.search_direction.as_ref().unwrap(),
             self.alpha,
         ) {
             TerminationReason::LineSearchConditionMet

--- a/src/solver/linesearch/condition.rs
+++ b/src/solver/linesearch/condition.rs
@@ -19,10 +19,10 @@ pub trait LineSearchCondition<T, F>: Serialize {
     fn eval(
         &self,
         cur_cost: F,
-        cur_grad: T,
+        cur_grad: &T,
         init_cost: F,
-        init_grad: T,
-        search_direction: T,
+        init_grad: &T,
+        search_direction: &T,
         alpha: F,
     ) -> bool;
 
@@ -57,13 +57,13 @@ where
     fn eval(
         &self,
         cur_cost: F,
-        _cur_grad: T,
+        _cur_grad: &T,
         init_cost: F,
-        init_grad: T,
-        search_direction: T,
+        init_grad: &T,
+        search_direction: &T,
         alpha: F,
     ) -> bool {
-        cur_cost <= init_cost + self.c * alpha * init_grad.dot(&search_direction)
+        cur_cost <= init_cost + self.c * alpha * init_grad.dot(search_direction)
     }
 
     fn requires_cur_grad(&self) -> bool {
@@ -105,15 +105,15 @@ where
     fn eval(
         &self,
         cur_cost: F,
-        cur_grad: T,
+        cur_grad: &T,
         init_cost: F,
-        init_grad: T,
-        search_direction: T,
+        init_grad: &T,
+        search_direction: &T,
         alpha: F,
     ) -> bool {
-        let tmp = init_grad.dot(&search_direction);
+        let tmp = init_grad.dot(search_direction);
         (cur_cost <= init_cost + self.c1 * alpha * tmp)
-            && cur_grad.dot(&search_direction) >= self.c2 * tmp
+            && cur_grad.dot(search_direction) >= self.c2 * tmp
     }
 
     fn requires_cur_grad(&self) -> bool {
@@ -155,15 +155,15 @@ where
     fn eval(
         &self,
         cur_cost: F,
-        cur_grad: T,
+        cur_grad: &T,
         init_cost: F,
-        init_grad: T,
-        search_direction: T,
+        init_grad: &T,
+        search_direction: &T,
         alpha: F,
     ) -> bool {
-        let tmp = init_grad.dot(&search_direction);
+        let tmp = init_grad.dot(search_direction);
         (cur_cost <= init_cost + self.c1 * alpha * tmp)
-            && cur_grad.dot(&search_direction).abs() <= self.c2 * tmp.abs()
+            && cur_grad.dot(search_direction).abs() <= self.c2 * tmp.abs()
     }
 
     fn requires_cur_grad(&self) -> bool {
@@ -198,13 +198,13 @@ where
     fn eval(
         &self,
         cur_cost: F,
-        _cur_grad: T,
+        _cur_grad: &T,
         init_cost: F,
-        init_grad: T,
-        search_direction: T,
+        init_grad: &T,
+        search_direction: &T,
         alpha: F,
     ) -> bool {
-        let tmp = alpha * init_grad.dot(&search_direction);
+        let tmp = alpha * init_grad.dot(search_direction);
         init_cost + (F::from_f64(1.0).unwrap() - self.c) * tmp <= cur_cost
             && cur_cost <= init_cost + self.c * alpha * tmp
     }


### PR DESCRIPTION
Currently the `LineSearchCondition` takes its vector arguments by value. Consequently, the line search always has to explicitly clone the gradient / search direction vectors. For larger systems this might be expensive, especially if many line search iterations are needed. I don't see a reason why an explicit clone should be enforced by the interface. Therefor, I would propose to change the trait to accept references.