### PR TITLE
Remove Default and other unnecessary trait bounds from solvers

### DIFF
--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -338,7 +338,7 @@ impl<O: ArgminOp> ArgminIterData<O> {
 }
 
 /// Defines a common interface for line search methods.
-pub trait ArgminLineSearch<P, F>: SerializeAlias {
+pub trait ArgminLineSearch<P, F> {
     /// Set the search direction
     fn set_search_direction(&mut self, direction: P);
 
@@ -348,7 +348,7 @@ pub trait ArgminLineSearch<P, F>: SerializeAlias {
 
 /// Defines a common interface to methods which calculate approximate steps for trust region
 /// methods.
-pub trait ArgminTrustRegion<F>: Clone + SerializeAlias {
+pub trait ArgminTrustRegion<F> {
     /// Set the initial step length
     fn set_radius(&mut self, radius: F);
 }

--- a/argmin/src/solver/conjugategradient/beta.rs
+++ b/argmin/src/solver/conjugategradient/beta.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 /// Fletcher and Reeves (FR) method
 /// TODO: Reference
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct FletcherReeves {}
 
@@ -44,7 +44,7 @@ where
 
 /// Polak and Ribiere (PR) method
 /// TODO: Reference
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibiere {}
 
@@ -57,7 +57,7 @@ impl PolakRibiere {
 
 impl<T, F> ArgminNLCGBetaUpdate<T, F> for PolakRibiere
 where
-    T: Clone + ArgminDot<T, F> + ArgminSub<T, T> + ArgminNorm<F>,
+    T: ArgminDot<T, F> + ArgminSub<T, T> + ArgminNorm<F>,
     F: ArgminFloat,
 {
     fn update(&self, dfk: &T, dfk1: &T, _pk: &T) -> F {
@@ -68,7 +68,7 @@ where
 
 /// Polak and Ribiere Plus (PR+) method
 /// TODO: Reference
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibierePlus {}
 
@@ -81,7 +81,7 @@ impl PolakRibierePlus {
 
 impl<T, F> ArgminNLCGBetaUpdate<T, F> for PolakRibierePlus
 where
-    T: Clone + ArgminDot<T, F> + ArgminSub<T, T> + ArgminNorm<F>,
+    T: ArgminDot<T, F> + ArgminSub<T, T> + ArgminNorm<F>,
     F: ArgminFloat,
 {
     fn update(&self, dfk: &T, dfk1: &T, _pk: &T) -> F {
@@ -93,7 +93,7 @@ where
 
 /// Hestenes and Stiefel (HS) method
 /// TODO: Reference
-#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct HestenesStiefel {}
 
@@ -106,7 +106,7 @@ impl HestenesStiefel {
 
 impl<T, F> ArgminNLCGBetaUpdate<T, F> for HestenesStiefel
 where
-    T: Clone + ArgminDot<T, F> + ArgminSub<T, T> + ArgminNorm<F>,
+    T: ArgminDot<T, F> + ArgminSub<T, T>,
     F: ArgminFloat,
 {
     fn update(&self, dfk: &T, dfk1: &T, pk: &T) -> F {

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -14,12 +14,9 @@ use crate::core::{
     ArgminError, ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, Error,
     Executor, IterState, OpWrapper, Solver, TerminationReason,
 };
-use argmin_math::{
-    ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminScaledSub, ArgminSub, ArgminTranspose,
-};
+use argmin_math::{ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminTranspose};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
 
 /// Gauss-Newton method with linesearch
 ///
@@ -61,10 +58,7 @@ impl<L, F: ArgminFloat> GaussNewtonLS<L, F> {
 impl<O, L, F> Solver<O> for GaussNewtonLS<L, F>
 where
     O: ArgminOp<Float = F>,
-    O::Param: std::fmt::Debug
-        + ArgminScaledSub<O::Param, O::Float, O::Param>
-        + ArgminSub<O::Param, O::Param>
-        + ArgminMul<O::Float, O::Param>,
+    O::Param: ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,
     O::Jacobian: ArgminTranspose<O::Jacobian>
         + ArgminInv<O::Jacobian>

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -14,12 +14,9 @@ use crate::core::{
     ArgminError, ArgminFloat, ArgminIterData, ArgminOp, Error, IterState, OpWrapper, Solver,
     TerminationReason,
 };
-use argmin_math::{
-    ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminScaledSub, ArgminSub, ArgminTranspose,
-};
+use argmin_math::{ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminSub, ArgminTranspose};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
 
 /// Gauss-Newton method
 ///
@@ -79,9 +76,7 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
 impl<O, F> Solver<O> for GaussNewton<F>
 where
     O: ArgminOp<Float = F>,
-    O::Param: ArgminScaledSub<O::Param, O::Float, O::Param>
-        + ArgminSub<O::Param, O::Param>
-        + ArgminMul<O::Float, O::Param>,
+    O::Param: ArgminSub<O::Param, O::Param> + ArgminMul<O::Float, O::Param>,
     O::Output: ArgminNorm<O::Float>,
     O::Jacobian: ArgminTranspose<O::Jacobian>
         + ArgminInv<O::Jacobian>

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -18,7 +18,7 @@ use crate::core::{
     ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, Error, Executor,
     IterState, OpWrapper, SerializeAlias, Solver,
 };
-use argmin_math::{ArgminDot, ArgminMul, ArgminNorm, ArgminScaledAdd, ArgminSub};
+use argmin_math::ArgminMul;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -46,16 +46,7 @@ impl<L> SteepestDescent<L> {
 impl<O, L, F> Solver<O> for SteepestDescent<L>
 where
     O: ArgminOp<Output = F, Float = F>,
-    O::Param: Clone
-        + Default
-        + SerializeAlias
-        + ArgminSub<O::Param, O::Param>
-        + ArgminDot<O::Param, O::Float>
-        + ArgminScaledAdd<O::Param, O::Float, O::Param>
-        + ArgminMul<O::Float, O::Param>
-        + ArgminSub<O::Param, O::Param>
-        + ArgminNorm<O::Float>,
-    O::Hessian: Default,
+    O::Param: SerializeAlias + ArgminMul<O::Float, O::Param>,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -32,7 +32,10 @@ pub struct Newton<F> {
     gamma: F,
 }
 
-impl<F: ArgminFloat> Newton<F> {
+impl<F> Newton<F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new() -> Self {
         Newton {
@@ -53,7 +56,10 @@ impl<F: ArgminFloat> Newton<F> {
     }
 }
 
-impl<F: ArgminFloat> Default for Newton<F> {
+impl<F> Default for Newton<F>
+where
+    F: ArgminFloat,
+{
     fn default() -> Newton<F> {
         Newton::new()
     }

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -12,13 +12,12 @@
 //! TODO
 
 use crate::core::{
-    ArgminFloat, ArgminIterData, ArgminKV, ArgminOp, DeserializeOwnedAlias, Error, IterState,
-    OpWrapper, SerializeAlias, Solver,
+    ArgminFloat, ArgminIterData, ArgminKV, ArgminOp, Error, IterState, OpWrapper, SerializeAlias,
+    Solver,
 };
 use argmin_math::{ArgminAdd, ArgminMinMax, ArgminMul, ArgminRandom, ArgminSub, ArgminZeroLike};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
 
 /// Particle Swarm Optimization (PSO)
 ///
@@ -43,7 +42,7 @@ pub struct ParticleSwarm<P, F> {
 
 impl<P, F> ParticleSwarm<P, F>
 where
-    P: Position<F> + DeserializeOwnedAlias + SerializeAlias,
+    P: Position<F>,
     F: ArgminFloat,
 {
     /// Constructor
@@ -137,7 +136,7 @@ where
 impl<O, P, F> Solver<O> for ParticleSwarm<P, F>
 where
     O: ArgminOp<Output = F, Param = P, Float = F>,
-    P: Position<F> + DeserializeOwnedAlias + SerializeAlias,
+    P: SerializeAlias + Position<F>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Particle Swarm Optimization";
@@ -220,9 +219,8 @@ where
 }
 
 /// Position
-pub trait Position<F: ArgminFloat>:
+pub trait Position<F>:
     Clone
-    + Default
     + ArgminAdd<Self, Self>
     + ArgminSub<Self, Self>
     + ArgminMul<F, Self>
@@ -230,12 +228,13 @@ pub trait Position<F: ArgminFloat>:
     + ArgminRandom
     + ArgminMinMax
     + std::fmt::Debug
+where
+    F: ArgminFloat,
 {
 }
-impl<T, F: ArgminFloat> Position<F> for T
+impl<T, F> Position<F> for T
 where
     T: Clone
-        + Default
         + ArgminAdd<Self, Self>
         + ArgminSub<Self, Self>
         + ArgminMul<F, Self>

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -11,16 +11,14 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, DeserializeOwnedAlias,
-    Error, Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
+    ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, Error, Executor,
+    IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
 };
 use argmin_math::{
-    ArgminAdd, ArgminDot, ArgminEye, ArgminMul, ArgminNorm, ArgminScaledAdd, ArgminSub,
-    ArgminTranspose,
+    ArgminAdd, ArgminDot, ArgminEye, ArgminMul, ArgminNorm, ArgminSub, ArgminTranspose,
 };
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// BFGS method
 ///
@@ -41,7 +39,10 @@ pub struct BFGS<L, H, F> {
     tol_cost: F,
 }
 
-impl<L, H, F: ArgminFloat> BFGS<L, H, F> {
+impl<L, H, F> BFGS<L, H, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
         BFGS {
@@ -70,19 +71,13 @@ impl<L, H, F: ArgminFloat> BFGS<L, H, F> {
 impl<O, L, H, F> Solver<O> for BFGS<L, H, F>
 where
     O: ArgminOp<Output = F, Hessian = H, Float = F>,
-    O::Param: Debug
-        + Default
-        + ArgminSub<O::Param, O::Param>
+    O::Param: ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
-        + ArgminScaledAdd<O::Param, O::Float, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    H: Clone
-        + Default
-        + Debug
+    O::Hessian: Clone
         + SerializeAlias
-        + DeserializeOwnedAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminDot<O::Hessian, O::Hessian>

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -11,13 +11,10 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, DeserializeOwnedAlias,
-    Error, Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
+    ArgminFloat, ArgminIterData, ArgminLineSearch, ArgminOp, ArgminResult, Error, Executor,
+    IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
 };
-use argmin_math::{
-    ArgminAdd, ArgminDot, ArgminEye, ArgminMul, ArgminNorm, ArgminScaledAdd, ArgminSub,
-    ArgminTranspose,
-};
+use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +35,10 @@ pub struct DFP<L, H, F> {
     tol_grad: F,
 }
 
-impl<L, H, F: ArgminFloat> DFP<L, H, F> {
+impl<L, H, F> DFP<L, H, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
         DFP {
@@ -59,27 +59,16 @@ impl<L, H, F: ArgminFloat> DFP<L, H, F> {
 impl<O, L, H, F> Solver<O> for DFP<L, H, F>
 where
     O: ArgminOp<Output = F, Hessian = H, Float = F>,
-    O::Param: Clone
-        + Default
-        + SerializeAlias
-        + ArgminSub<O::Param, O::Param>
+    O::Param: ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
-        + ArgminScaledAdd<O::Param, F, O::Param>
         + ArgminNorm<O::Float>
-        + ArgminMul<O::Float, O::Param>
-        + ArgminTranspose<O::Param>,
-    H: Clone
-        + Default
-        + SerializeAlias
-        + DeserializeOwnedAlias
+        + ArgminMul<O::Float, O::Param>,
+    H: SerializeAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
-        + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
-        + ArgminMul<F, O::Hessian>
-        + ArgminTranspose<O::Hessian>
-        + ArgminEye,
+        + ArgminMul<F, O::Hessian>,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -11,15 +11,13 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminFloat, ArgminIterData, ArgminKV, ArgminLineSearch, ArgminOp, ArgminResult,
-    DeserializeOwnedAlias, Error, Executor, IterState, OpWrapper, SerializeAlias, Solver,
-    TerminationReason,
+    ArgminFloat, ArgminIterData, ArgminKV, ArgminLineSearch, ArgminOp, ArgminResult, Error,
+    Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
 };
-use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminScaledAdd, ArgminSub};
+use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::fmt::Debug;
 
 /// L-BFGS method
 ///
@@ -46,7 +44,10 @@ pub struct LBFGS<L, P, F> {
     tol_cost: F,
 }
 
-impl<L, P, F: ArgminFloat> LBFGS<L, P, F> {
+impl<L, P, F> LBFGS<L, P, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(linesearch: L, m: usize) -> Self {
         LBFGS {
@@ -79,18 +80,12 @@ where
     O: ArgminOp<Param = P, Output = F, Float = F>,
     O::Param: Clone
         + SerializeAlias
-        + DeserializeOwnedAlias
-        + Debug
-        + Default
         + ArgminSub<O::Param, O::Param>
         + ArgminAdd<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
-        + ArgminScaledAdd<O::Param, O::Float, O::Param>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: Clone + Default + SerializeAlias + DeserializeOwnedAlias,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,
-    // L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<OpWrapper<O>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "L-BFGS";

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -12,13 +12,11 @@
 
 use crate::core::{
     ArgminError, ArgminFloat, ArgminIterData, ArgminKV, ArgminLineSearch, ArgminOp, ArgminResult,
-    DeserializeOwnedAlias, Error, Executor, IterState, OpWrapper, SerializeAlias, Solver,
-    TerminationReason,
+    Error, Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
 };
 use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// SR1 method (broken!)
 ///
@@ -41,7 +39,10 @@ pub struct SR1<L, H, F> {
     tol_cost: F,
 }
 
-impl<L, H, F: ArgminFloat> SR1<L, H, F> {
+impl<L, H, F> SR1<L, H, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
         SR1 {
@@ -84,23 +85,13 @@ impl<L, H, F: ArgminFloat> SR1<L, H, F> {
 impl<O, L, H, F> Solver<O> for SR1<L, H, F>
 where
     O: ArgminOp<Output = F, Hessian = H, Float = F>,
-    O::Param: Debug
-        + Clone
-        + Default
-        + SerializeAlias
-        + ArgminSub<O::Param, O::Param>
+    O::Param: ArgminSub<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    H: Debug
-        + Clone
-        + Default
-        + SerializeAlias
-        + DeserializeOwnedAlias
-        + ArgminSub<O::Hessian, O::Hessian>
+    O::Hessian: SerializeAlias
         + ArgminDot<O::Param, O::Param>
-        + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>,
     L: Clone + ArgminLineSearch<O::Param, O::Float> + Solver<O>,

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -12,15 +12,13 @@
 
 use crate::core::{
     ArgminError, ArgminFloat, ArgminIterData, ArgminKV, ArgminOp, ArgminResult, ArgminTrustRegion,
-    DeserializeOwnedAlias, Error, Executor, IterState, OpWrapper, SerializeAlias, Solver,
-    TerminationReason,
+    Error, Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub, ArgminWeightedDot, ArgminZeroLike,
 };
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// SR1 Trust Region method
 ///
@@ -45,7 +43,10 @@ pub struct SR1TrustRegion<B, R, F> {
     tol_grad: F,
 }
 
-impl<B, R, F: ArgminFloat> SR1TrustRegion<B, R, F> {
+impl<B, R, F> SR1TrustRegion<B, R, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(subproblem: R) -> Self {
         SR1TrustRegion {
@@ -109,29 +110,18 @@ impl<B, R, F: ArgminFloat> SR1TrustRegion<B, R, F> {
 impl<O, B, R, F> Solver<O> for SR1TrustRegion<B, R, F>
 where
     O: ArgminOp<Output = F, Hessian = B, Float = F>,
-    O::Param: Debug
-        + Clone
-        + Default
-        + SerializeAlias
-        + ArgminSub<O::Param, O::Param>
+    O::Param: ArgminSub<O::Param, O::Param>
         + ArgminAdd<O::Param, O::Param>
         + ArgminDot<O::Param, O::Float>
         + ArgminDot<O::Param, O::Hessian>
-        + ArgminWeightedDot<O::Param, O::Float, O::Hessian>
         + ArgminNorm<O::Float>
-        + ArgminZeroLike
-        + ArgminMul<F, O::Param>,
-    B: Debug
-        + Clone
-        + Default
+        + ArgminZeroLike,
+    B: Clone
         + SerializeAlias
-        + DeserializeOwnedAlias
-        + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
-        + ArgminDot<O::Hessian, O::Hessian>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>,
-    R: ArgminTrustRegion<F> + Solver<O>,
+    R: Clone + ArgminTrustRegion<F> + Solver<O>,
     F: ArgminFloat + ArgminNorm<O::Float>,
 {
     const NAME: &'static str = "SR1 Trust Region";

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -45,7 +45,7 @@ pub enum SATempFunc<F> {
     // Custom(Box<Fn(f64, u64) -> f64>),
 }
 
-impl<F> std::default::Default for SATempFunc<F> {
+impl<F> Default for SATempFunc<F> {
     fn default() -> Self {
         SATempFunc::Boltzmann
     }

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -11,8 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminFloat, ArgminIterData, ArgminOp, ArgminTrustRegion, Error, IterState, OpWrapper,
-    SerializeAlias, Solver, TerminationReason,
+    ArgminFloat, ArgminIterData, ArgminOp, ArgminTrustRegion, Error, IterState, OpWrapper, Solver,
+    TerminationReason,
 };
 use argmin_math::{ArgminMul, ArgminNorm, ArgminWeightedDot};
 #[cfg(feature = "serde1")]
@@ -33,7 +33,10 @@ pub struct CauchyPoint<F> {
     radius: F,
 }
 
-impl<F: ArgminFloat> CauchyPoint<F> {
+impl<F> CauchyPoint<F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new() -> Self {
         CauchyPoint { radius: F::nan() }
@@ -43,13 +46,9 @@ impl<F: ArgminFloat> CauchyPoint<F> {
 impl<O, F> Solver<O> for CauchyPoint<F>
 where
     O: ArgminOp<Output = F, Float = F>,
-    O::Param: Debug
-        + Clone
-        + SerializeAlias
-        + ArgminMul<O::Float, O::Param>
+    O::Param: ArgminMul<O::Float, O::Param>
         + ArgminWeightedDot<O::Param, F, O::Hessian>
         + ArgminNorm<O::Float>,
-    O::Hessian: Clone + SerializeAlias,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Cauchy Point";
@@ -90,7 +89,10 @@ where
     }
 }
 
-impl<F: ArgminFloat> ArgminTrustRegion<F> for CauchyPoint<F> {
+impl<F> ArgminTrustRegion<F> for CauchyPoint<F>
+where
+    F: ArgminFloat,
+{
     fn set_radius(&mut self, radius: F) {
         self.radius = radius;
     }

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -35,7 +35,10 @@ pub struct Dogleg<F> {
     radius: F,
 }
 
-impl<F: ArgminFloat> Dogleg<F> {
+impl<F> Dogleg<F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new() -> Self {
         Dogleg { radius: F::nan() }
@@ -45,9 +48,7 @@ impl<F: ArgminFloat> Dogleg<F> {
 impl<O, F> Solver<O> for Dogleg<F>
 where
     O: ArgminOp<Output = F, Float = F>,
-    O::Param: std::fmt::Debug
-        + ArgminMul<F, O::Param>
-        + ArgminWeightedDot<O::Param, O::Float, O::Hessian>
+    O::Param: ArgminMul<F, O::Param>
         + ArgminNorm<F>
         + ArgminDot<O::Param, O::Float>
         + ArgminAdd<O::Param, O::Param>

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -12,15 +12,12 @@
 
 use crate::core::{
     ArgminError, ArgminFloat, ArgminIterData, ArgminKV, ArgminOp, ArgminResult, ArgminTrustRegion,
-    Error, Executor, IterState, OpWrapper, SerializeAlias, Solver, TerminationReason,
+    Error, Executor, IterState, OpWrapper, Solver, TerminationReason,
 };
 use crate::solver::trustregion::reduction_ratio;
-use argmin_math::{
-    ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub, ArgminWeightedDot, ArgminZeroLike,
-};
+use argmin_math::{ArgminAdd, ArgminDot, ArgminNorm, ArgminWeightedDot};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Debug;
 
 /// The trust region method approximates the cost function within a certain region around the
 /// current point in parameter space. Depending on the quality of this approximation, the region is
@@ -57,7 +54,10 @@ pub struct TrustRegion<R, F> {
     mk0: F,
 }
 
-impl<R, F: ArgminFloat> TrustRegion<R, F> {
+impl<R, F> TrustRegion<R, F>
+where
+    F: ArgminFloat,
+{
     /// Constructor
     pub fn new(subproblem: R) -> Self {
         TrustRegion {
@@ -100,19 +100,9 @@ impl<R, F: ArgminFloat> TrustRegion<R, F> {
 impl<O, R, F> Solver<O> for TrustRegion<R, F>
 where
     O: ArgminOp<Output = F, Float = F>,
-    O::Param: Clone
-        + Debug
-        + SerializeAlias
-        + ArgminMul<F, O::Param>
-        + ArgminWeightedDot<O::Param, F, O::Hessian>
-        + ArgminNorm<F>
-        + ArgminDot<O::Param, F>
-        + ArgminAdd<O::Param, O::Param>
-        + ArgminSub<O::Param, O::Param>
-        + ArgminZeroLike
-        + ArgminMul<F, O::Param>,
-    O::Hessian: Clone + Debug + SerializeAlias + ArgminDot<O::Param, O::Param>,
-    R: ArgminTrustRegion<F> + Solver<O>,
+    O::Param: ArgminNorm<F> + ArgminDot<O::Param, F> + ArgminAdd<O::Param, O::Param>,
+    O::Hessian: ArgminDot<O::Param, O::Param>,
+    R: Clone + ArgminTrustRegion<F> + Solver<O>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Trust region";


### PR DESCRIPTION
#187 has shown that a `Default` trait bound on `O::Param` or `O::Hessian` causes `ndarray` types to not work anymore. Parts of it were fixed in #192. In this PR I removed all remaining `Default` trait bounds and also cleaned up all other trait bounds. 