### PR TITLE
WASM builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: argmin CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,3 +46,32 @@ jobs:
           override: true
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
+  
+  wasm-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Install toolchains
+        run: |
+          rustup target add wasm32-unknown-unknown
+          rustup target add wasm32-unknown-emscripten
+          rustup target add wasm32-wasi
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
+      - name: Build target wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown --features wasm-bindgen
+      - name: Build target wasm32-wasi with feature stdweb
+        run: cargo build --target wasm32-wasi --features stdweb
+      - name: Build target wasm32-wasi with feature wasm-bindgen
+        run: cargo build --target wasm32-wasi --features wasm-bindgen
+      - name: Build target wasm32-unknown-emscripten
+        run: cargo build --target wasm32-unknown-emscripten --no-default-features --features wasm-bindgen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ approx = "0.5.0"
 bincode = "1.1.4"
 ctrlc = { version = "3.1.2", optional = true }
 instant = {version = "0.1", features = ["now"] }
-gnuplot = { version = "0.0.37", optional = true}
+gnuplot = { version = "0.0.37", optional = true }
+getrandom = { version = "0.2", features = ["js"] }
 paste = "1.0.0"
 nalgebra = { version = "0.30.0", optional = true, features = ["serde-serialize"] }
 ndarray = { version = "0.15", optional = true, features = ["serde-1"] }
 ndarray-linalg = { version = "0.14", optional = true }
 ndarray-rand = {version = "0.14.0", optional = true }
 num = { version = "0.4" }
-num-complex = "0.4"
+num-complex = { version = "0.4" }
 rand = { version = "0.8.3", features = ["serde1"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ slog-json = { version = "2.3.0", optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]
-ndarray-linalg = { version = "0.14", features = ["openblas"] }
+ndarray-linalg = { version = "0.14", features = ["netlib"] }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
 argmin_testfunctions = "0.1.1"
 rand_xoshiro = { version = "0.6.0", features = ["serde1"] }


### PR DESCRIPTION
This adds building for various WASM targets in the CI. Its likely far from perfect, but it should be able to catch a couple of things that could go wrong. 

Also includes changes which were necessary due to closing #148 and uses `netlib` instead of `openblas` in the tests (needed by `ndarray-linalg`) which hopefully fixes the problem that the CI regularly, but not always, crashes during compilation of `openblas`. 