### PR TITLE
Make inverse Hessian part of IterState (fixes #185)

### DIFF
--- a/argmin/examples/bfgs.rs
+++ b/argmin/examples/bfgs.rs
@@ -52,7 +52,7 @@ fn run() -> Result<(), Error> {
     // Run solver
     let res = Executor::new(cost, solver, init_param)
         .add_observer(ArgminSlogLogger::term(), ObserverMode::Always)
-        .max_iters(100)
+        .max_iters(60)
         .run()?;
 
     // Wait a second (lets the logger flush everything before printing again)

--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -108,6 +108,9 @@ where
         if let Some(hessian) = data.get_hessian() {
             self.state.hessian(hessian);
         }
+        if let Some(inv_hessian) = data.get_inv_hessian() {
+            self.state.inv_hessian(inv_hessian);
+        }
         if let Some(jacobian) = data.get_jacobian() {
             self.state.jacobian(jacobian);
         }

--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -210,6 +210,8 @@ pub struct ArgminIterData<O: ArgminOp> {
     grad: Option<O::Param>,
     /// Current Hessian
     hessian: Option<O::Hessian>,
+    /// Current inverse Hessian
+    inv_hessian: Option<O::Hessian>,
     /// Current Jacobian
     jacobian: Option<O::Jacobian>,
     /// Current population
@@ -230,6 +232,7 @@ impl<O: ArgminOp> ArgminIterData<O> {
             cost: None,
             grad: None,
             hessian: None,
+            inv_hessian: None,
             jacobian: None,
             termination_reason: None,
             population: None,
@@ -262,6 +265,13 @@ impl<O: ArgminOp> ArgminIterData<O> {
     #[must_use]
     pub fn hessian(mut self, hessian: O::Hessian) -> Self {
         self.hessian = Some(hessian);
+        self
+    }
+
+    /// Set inverse Hessian
+    #[must_use]
+    pub fn inv_hessian(mut self, inv_hessian: O::Hessian) -> Self {
+        self.inv_hessian = Some(inv_hessian);
         self
     }
 
@@ -311,6 +321,11 @@ impl<O: ArgminOp> ArgminIterData<O> {
     /// Get Hessian
     pub fn get_hessian(&self) -> Option<O::Hessian> {
         self.hessian.clone()
+    }
+
+    /// Get inverse Hessian
+    pub fn get_inv_hessian(&self) -> Option<O::Hessian> {
+        self.inv_hessian.clone()
     }
 
     /// Get Jacobian

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -32,7 +32,7 @@ use std::fmt::Debug;
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct BFGS<L, H, F> {
     /// Inverse Hessian
-    inv_hessian: H,
+    init_inv_hessian: H,
     /// line search
     linesearch: L,
     /// Tolerance for the stopping criterion based on the change of the norm on the gradient
@@ -45,7 +45,7 @@ impl<L, H, F: ArgminFloat> BFGS<L, H, F> {
     /// Constructor
     pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
         BFGS {
-            inv_hessian: init_inverse_hessian,
+            init_inv_hessian: init_inverse_hessian,
             linesearch,
             tol_grad: F::epsilon().sqrt(),
             tol_cost: F::epsilon(),
@@ -104,7 +104,11 @@ where
         let cost = op.apply(&param)?;
         let grad = op.gradient(&param)?;
         Ok(Some(
-            ArgminIterData::new().param(param).cost(cost).grad(grad),
+            ArgminIterData::new()
+                .param(param)
+                .cost(cost)
+                .grad(grad)
+                .inv_hessian(self.init_inv_hessian.clone()),
         ))
     }
 
@@ -116,11 +120,9 @@ where
         let param = state.get_param();
         let cur_cost = state.get_cost();
         let prev_grad = state.get_grad().unwrap();
+        let inv_hessian = state.get_inv_hessian().unwrap();
 
-        let p = self
-            .inv_hessian
-            .dot(&prev_grad)
-            .mul(&F::from_f64(-1.0).unwrap());
+        let p = inv_hessian.dot(&prev_grad).mul(&F::from_f64(-1.0).unwrap());
 
         self.linesearch.set_search_direction(p);
 
@@ -155,7 +157,7 @@ where
         let yksk: F = yk.dot(&sk);
         let rhok = F::from_f64(1.0).unwrap() / yksk;
 
-        let e = self.inv_hessian.eye_like();
+        let e = inv_hessian.eye_like();
         let mat1: O::Hessian = sk.dot(&yk);
         let mat1 = mat1.mul(&rhok);
 
@@ -173,9 +175,13 @@ where
         //     println!("{:?}", self.inv_hessian);
         // }
 
-        self.inv_hessian = tmp1.dot(&self.inv_hessian.dot(&tmp2)).add(&sksk);
+        let inv_hessian = tmp1.dot(&inv_hessian.dot(&tmp2)).add(&sksk);
 
-        Ok(ArgminIterData::new().param(xk1).cost(next_cost).grad(grad))
+        Ok(ArgminIterData::new()
+            .param(xk1)
+            .cost(next_cost)
+            .grad(grad)
+            .inv_hessian(inv_hessian))
     }
 
     fn terminate(&mut self, state: &IterState<O>) -> TerminationReason {

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -88,9 +88,7 @@ where
         + ArgminScaledAdd<O::Param, O::Float, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: Clone + Default + SerializeAlias + DeserializeOwnedAlias,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
-    // L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "L-BFGS";


### PR DESCRIPTION
With these changes the inverse Hessian is treated just like the Hessian in the `IterState` struct. This allows one to extract the final inverse Hessian after running a solver. Fixes #185 .