### PR TITLE
Configure CircleCI to not send emails when pushing to gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - lint
+      - lint:
+        filters:
+          branches:
+            ignore: gh-pages


### PR DESCRIPTION
Avoids running the CircleCI pipeline when deploying the docs.