### PR TITLE
Faster CI by removing unnecessary `cargo clean`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
           override: true
       - name: Install dependencies
         run: sudo apt-get install cmake gfortran libelf-dev libdw-dev binutils-dev libiberty-dev liblapacke-dev libopenblas-dev gcc
-      - run: cargo build --verbose --all --all-features && cargo clean && cargo test --verbose --all --all-features
+      - name: Build
+        run: cargo build --verbose --all --all-features
+      - name: Test
+        run: cargo test --verbose --all --all-features
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In the past there was a problem on Travis CI which (apparently) could be fixed by cleaning between build and test. Obviously this slows everything down. I assume this "fix" is not necessary anymore. 