### PR TITLE
Make serde an optional dependency behind feature gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,38 @@ jobs:
           override: true
       - name: Install dependencies
         run: sudo apt-get install cmake gfortran libelf-dev libdw-dev binutils-dev libiberty-dev liblapacke-dev libopenblas-dev gcc
-      - name: Build
+      - name: Build (default features)
+        run: cargo build --verbose --all
+      - name: Test (default features)
+        run: cargo test --verbose --all
+      - name: Build (all features)
         run: cargo build --verbose --all --all-features
-      - name: Test
+      - name: Test (all features)
         run: cargo test --verbose --all --all-features
+
+  test-serde1-feature:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Build (no default features)
+        run: cargo build --verbose --all --no-default-features
+      - name: Test (no default features)
+        run: cargo test --verbose --all --no-default-features
+      - name: Test with serde1 feature
+        run: cargo test --verbose --all --no-default-features --features "serde1"
+      - name: Test with slog-logger feature
+        run: cargo test --verbose --all --no-default-features --features "slog-logger"
 
   clippy:
     runs-on: ubuntu-latest
@@ -48,7 +76,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Clippy with default features
+        run: cargo clippy --all-targets -- -D warnings
+      - name: Clippy without default features
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
+      - name: Clippy without serde1 feature
+        run: cargo clippy --all-targets --no-default-features --features="ndarrayl,nalgebral,visualizer,slog-logger" -- -D warnings
+      - name: Clippy with all features
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,118 +17,122 @@ exclude = [
 ]
 
 [dependencies]
+# Required
 anyhow = "1.0"
 approx = "0.5.0"
-bincode = "1.1.4"
-ctrlc = { version = "3.1.2", optional = true }
 instant = {version = "0.1", features = ["now"] }
-gnuplot = { version = "0.0.37", optional = true }
 getrandom = { version = "0.2", features = ["js"] }
 paste = "1.0.0"
-nalgebra = { version = "0.30.0", optional = true, features = ["serde-serialize"] }
-ndarray = { version = "0.15", optional = true, features = ["serde-1"] }
+num-traits = { version = "0.2" }
+num-integer = { version = "0.1" }
+num-complex = { version = "0.4", default-features = false, features = ["std"] }
+rand = { version = "0.8.3"}
+thiserror = "1.0"
+# optional
+bincode = { version = "1.1.4", optional = true }
+ctrlc = { version = "3.1.2", optional = true }
+gnuplot = { version = "0.0.37", optional = true }
+nalgebra = { version = "0.30.0", optional = true }
+ndarray = { version = "0.15", optional = true }
 ndarray-linalg = { version = "0.14", optional = true }
 ndarray-rand = {version = "0.14.0", optional = true }
-num = { version = "0.4" }
-num-complex = { version = "0.4" }
-rand = { version = "0.8.3", features = ["serde1"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = "1.0"
+serde = { version = "1.0", features = ["derive", "rc"], optional = true }
+serde_json = { version = "1.0", optional = true }
 slog = { version = "2.4.1", optional = true }
 slog-term = { version = "2.4.0", optional = true }
 slog-async = { version = "2.3.0", optional = true }
 slog-json = { version = "2.3.0", optional = true }
-thiserror = "1.0"
 
 [dev-dependencies]
 ndarray-linalg = { version = "0.14", features = ["netlib"] }
-finitediff = { version = "0.1.4", features = ["ndarray"] }
+finitediff = { version = "0.1.4" }
 argmin_testfunctions = "0.1.1"
-rand_xoshiro = { version = "0.6.0", features = ["serde1"] }
+rand_xoshiro = { version = "0.6.0" }
 
 [features]
-default = ["slog-logger"]
+default = ["slog-logger", "serde1"]
 nalgebral = ["nalgebra"]
-ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand"]
+ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand", "finitediff/ndarray"]
 visualizer = ["gnuplot"]
 wasm-bindgen = ["instant/wasm-bindgen"]
-slog-logger = ["slog", "slog-term", "slog-async", "slog-json"]
+slog-logger = ["slog", "slog-term", "slog-async"]
 stdweb = ["instant/stdweb"]
+serde1 = ["serde", "serde_json", "nalgebra/serde-serialize", "ndarray/serde-1", "rand/serde1", "bincode", "rand_xoshiro/serde1", "num-complex/serde", "slog-json"]
 
 [badges]
 maintenance = { status = "actively-developed" }
 
 [[example]]
 name = "backtracking"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "bfgs"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "brent"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "checkpoint"
-required-features = []
+required-features = ["serde1", "slog-logger"]
 
 [[example]]
 name = "conjugategradient"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "dfp"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "gaussnewton"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "gaussnewton_linesearch"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "gaussnewton_nalgebra"
-required-features = ["nalgebral"]
+required-features = ["nalgebral", "slog-logger"]
 
 [[example]]
 name = "goldensectionsearch"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "hagerzhang"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "landweber"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "lbfgs"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "morethuente"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "neldermead"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "newton"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "newton_cg"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "nonlinear_cg"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "particleswarm"
@@ -136,24 +140,24 @@ required-features = []
 
 [[example]]
 name = "simulatedannealing"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "sr1"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "sr1_trustregion"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "steepestdescent"
-required-features = []
+required-features = ["slog-logger"]
 
 [[example]]
 name = "trustregion_nd"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "slog-logger"]
 
 [[example]]
 name = "writers"
-required-features = ["ndarrayl"]
+required-features = ["ndarrayl", "serde1"]

--- a/src/core/iterstate.rs
+++ b/src/core/iterstate.rs
@@ -7,12 +7,14 @@
 
 use crate::core::{ArgminOp, OpWrapper, TerminationReason};
 use instant;
-use num::traits::float::Float;
+use num_traits::Float;
 use paste::item;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// Maintains the state from iteration to iteration of a solver
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct IterState<O: ArgminOp> {
     /// Current parameter vector
     pub param: O::Param,

--- a/src/core/kv.rs
+++ b/src/core/kv.rs
@@ -13,14 +13,16 @@
 //!   * Either use something existing, or at least evaluate the performance and if necessary,
 //!     improve performance.
 
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std;
 
 /// A simple key-value storage
-#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ArgminKV {
     /// The actual key value storage
-    #[serde(borrow)]
+    #[cfg_attr(feature = "serde1", serde(borrow))]
     pub kv: Vec<(&'static str, String)>,
 }
 

--- a/src/core/math/dot_nalgebra.rs
+++ b/src/core/math/dot_nalgebra.rs
@@ -7,7 +7,7 @@
 
 use crate::core::math::ArgminDot;
 
-use num::{One, Zero};
+use num_traits::{One, Zero};
 
 use nalgebra::{
     base::{

--- a/src/core/math/eye_nalgebra.rs
+++ b/src/core/math/eye_nalgebra.rs
@@ -7,7 +7,7 @@
 
 use crate::core::math::ArgminEye;
 
-use num::{One, Zero};
+use num_traits::{One, Zero};
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim},

--- a/src/core/math/norm_ndarray.rs
+++ b/src/core/math/norm_ndarray.rs
@@ -7,8 +7,8 @@
 
 use crate::core::math::ArgminNorm;
 use ndarray::Array1;
-use num::integer::Roots;
 use num_complex::Complex;
+use num_integer::Roots;
 
 macro_rules! make_norm_float {
     ($t:ty) => {

--- a/src/core/math/norm_vec.rs
+++ b/src/core/math/norm_vec.rs
@@ -6,8 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::math::ArgminNorm;
-use num::integer::Roots;
 use num_complex::Complex;
+use num_integer::Roots;
 
 macro_rules! make_norm_float {
     ($t:ty) => {

--- a/src/core/math/zero_nalgebra.rs
+++ b/src/core/math/zero_nalgebra.rs
@@ -7,7 +7,7 @@
 
 use crate::core::math::{ArgminZero, ArgminZeroLike};
 
-use num::Zero;
+use num_traits::Zero;
 
 use nalgebra::{
     base::{allocator::Allocator, dimension::Dim},

--- a/src/core/math/zero_ndarray.rs
+++ b/src/core/math/zero_ndarray.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::math::{ArgminZero, ArgminZeroLike};
-use num::Zero;
+use num_traits::Zero;
 
 impl<T> ArgminZeroLike for ndarray::Array1<T>
 where

--- a/src/core/nooperator.rs
+++ b/src/core/nooperator.rs
@@ -5,17 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{ArgminFloat, ArgminOp, Error};
-use serde::de::DeserializeOwned;
+use crate::core::{ArgminFloat, ArgminOp, DeserializeOwnedAlias, Error, SerializeAlias};
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display};
 
 /// Fake Operators for testing
 
 /// No-op operator with free choice of the types
-#[derive(
-    Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Copy,
-)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct NoOperator<T, U, H, J, F> {
     /// Fake parameter
     param: std::marker::PhantomData<T>,
@@ -51,10 +50,10 @@ impl<T, U, H, J, F> Display for NoOperator<T, U, H, J, F> {
 
 impl<T, U, H, J, F> ArgminOp for NoOperator<T, U, H, J, F>
 where
-    T: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
-    U: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
-    H: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
-    J: Clone + Default + Debug + Send + Sync + Serialize + DeserializeOwned,
+    T: Clone + Default + Debug + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
+    U: Clone + Default + Debug + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
+    H: Clone + Default + Debug + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
+    J: Clone + Default + Debug + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
     F: ArgminFloat,
 {
     type Param = T;
@@ -85,9 +84,8 @@ where
 }
 
 /// Minimal No-op operator which does nothing, really.
-#[derive(
-    Clone, Default, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, Copy,
-)]
+#[derive(Clone, Default, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Copy)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct MinimalNoOperator {}
 
 /// No-op operator with fixed types (See `ArgminOp` impl on `MinimalNoOperator`)

--- a/src/core/observers/mod.rs
+++ b/src/core/observers/mod.rs
@@ -11,6 +11,7 @@
 //! the current state of the optimization. This can be used for logging or writing the current
 //! parameter vector to disk.
 
+#[cfg(feature = "serde1")]
 pub mod file;
 #[cfg(feature = "slog-logger")]
 pub mod slog_logger;
@@ -18,10 +19,12 @@ pub mod slog_logger;
 pub mod visualizer;
 
 use crate::core::{ArgminKV, ArgminOp, Error, IterState};
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "serde1")]
 pub use file::*;
 #[cfg(feature = "slog-logger")]
 pub use slog_logger::*;
@@ -118,7 +121,8 @@ impl<O: ArgminOp> Observe<O> for Observer<O> {
 /// This is used to indicate how often the observer will observe the status. `Never` deactivates
 /// the observer, `Always` and `Every(i)` will call the observer in every or every ith iteration,
 /// respectively. `NewBest` will call the observer only, if a new best solution is found.
-#[derive(Copy, Clone, Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub enum ObserverMode {
     /// Never call the observer
     Never,

--- a/src/core/observers/slog_logger.rs
+++ b/src/core/observers/slog_logger.rs
@@ -12,9 +12,12 @@ use slog;
 use slog::{info, o, Drain, Record, Serializer, KV};
 use slog_async;
 use slog_async::OverflowStrategy;
+#[cfg(feature = "serde1")]
 use slog_json;
 use slog_term;
+#[cfg(feature = "serde1")]
 use std::fs::OpenOptions;
+#[cfg(feature = "serde1")]
 use std::sync::Mutex;
 
 /// A logger based on `slog`
@@ -55,6 +58,9 @@ impl ArgminSlogLogger {
     ///
     /// If `truncate` is set to `true`, the content of existing log files at `file` will be
     /// cleared.
+    ///
+    /// Only available when the `serde1` feature is set.
+    #[cfg(feature = "serde1")]
     pub fn file(file: &str, truncate: bool) -> Result<Self, Error> {
         ArgminSlogLogger::file_internal(file, OverflowStrategy::Block, truncate)
     }
@@ -63,11 +69,17 @@ impl ArgminSlogLogger {
     ///
     /// If `truncate` is set to `true`, the content of existing log files at `file` will be
     /// cleared.
+    ///
+    /// Only available when the `serde1` feature is set.
+    #[cfg(feature = "serde1")]
     pub fn file_noblock(file: &str, truncate: bool) -> Result<Self, Error> {
         ArgminSlogLogger::file_internal(file, OverflowStrategy::Drop, truncate)
     }
 
+    #[cfg(feature = "serde1")]
     /// Actual implementaiton of logging JSON to file
+    ///
+    /// Only available when the `serde1` feature is set.
     fn file_internal(
         file: &str,
         overflow_strategy: OverflowStrategy,

--- a/src/core/opwrapper.rs
+++ b/src/core/opwrapper.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::{ArgminOp, Error};
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -13,7 +14,8 @@ use std::default::Default;
 /// computed and how often the modify function has been called. Usually, this is an implementation
 /// detail unless a solver is needed within another solver (such as a line search within a gradient
 /// descent method).
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct OpWrapper<O: ArgminOp> {
     /// Operator
     pub op: Option<O>,

--- a/src/core/result.rs
+++ b/src/core/result.rs
@@ -15,71 +15,76 @@
 //!
 //! ## Examples:
 //!
-//! ```
-//! # #![allow(unused_imports)]
-//! # extern crate argmin;
-//! # extern crate argmin_testfunctions;
-//! # use argmin::prelude::*;
-//! # use argmin::solver::gradientdescent::SteepestDescent;
-//! # use argmin::solver::linesearch::MoreThuenteLineSearch;
-//! # use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
-//! # use serde::{Deserialize, Serialize};
-//! #
-//! # #[derive(Clone, Default, Serialize, Deserialize)]
-//! # struct Rosenbrock {
-//! #     a: f64,
-//! #     b: f64,
-//! # }
-//! #
-//! # impl ArgminOp for Rosenbrock {
-//! #     type Param = Vec<f64>;
-//! #     type Output = f64;
-//! #     type Hessian = ();
-//! #     type Jacobian = ();
-//! #     type Float = f64;
-//! #
-//! #     fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
-//! #         Ok(rosenbrock_2d(p, self.a, self.b))
-//! #     }
-//! #
-//! #     fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
-//! #         Ok(rosenbrock_2d_derivative(p, self.a, self.b))
-//! #     }
-//! # }
-//! #
-//! # fn run() -> Result<(), Error> {
-//! #     // Define cost function (must implement `ArgminOperator`)
-//! #     let cost = Rosenbrock { a: 1.0, b: 100.0 };
-//! #     // Define initial parameter vector
-//! #     let init_param: Vec<f64> = vec![-1.2, 1.0];
-//! #     // Set up line search
-//! #     let linesearch = MoreThuenteLineSearch::new();
-//! #     // Set up solver
-//! #     let solver = SteepestDescent::new(linesearch);
-//! #     // Run solver
-//! #     let result = Executor::new(cost, solver, init_param)
-//! #         // Set maximum iterations to 10
-//! #         .max_iters(1)
-//! #         // run the solver on the defined problem
-//! #         .run()?;
-//! // Get best parameter vector
-//! let best_parameter = result.state().get_best_param();
-//!
-//! // Get best cost function value
-//! let best_cost = result.state().get_best_cost();
-//!
-//! // Get the number of iterations
-//! let num_iters = result.state().get_iter();
-//! #     Ok(())
-//! # }
-//! #
-//! # fn main() {
-//! #     if let Err(ref e) = run() {
-//! #         println!("{}", e);
-//! #         std::process::exit(1);
-//! #     }
-//! # }
-//! ```
+#![cfg_attr(
+    feature = "serde1",
+    doc = r##"
+```
+# #![allow(unused_imports)]
+# extern crate argmin;
+# extern crate argmin_testfunctions;
+# use argmin::prelude::*;
+# use argmin::solver::gradientdescent::SteepestDescent;
+# use argmin::solver::linesearch::MoreThuenteLineSearch;
+# use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
+# use serde::{Deserialize, Serialize};
+#
+# #[derive(Clone, Default, Serialize, Deserialize)]
+# struct Rosenbrock {
+#     a: f64,
+#     b: f64,
+# }
+#
+# impl ArgminOp for Rosenbrock {
+#     type Param = Vec<f64>;
+#     type Output = f64;
+#     type Hessian = ();
+#     type Jacobian = ();
+#     type Float = f64;
+#
+#     fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
+#         Ok(rosenbrock_2d(p, self.a, self.b))
+#     }
+#
+#     fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+#         Ok(rosenbrock_2d_derivative(p, self.a, self.b))
+#     }
+# }
+#
+# fn run() -> Result<(), Error> {
+#     // Define cost function (must implement `ArgminOperator`)
+#     let cost = Rosenbrock { a: 1.0, b: 100.0 };
+#     // Define initial parameter vector
+#     let init_param: Vec<f64> = vec![-1.2, 1.0];
+#     // Set up line search
+#     let linesearch = MoreThuenteLineSearch::new();
+#     // Set up solver
+#     let solver = SteepestDescent::new(linesearch);
+#     // Run solver
+#     let result = Executor::new(cost, solver, init_param)
+#         // Set maximum iterations to 10
+#         .max_iters(1)
+#         // run the solver on the defined problem
+#         .run()?;
+// Get best parameter vector
+let best_parameter = result.state().get_best_param();
+
+// Get best cost function value
+let best_cost = result.state().get_best_cost();
+
+// Get the number of iterations
+let num_iters = result.state().get_iter();
+#     Ok(())
+# }
+#
+# fn main() {
+#     if let Err(ref e) = run() {
+#         println!("{}", e);
+#         std::process::exit(1);
+#     }
+# }
+```
+"##
+)]
 //!
 //! More details can be found in the `IterState` documentation.
 

--- a/src/core/serialization.rs
+++ b/src/core/serialization.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{ArgminError, Error};
-use serde::de::DeserializeOwned;
+use crate::core::{ArgminError, DeserializeOwnedAlias, Error, SerializeAlias};
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use std::fmt::Display;
@@ -118,7 +117,7 @@ impl ArgminCheckpoint {
 
     /// Write checkpoint to disk
     #[inline]
-    pub fn store<T: Serialize>(&self, executor: &T, filename: &str) -> Result<(), Error> {
+    pub fn store<T: SerializeAlias>(&self, executor: &T, filename: &str) -> Result<(), Error> {
         let dir = Path::new(&self.directory);
         if !dir.exists() {
             std::fs::create_dir_all(&dir)?
@@ -132,7 +131,7 @@ impl ArgminCheckpoint {
 
     /// Write checkpoint based on the desired `CheckpointMode`
     #[inline]
-    pub fn store_cond<T: Serialize>(&self, executor: &T, iter: u64) -> Result<(), Error> {
+    pub fn store_cond<T: SerializeAlias>(&self, executor: &T, iter: u64) -> Result<(), Error> {
         match self.mode {
             CheckpointMode::Always => self.store(executor, &self.filename)?,
             CheckpointMode::Every(it) if iter % it == 0 => self.store(executor, &self.filename)?,
@@ -143,7 +142,7 @@ impl ArgminCheckpoint {
 }
 
 /// Load a checkpoint from disk
-pub fn load_checkpoint<T: DeserializeOwned, P: AsRef<Path>>(path: P) -> Result<T, Error> {
+pub fn load_checkpoint<T: DeserializeOwnedAlias, P: AsRef<Path>>(path: P) -> Result<T, Error> {
     let path = path.as_ref();
     if !path.exists() {
         return Err(ArgminError::CheckpointNotFound {

--- a/src/core/termination.rs
+++ b/src/core/termination.rs
@@ -14,10 +14,12 @@
 //!     would allow implementers of solvers to define their own `TerminationReason`s. However, this
 //!     would require a lot of work.
 
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// Indicates why the optimization algorithm stopped
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub enum TerminationReason {
     /// In case it has not terminated yet
     NotTerminated,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,22 @@
 //! argmin = "0.5.0"
 //! ```
 //!
-//! ## Optional features
+//! or, for the current development version:
 //!
-//! ### Recommended features
+//! ```toml
+//! [dependencies]
+//! argmin = { git = "https://github.com/argmin-rs/argmin" }
+//! ```
+//!
+//! ## Features
+//!
+//! ### Default features
+//!
+//! - `slog-logger`: Support for logging using `slog`
+//! - `serde1`: Support for `serde`. Needed for checkpointing and writing parameters to disk as
+//! well as logging to disk.
+//!
+//! ### Additional features
 //!
 //! There are additional features which can be activated in `Cargo.toml`:
 //!
@@ -99,11 +112,8 @@
 //! argmin = { version = "0.5.0", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 //! ```
 //!
-//! These may become default features in the future. Without these features compilation to
-//! `wasm32-unknown-unkown` seems to be possible.
-//!
 //! - `ctrlc`: Uses the `ctrlc` crate to properly stop the optimization (and return the current best
-//!    result) after pressing Ctrl+C.
+//!    result) after pressing Ctrl+C during an optimization run.
 //! - `ndarrayl`: Support for `ndarray`, `ndarray-linalg` and `ndarray-rand`.
 //! - `nalgebral`: Support for `nalgebra`.
 //!
@@ -126,17 +136,24 @@
 //! argmin = { version = "0.5.0", features = ["stdweb"] }
 //! ```
 //!
-//! Note that WASM support is still experimental. Please report any issues you encounter when compiling argmin to WASM.
+//! WASM support is still experimental. Please report any issues you encounter when compiling argmin
+//! to WASM.
+//!
+//! ### Compiling without `serde` dependency
+//!
+//! The `serde` dependency can be removed by turning off the `serde1` feature, for instance like so:
+//!
+//! ```toml
+//! [dependencies]
+//! argmin = { version = "0.5.0", default-features = false, features = ["slog-logger"] }
+//! ```
+//!
+//! Note that this will remove the ability to write parameters and logs to disk as well as
+//! checkpointing.
 //!
 //! ## Running the tests and building the examples
 //!
-//! Running the tests requires the `ndarrayl` and feature to be enabled:
-//!
-//! ```bash
-//! cargo test --features "ndarrayl"
-//! ```
-//!
-//! The examples require all features to be enabled:
+//! The tests and examples require all features to be enabled:
 //!
 //! ```bash
 //! cargo test --features --all-features
@@ -166,7 +183,6 @@
 //! ```rust
 //! # extern crate argmin;
 //! # extern crate argmin_testfunctions;
-//! # extern crate ndarray;
 //! use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative, rosenbrock_2d_hessian};
 //! use argmin::prelude::*;
 //!
@@ -263,16 +279,18 @@
 //!  
 //! // Run solver
 //! let res = Executor::new(cost, solver, init_param)
+//! # ;
+//! # #[cfg(feature = "slog-logger")]
+//! # let res = res
 //!     // Add an observer which will log all iterations to the terminal
 //!     .add_observer(ArgminSlogLogger::term(), ObserverMode::Always)
+//! # ;
+//! # let res = res
 //!     // Set maximum iterations to 10
 //!     .max_iters(10)
 //!     // run the solver on the defined problem
 //!     .run()?;
 //! #
-//! #     // Wait a second (lets the logger flush everything first)
-//! #     std::thread::sleep(instant::Duration::from_secs(1));
-//!  
 //! // print result
 //! println!("{}", res);
 //! #     Ok(())
@@ -347,12 +365,21 @@
 //! # let solver = SteepestDescent::new(linesearch);
 //! #
 //! let res = Executor::new(problem, solver, init_param)
+//! # ;
+//! # #[cfg(feature = "slog-logger")]
+//! let res = res
 //!     // Add an observer which will log all iterations to the terminal (without blocking)
 //!     .add_observer(ArgminSlogLogger::term_noblock(), ObserverMode::Always)
+//! # ;
+//! # #[cfg(feature = "serde1")]
+//! # #[cfg(feature = "slog-logger")]
+//! # let res = res
 //!     // Log to file whenever a new best solution is found
 //!     .add_observer(ArgminSlogLogger::file("solver.log", false)?, ObserverMode::NewBest)
 //!     // Write parameter vector to `params/param.arg` every 20th iteration
 //!     .add_observer(WriteToFile::new("params", "param"), ObserverMode::Every(20))
+//! # ;
+//! # let res = res
 //! #     .max_iters(2)
 //!     // run the solver on the defined problem
 //!     .run()?;
@@ -417,6 +444,7 @@
 //! #     let iters = 35;
 //! #     let solver = Landweber::new(0.001);
 //! #
+//! # #[cfg(feature = "serde1")]
 //! let res = Executor::from_checkpoint(".checkpoints/optim.arg", Rosenbrock {})
 //!     .unwrap_or(Executor::new(Rosenbrock {}, solver, init_param))
 //!     .max_iters(iters)
@@ -425,9 +453,6 @@
 //!     .checkpoint_mode(CheckpointMode::Every(20))
 //!     .run()?;
 //! #
-//! #     // Wait a second (lets the logger flush everything before printing to screen again)
-//! #     std::thread::sleep(instant::Duration::from_secs(1));
-//! #     println!("{}", res);
 //! #     Ok(())
 //! # }
 //! #
@@ -457,12 +482,13 @@
 //!
 //! ```rust
 //! use argmin::prelude::*;
+//! #[cfg(feature = "serde1")]
 //! use serde::{Deserialize, Serialize};
 //!
 //! // Define a struct which holds any parameters/data which are needed during the execution of the
 //! // solver. Note that this does not include parameter vectors, gradients, Hessians, cost
 //! // function values and so on, as those will be handled by the `Executor`.
-//! #[derive(Serialize, Deserialize)]
+//! #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 //! pub struct Landweber<F> {
 //!     /// omega
 //!     omega: F,
@@ -553,4 +579,5 @@ pub mod solver;
 mod macros;
 
 #[cfg(test)]
+#[cfg(feature = "ndarrayl")]
 mod tests;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,4 +10,4 @@
 //! Put `argmin::prelude::*` on top of your code to get all relevant traits into scope.
 
 pub use crate::core::*;
-pub use num::traits::*;
+pub use num_traits::*;

--- a/src/solver/brent/mod.rs
+++ b/src/solver/brent/mod.rs
@@ -19,6 +19,7 @@
 /// Implementation of Brent's optimization method,
 /// see <https://en.wikipedia.org/wiki/Brent%27s_method>
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -38,7 +39,8 @@ pub enum BrentError {
 ///
 /// # References:
 /// <https://en.wikipedia.org/wiki/Brent%27s_method>
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Brent<F> {
     /// required relative accuracy
     tol: F,

--- a/src/solver/conjugategradient/beta.rs
+++ b/src/solver/conjugategradient/beta.rs
@@ -15,13 +15,13 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// Fletcher and Reeves (FR) method
 /// TODO: Reference
-#[derive(
-    Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug,
-)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct FletcherReeves {}
 
 impl FletcherReeves {
@@ -43,9 +43,8 @@ where
 
 /// Polak and Ribiere (PR) method
 /// TODO: Reference
-#[derive(
-    Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug,
-)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibiere {}
 
 impl PolakRibiere {
@@ -68,9 +67,8 @@ where
 
 /// Polak and Ribiere Plus (PR+) method
 /// TODO: Reference
-#[derive(
-    Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug,
-)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibierePlus {}
 
 impl PolakRibierePlus {
@@ -94,9 +92,8 @@ where
 
 /// Hestenes and Stiefel (HS) method
 /// TODO: Reference
-#[derive(
-    Default, Serialize, Deserialize, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug,
-)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct HestenesStiefel {}
 
 impl HestenesStiefel {

--- a/src/solver/conjugategradient/cg.rs
+++ b/src/solver/conjugategradient/cg.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 use std::fmt::Debug;
@@ -23,7 +23,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ConjugateGradient<P, S> {
     /// b (right hand side)
     b: P,
@@ -34,13 +35,13 @@ pub struct ConjugateGradient<P, S> {
     /// previous p
     p_prev: P,
     /// r^T * r
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde1", serde(skip))]
     rtr: S,
     /// alpha
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde1", serde(skip))]
     alpha: S,
     /// beta
-    #[serde(skip)]
+    #[cfg_attr(feature = "serde1", serde(skip))]
     beta: S,
 }
 
@@ -86,8 +87,8 @@ impl<P, O, S, F> Solver<O> for ConjugateGradient<P, S>
 where
     O: ArgminOp<Param = P, Output = P, Float = F>,
     P: Clone
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminDot<O::Param, S>
         + ArgminSub<O::Param, O::Param>
         + ArgminScaledAdd<O::Param, S, O::Param>

--- a/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/src/solver/conjugategradient/nonlinear_cg.rs
@@ -14,7 +14,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -25,7 +25,8 @@ use std::default::Default;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct NonlinearConjugateGradient<P, L, B, F> {
     /// p
     p: P,
@@ -85,8 +86,8 @@ where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     P: Clone
         + Default
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminScaledAdd<O::Param, O::Float, O::Param>

--- a/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -11,6 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -20,7 +21,8 @@ use std::default::Default;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct GaussNewtonLS<L, F> {
     /// linesearch
     linesearch: L,
@@ -123,7 +125,8 @@ where
 }
 
 #[doc(hidden)]
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct LineSearchOP<O> {
     pub op: O,
 }

--- a/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/src/solver/gaussnewton/gaussnewton_method.rs
@@ -11,6 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -20,7 +21,8 @@ use std::default::Default;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct GaussNewton<F> {
     /// gamma
     gamma: F,
@@ -119,6 +121,7 @@ where
 mod tests {
     use super::*;
     use crate::test_trait_impl;
+    #[cfg(feature = "ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(gauss_newton_method, GaussNewton<f64>);
@@ -183,6 +186,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ndarrayl")]
     #[test]
     fn test_solver() {
         use ndarray::{Array, Array1, Array2};

--- a/src/solver/goldensectionsearch/mod.rs
+++ b/src/solver/goldensectionsearch/mod.rs
@@ -10,6 +10,7 @@
 //! [Wikipedia](https://en.wikipedia.org/wiki/Golden-section_search)
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 // Golden ratio is actually 1.61803398874989484820, but that is too much precision for f64.
@@ -33,7 +34,8 @@ const G2: f64 = 1.0 - G1;
 /// # References:
 ///
 /// [Wikipedia](https://en.wikipedia.org/wiki/Golden-section_search)
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct GoldenSectionSearch<F> {
     g1: F,
     g2: F,

--- a/src/solver/gradientdescent/steepestdescent.rs
+++ b/src/solver/gradientdescent/steepestdescent.rs
@@ -15,6 +15,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// Steepest descent iteratively takes steps in the direction of the strongest negative gradient.
@@ -24,7 +25,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct SteepestDescent<L> {
     /// line search
     linesearch: L,
@@ -42,7 +44,7 @@ where
     O: ArgminOp<Output = F, Float = F>,
     O::Param: Clone
         + Default
-        + Serialize
+        + SerializeAlias
         + ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminScaledAdd<O::Param, O::Float, O::Param>

--- a/src/solver/landweber/mod.rs
+++ b/src/solver/landweber/mod.rs
@@ -16,6 +16,7 @@
 //! \[1\] <https://en.wikipedia.org/wiki/Landweber_iteration>
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// The Landweber iteration is a solver for ill-posed linear inverse problems.
@@ -30,7 +31,8 @@ use serde::{Deserialize, Serialize};
 /// \[0\] Landweber, L. (1951): An iteration formula for Fredholm integral equations of the first
 /// kind. Amer. J. Math. 73, 615–624
 /// \[1\] <https://en.wikipedia.org/wiki/Landweber_iteration>
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Landweber<F> {
     /// omega
     omega: F,

--- a/src/solver/linesearch/backtracking.rs
+++ b/src/solver/linesearch/backtracking.rs
@@ -9,7 +9,7 @@
 
 use crate::prelude::*;
 use crate::solver::linesearch::condition::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -22,7 +22,8 @@ use std::borrow::Cow;
 /// Springer. ISBN 0-387-30303-0.
 ///
 /// \[1\] Wikipedia: <https://en.wikipedia.org/wiki/Backtracking_line_search>
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct BacktrackingLineSearch<P, L, F> {
     /// initial parameter vector
     init_param: P,
@@ -70,9 +71,9 @@ impl<P: Default, L, F: ArgminFloat> BacktrackingLineSearch<P, L, F> {
 
 impl<P, L, F> ArgminLineSearch<P, F> for BacktrackingLineSearch<P, L, F>
 where
-    P: Clone + Serialize + ArgminSub<P, P> + ArgminDot<P, f64> + ArgminScaledAdd<P, f64, P>,
+    P: Clone + SerializeAlias + ArgminSub<P, P> + ArgminDot<P, f64> + ArgminScaledAdd<P, f64, P>,
     L: LineSearchCondition<P, F>,
-    F: ArgminFloat + Serialize + DeserializeOwned,
+    F: ArgminFloat + SerializeAlias + DeserializeOwnedAlias,
 {
     /// Set search direction
     fn set_search_direction(&mut self, search_direction: P) {
@@ -122,7 +123,7 @@ where
 
 impl<O, P, L, F> Solver<O> for BacktrackingLineSearch<P, L, F>
 where
-    P: Clone + Default + Serialize + DeserializeOwned + ArgminScaledAdd<P, F, P>,
+    P: Clone + Default + SerializeAlias + DeserializeOwnedAlias + ArgminScaledAdd<P, F, P>,
     O: ArgminOp<Param = P, Output = F, Float = F>,
     L: LineSearchCondition<P, F>,
     F: ArgminFloat,

--- a/src/solver/linesearch/condition.rs
+++ b/src/solver/linesearch/condition.rs
@@ -10,11 +10,14 @@
 //! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-use crate::core::{ArgminDot, ArgminError, ArgminFloat, Error};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use crate::core::{
+    ArgminDot, ArgminError, ArgminFloat, DeserializeOwnedAlias, Error, SerializeAlias,
+};
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 
 /// Needs to be implemented by everything that wants to be a LineSearchCondition
-pub trait LineSearchCondition<T, F>: Serialize {
+pub trait LineSearchCondition<T, F>: SerializeAlias {
     /// Evaluate the condition
     fn eval(
         &self,
@@ -31,7 +34,8 @@ pub trait LineSearchCondition<T, F>: Serialize {
 }
 
 /// Armijo Condition
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ArmijoCondition<F> {
     c: F,
 }
@@ -52,7 +56,7 @@ impl<F: ArgminFloat> ArmijoCondition<F> {
 impl<T, F> LineSearchCondition<T, F> for ArmijoCondition<F>
 where
     T: ArgminDot<T, F>,
-    F: ArgminFloat + Serialize + DeserializeOwned,
+    F: ArgminFloat + SerializeAlias + DeserializeOwnedAlias,
 {
     fn eval(
         &self,
@@ -72,7 +76,8 @@ where
 }
 
 /// Wolfe Condition
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct WolfeCondition<F> {
     c1: F,
     c2: F,
@@ -100,7 +105,7 @@ impl<F: ArgminFloat> WolfeCondition<F> {
 impl<T, F> LineSearchCondition<T, F> for WolfeCondition<F>
 where
     T: Clone + ArgminDot<T, F>,
-    F: ArgminFloat + DeserializeOwned + Serialize,
+    F: ArgminFloat + DeserializeOwnedAlias + SerializeAlias,
 {
     fn eval(
         &self,
@@ -122,7 +127,8 @@ where
 }
 
 /// Strong Wolfe conditions
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct StrongWolfeCondition<F> {
     c1: F,
     c2: F,
@@ -150,7 +156,7 @@ impl<F: ArgminFloat> StrongWolfeCondition<F> {
 impl<T, F> LineSearchCondition<T, F> for StrongWolfeCondition<F>
 where
     T: Clone + ArgminDot<T, F>,
-    F: ArgminFloat + Serialize + DeserializeOwned,
+    F: ArgminFloat + SerializeAlias + DeserializeOwnedAlias,
 {
     fn eval(
         &self,
@@ -172,7 +178,8 @@ where
 }
 
 /// Goldstein conditions
-#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct GoldsteinCondition<F> {
     c: F,
 }
@@ -193,7 +200,7 @@ impl<F: ArgminFloat> GoldsteinCondition<F> {
 impl<T, F> LineSearchCondition<T, F> for GoldsteinCondition<F>
 where
     T: ArgminDot<T, F>,
-    F: ArgminFloat + Serialize + DeserializeOwned,
+    F: ArgminFloat + SerializeAlias + DeserializeOwnedAlias,
 {
     fn eval(
         &self,

--- a/src/solver/linesearch/hagerzhang.rs
+++ b/src/solver/linesearch/hagerzhang.rs
@@ -16,7 +16,7 @@
 //! DOI: <https://doi.org/10.1137/030601880>
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -30,7 +30,8 @@ type Triplet<F> = (F, F, F);
 /// \[0\] William W. Hager and Hongchao Zhang. "A new conjugate gradient method with guaranteed
 /// descent and an efficient line search." SIAM J. Optim. 16(1), 2006, 170-192.
 /// DOI: <https://doi.org/10.1137/030601880>
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct HagerZhangLineSearch<P, F> {
     /// delta: (0, 0.5), used in the Wolve conditions
     delta: F,
@@ -129,7 +130,12 @@ impl<P: Default, F: ArgminFloat> HagerZhangLineSearch<P, F> {
 
 impl<P, F> HagerZhangLineSearch<P, F>
 where
-    P: Clone + Default + Serialize + DeserializeOwned + ArgminScaledAdd<P, F, P> + ArgminDot<P, F>,
+    P: Clone
+        + Default
+        + SerializeAlias
+        + DeserializeOwnedAlias
+        + ArgminScaledAdd<P, F, P>
+        + ArgminDot<P, F>,
     F: ArgminFloat,
 {
     /// set delta
@@ -399,7 +405,7 @@ impl<P, F> ArgminLineSearch<P, F> for HagerZhangLineSearch<P, F>
 where
     P: Clone
         + Default
-        + Serialize
+        + SerializeAlias
         + ArgminSub<P, P>
         + ArgminDot<P, f64>
         + ArgminScaledAdd<P, f64, P>,
@@ -422,8 +428,8 @@ where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     P: Clone
         + Default
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<P, P>
         + ArgminDot<P, F>
         + ArgminScaledAdd<P, F, P>,

--- a/src/solver/linesearch/morethuente.rs
+++ b/src/solver/linesearch/morethuente.rs
@@ -17,7 +17,7 @@
 //! DOI: <https://doi.org/10.1145/192115.192132>
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -32,7 +32,8 @@ use std::default::Default;
 /// \[0\] Jorge J. More and David J. Thuente. "Line search algorithms with guaranteed sufficient
 /// decrease." ACM Trans. Math. Softw. 20, 3 (September 1994), 286-307.
 /// DOI: <https://doi.org/10.1145/192115.192132>
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct MoreThuenteLineSearch<P, F> {
     /// Search direction (builder)
     search_direction_b: Option<P>,
@@ -82,7 +83,8 @@ pub struct MoreThuenteLineSearch<P, F> {
     infoc: usize,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct Step<F> {
     pub x: F,
     pub fx: F,
@@ -183,7 +185,7 @@ impl<P: Default, F: ArgminFloat> Default for MoreThuenteLineSearch<P, F> {
 
 impl<P, F> ArgminLineSearch<P, F> for MoreThuenteLineSearch<P, F>
 where
-    P: Clone + Serialize + ArgminSub<P, P> + ArgminDot<P, F> + ArgminScaledAdd<P, F, P>,
+    P: Clone + SerializeAlias + ArgminSub<P, P> + ArgminDot<P, F> + ArgminScaledAdd<P, F, P>,
     F: ArgminFloat,
 {
     /// Set search direction
@@ -208,8 +210,8 @@ impl<P, O, F> Solver<O> for MoreThuenteLineSearch<P, F>
 where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     P: Clone
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<P, P>
         + ArgminDot<P, F>
         + ArgminScaledAdd<P, F, P>,

--- a/src/solver/neldermead/mod.rs
+++ b/src/solver/neldermead/mod.rs
@@ -10,7 +10,8 @@
 //! [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
 
 use crate::prelude::*;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 use std::default::Default;
 
 /// Nelder-Mead method
@@ -34,7 +35,8 @@ use std::default::Default;
 /// # References:
 ///
 /// [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct NelderMead<P, F> {
     /// alpha
     alpha: F,
@@ -192,8 +194,8 @@ impl<O, P, F> Solver<O> for NelderMead<P, F>
 where
     O: ArgminOp<Output = F, Param = P, Float = F>,
     P: Clone
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminScaledSub<O::Param, O::Float, O::Param>
         + ArgminSub<O::Param, O::Param>
         + ArgminAdd<O::Param, O::Param>

--- a/src/solver/newton/newton_cg.rs
+++ b/src/solver/newton/newton_cg.rs
@@ -14,6 +14,7 @@
 
 use crate::prelude::*;
 use crate::solver::conjugategradient::ConjugateGradient;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// The Newton-CG method (also called truncated Newton method) uses a modified CG to solve the
@@ -23,7 +24,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct NewtonCG<L, F> {
     /// line search
     linesearch: L,
@@ -68,7 +70,7 @@ where
     O::Param: Send
         + Sync
         + Clone
-        + Serialize
+        + SerializeAlias
         + Default
         + ArgminSub<O::Param, O::Param>
         + ArgminAdd<O::Param, O::Param>
@@ -82,7 +84,7 @@ where
         + Sync
         + Default
         + Clone
-        + Serialize
+        + SerializeAlias
         + Default
         + ArgminInv<O::Hessian>
         + ArgminDot<O::Param, O::Param>,
@@ -167,7 +169,8 @@ where
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct CGSubProblem<T, H, F> {
     hessian: H,
     phantom: std::marker::PhantomData<T>,
@@ -191,8 +194,8 @@ where
 
 impl<T, H, F> ArgminOp for CGSubProblem<T, H, F>
 where
-    T: Clone + Default + Send + Sync + Serialize + serde::de::DeserializeOwned,
-    H: Clone + Default + ArgminDot<T, T> + Send + Sync + Serialize + serde::de::DeserializeOwned,
+    T: Clone + Default + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
+    H: Clone + Default + ArgminDot<T, T> + Send + Sync + SerializeAlias + DeserializeOwnedAlias,
     F: ArgminFloat,
 {
     type Param = T;

--- a/src/solver/newton/newton_method.rs
+++ b/src/solver/newton/newton_method.rs
@@ -11,6 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::default::Default;
 
@@ -21,7 +22,8 @@ use std::default::Default;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Newton<F> {
     /// gamma
     gamma: F,
@@ -80,6 +82,7 @@ where
 mod tests {
     use super::*;
     use crate::test_trait_impl;
+    #[cfg(feature = "ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(newton_method, Newton<f64>);
@@ -128,6 +131,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ndarrayl")]
     #[test]
     fn test_solver() {
         use ndarray::{Array, Array1, Array2};

--- a/src/solver/particleswarm/mod.rs
+++ b/src/solver/particleswarm/mod.rs
@@ -10,8 +10,8 @@
 //! TODO
 
 use crate::prelude::*;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std;
+#[cfg(feature = "serde1")]
+use serde::{Deserialize, Serialize};
 use std::default::Default;
 
 /// Particle Swarm Optimization (PSO)
@@ -19,7 +19,8 @@ use std::default::Default;
 /// # References:
 ///
 /// TODO
-#[derive(Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ParticleSwarm<P, F> {
     particles: Vec<Particle<P, F>>,
     best_position: P,
@@ -36,7 +37,7 @@ pub struct ParticleSwarm<P, F> {
 
 impl<P, F> ParticleSwarm<P, F>
 where
-    P: Position<F> + DeserializeOwned + Serialize,
+    P: Position<F> + DeserializeOwnedAlias + SerializeAlias,
     F: ArgminFloat,
 {
     /// Constructor
@@ -130,7 +131,7 @@ where
 impl<O, P, F> Solver<O> for ParticleSwarm<P, F>
 where
     O: ArgminOp<Output = F, Param = P, Float = F>,
-    P: Position<F> + DeserializeOwned + Serialize,
+    P: Position<F> + DeserializeOwnedAlias + SerializeAlias,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Particle Swarm Optimization";
@@ -241,7 +242,8 @@ where
 }
 
 /// A single particle
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Particle<T, F> {
     /// Position of particle
     pub position: T,

--- a/src/solver/quasinewton/bfgs.rs
+++ b/src/solver/quasinewton/bfgs.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -21,7 +21,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct BFGS<L, H, F> {
     /// Inverse Hessian
     inv_hessian: H,
@@ -71,8 +72,8 @@ where
     H: Clone
         + Default
         + Debug
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminDot<O::Hessian, O::Hessian>

--- a/src/solver/quasinewton/dfp.rs
+++ b/src/solver/quasinewton/dfp.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// DFP method
@@ -20,7 +20,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct DFP<L, H, F> {
     /// Inverse Hessian
     inv_hessian: H,
@@ -52,7 +53,7 @@ where
     O: ArgminOp<Output = F, Hessian = H, Float = F>,
     O::Param: Clone
         + Default
-        + Serialize
+        + SerializeAlias
         + ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
@@ -62,8 +63,8 @@ where
         + ArgminTranspose<O::Param>,
     H: Clone
         + Default
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminDot<O::Hessian, O::Hessian>

--- a/src/solver/quasinewton/lbfgs.rs
+++ b/src/solver/quasinewton/lbfgs.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::fmt::Debug;
@@ -24,7 +24,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct LBFGS<L, P, F> {
     /// line search
     linesearch: L,
@@ -70,8 +71,8 @@ impl<O, L, P, F> Solver<O> for LBFGS<L, P, F>
 where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     O::Param: Clone
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + Debug
         + Default
         + ArgminSub<O::Param, O::Param>
@@ -80,7 +81,7 @@ where
         + ArgminScaledAdd<O::Param, O::Float, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: Clone + Default + Serialize + DeserializeOwned,
+    O::Hessian: Clone + Default + SerializeAlias + DeserializeOwnedAlias,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     // L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,

--- a/src/solver/quasinewton/sr1.rs
+++ b/src/solver/quasinewton/sr1.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -21,7 +21,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct SR1<L, H, F> {
     /// parameter for skipping rule
     r: F,
@@ -79,7 +80,7 @@ where
     O::Param: Debug
         + Clone
         + Default
-        + Serialize
+        + SerializeAlias
         + ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
@@ -88,8 +89,8 @@ where
     H: Debug
         + Clone
         + Default
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminDot<O::Hessian, O::Hessian>

--- a/src/solver/quasinewton/sr1_trustregion.rs
+++ b/src/solver/quasinewton/sr1_trustregion.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -21,7 +21,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct SR1TrustRegion<B, R, F> {
     /// parameter for skipping rule
     r: F,
@@ -101,7 +102,7 @@ where
     O::Param: Debug
         + Clone
         + Default
-        + Serialize
+        + SerializeAlias
         + ArgminSub<O::Param, O::Param>
         + ArgminAdd<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
@@ -112,8 +113,8 @@ where
     B: Debug
         + Clone
         + Default
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminDot<O::Hessian, O::Hessian>

--- a/src/solver/simulatedannealing/mod.rs
+++ b/src/solver/simulatedannealing/mod.rs
@@ -17,6 +17,7 @@
 
 use crate::prelude::*;
 use rand::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// Temperature functions for Simulated Annealing.
@@ -27,7 +28,8 @@ use serde::{Deserialize, Serialize};
 /// * `SATempFunc::TemperatureFast`: `t_i = t_init / i`
 /// * `SATempFunc::Boltzmann`: `t_i = t_init / ln(i)`
 /// * `SATempFunc::Exponential`: `t_i = t_init * 0.95^i`
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub enum SATempFunc<F> {
     /// `t_i = t_init / i`
     TemperatureFast,
@@ -55,7 +57,8 @@ impl<F> std::default::Default for SATempFunc<F> {
 /// \[1\] S Kirkpatrick, CD Gelatt Jr, MP Vecchi. (1983). "Optimization by Simulated Annealing".
 /// Science 13 May 1983, Vol. 220, Issue 4598, pp. 671-680
 /// DOI: 10.1126/science.220.4598.671
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct SimulatedAnnealing<F, R> {
     /// Initial temperature
     init_temp: F,
@@ -99,7 +102,7 @@ where
     /// Parameter:
     ///
     /// * `init_temp`: initial temperature
-    /// * `rng`: an RNG (must implement Serialize)
+    /// * `rng`: an RNG (must implement Serialize when `serde1` feature is activated)
     pub fn new(init_temp: F, rng: R) -> Result<Self, Error> {
         if init_temp <= F::from_f64(0.0).unwrap() {
             Err(ArgminError::InvalidParameter {
@@ -227,7 +230,7 @@ impl<O, F, R> Solver<O> for SimulatedAnnealing<F, R>
 where
     O: ArgminOp<Output = F, Float = F>,
     F: ArgminFloat,
-    R: Rng + Serialize,
+    R: Rng + SerializeAlias,
 {
     const NAME: &'static str = "Simulated Annealing";
     fn init(

--- a/src/solver/trustregion/cauchypoint.rs
+++ b/src/solver/trustregion/cauchypoint.rs
@@ -11,6 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -21,7 +22,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize, Debug, Copy, PartialEq, PartialOrd, Default)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct CauchyPoint<F> {
     /// Radius
     radius: F,
@@ -39,11 +41,11 @@ where
     O: ArgminOp<Output = F, Float = F>,
     O::Param: Debug
         + Clone
-        + Serialize
+        + SerializeAlias
         + ArgminMul<O::Float, O::Param>
         + ArgminWeightedDot<O::Param, F, O::Hessian>
         + ArgminNorm<O::Float>,
-    O::Hessian: Clone + Serialize,
+    O::Hessian: Clone + SerializeAlias,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Cauchy Point";

--- a/src/solver/trustregion/dogleg.rs
+++ b/src/solver/trustregion/dogleg.rs
@@ -11,6 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// The Dogleg method computes the intersection of the trust region boundary with a path given by
@@ -21,7 +22,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize, Debug, Copy, PartialEq, PartialOrd, Default)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Dogleg<F> {
     /// Radius
     radius: F,

--- a/src/solver/trustregion/steihaug.rs
+++ b/src/solver/trustregion/steihaug.rs
@@ -11,7 +11,7 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::prelude::*;
-use serde::de::DeserializeOwned;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
 /// The Steihaug method is a conjugate gradients based approach for finding an approximate solution
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize, Debug, Copy, PartialEq, PartialOrd, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct Steihaug<P, F> {
     /// Radius
     radius: F,
@@ -142,8 +143,8 @@ impl<P, O, F> Solver<O> for Steihaug<P, F>
 where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     P: Clone
-        + Serialize
-        + DeserializeOwned
+        + SerializeAlias
+        + DeserializeOwnedAlias
         + Default
         + ArgminMul<F, P>
         + ArgminWeightedDot<P, F, O::Hessian>
@@ -240,7 +241,7 @@ where
     }
 }
 
-impl<P: Clone + Serialize, F: ArgminFloat> ArgminTrustRegion<F> for Steihaug<P, F> {
+impl<P: Clone + SerializeAlias, F: ArgminFloat> ArgminTrustRegion<F> for Steihaug<P, F> {
     fn set_radius(&mut self, radius: F) {
         self.radius = radius;
     }

--- a/src/solver/trustregion/trustregion_method.rs
+++ b/src/solver/trustregion/trustregion_method.rs
@@ -12,6 +12,7 @@
 
 use crate::prelude::*;
 use crate::solver::trustregion::reduction_ratio;
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -33,7 +34,8 @@ use std::fmt::Debug;
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct TrustRegion<R, F> {
     /// Radius
     radius: F,
@@ -93,7 +95,7 @@ where
     O::Param: Default
         + Clone
         + Debug
-        + Serialize
+        + SerializeAlias
         + ArgminMul<F, O::Param>
         + ArgminWeightedDot<O::Param, F, O::Hessian>
         + ArgminNorm<F>
@@ -102,7 +104,7 @@ where
         + ArgminSub<O::Param, O::Param>
         + ArgminZeroLike
         + ArgminMul<F, O::Param>,
-    O::Hessian: Default + Clone + Debug + Serialize + ArgminDot<O::Param, O::Param>,
+    O::Hessian: Default + Clone + Debug + SerializeAlias + ArgminDot<O::Param, O::Param>,
     R: ArgminTrustRegion<F> + Solver<O>,
     F: ArgminFloat,
 {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,9 +17,11 @@ use crate::solver::linesearch::{HagerZhangLineSearch, MoreThuenteLineSearch};
 use crate::solver::newton::NewtonCG;
 use crate::solver::quasinewton::{BFGS, DFP, LBFGS};
 
+#[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Default, Serialize, Deserialize, Debug)]
+#[derive(Clone, Default, Debug)]
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct MaxEntropy {
     F: Array2<f64>,
     K: Array1<f64>,


### PR DESCRIPTION
This PR makes the `serde` dependency optional by putting it behind the feature gate `serde1`. The downside is that checkpointing and logging to file is not possible anymore (obviously). Since most users probably don't mind having `serde` as a dependency, the feature is part of the default features. So far other dependencies might still pull in serde, I will see how far this can be improved.
Doctests are a bit of a pain when they require special features. Need to check how this affects the created docs and in particular need to check how `cargo readme` will handle the changes. 

This PR also adds additional checks in the CI, in particular running tests with `serde1` disabled as well as clippy checks with `serde1` disabled.
Previously the compiler was sometimes not able to detect dead code in structs when `Serialize`/`Deserialize` was derived for the struct. Being able to run the CI without `serde1` therefore helps finding dead code. 

This has been discussed a while back in #7, #34, #36.