### PR TITLE
More efficient ways of retrieving data from `IterState`

### DIFF
--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -153,7 +153,7 @@ pub trait Solver<O: ArgminOp>: SerializeAlias {
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error>;
 
     /// Initializes the algorithm
@@ -163,7 +163,7 @@ pub trait Solver<O: ArgminOp>: SerializeAlias {
     fn init(
         &mut self,
         _op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
         Ok(None)
     }

--- a/argmin/src/core/observers/visualizer.rs
+++ b/argmin/src/core/observers/visualizer.rs
@@ -159,7 +159,11 @@ where
     fn observe_iter(&mut self, state: &IterState<O>, _kv: &ArgminKV) -> Result<(), Error> {
         // TODO: get particles from `state` or `kv`
 
-        self.iteration(&state.param, state.best_cost, state.get_population());
+        self.iteration(
+            state.get_param_ref().unwrap(),
+            state.best_cost,
+            state.get_population(),
+        );
 
         Ok(())
     }

--- a/argmin/src/core/serialization.rs
+++ b/argmin/src/core/serialization.rs
@@ -178,7 +178,7 @@ mod tests {
         fn next_iter(
             &mut self,
             _op: &mut OpWrapper<O>,
-            _state: &IterState<O>,
+            _state: &mut IterState<O>,
         ) -> Result<ArgminIterData<O>, Error> {
             unimplemented!()
         }

--- a/argmin/src/lib.rs
+++ b/argmin/src/lib.rs
@@ -530,10 +530,10 @@
 //!         // Current state of the optimization. This gives access to the parameter vector,
 //!         // gradient, Hessian and cost function value of the current, previous and best
 //!         // iteration as well as current iteration number, and many more.
-//!         state: &IterState<O>,
+//!         state: &mut IterState<O>,
 //!     ) -> Result<ArgminIterData<O>, Error> {
 //!         // First we obtain the current parameter vector from the `state` struct (`x_k`).
-//!         let xk = state.get_param();
+//!         let xk = state.take_param().unwrap();
 //!         // Then we compute the gradient at `x_k` (`\nabla f(x_k)`)
 //!         let grad = op.gradient(&xk)?;
 //!         // Now subtract `\nabla f(x_k)` scaled by `omega` from `x_k` to compute `x_{k+1}`

--- a/argmin/src/solver/brent/mod.rs
+++ b/argmin/src/solver/brent/mod.rs
@@ -94,7 +94,7 @@ where
         &mut self,
         op: &mut OpWrapper<O>,
         // Brent maintains its own state
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
         self.fa = op.apply(&self.a)?;
         self.fb = op.apply(&self.b)?;
@@ -111,7 +111,7 @@ where
         &mut self,
         op: &mut OpWrapper<O>,
         // Brent maintains its own state
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         if (self.fb > F::from_f64(0.0).unwrap() && self.fc > F::from_f64(0.0).unwrap())
             || self.fb < F::from_f64(0.0).unwrap() && self.fc < F::from_f64(0.0).unwrap()

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -94,10 +94,10 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
-        let init_param = state.get_param();
-        let ap = op.apply(&init_param)?;
+        let init_param = state.get_param_ref().unwrap();
+        let ap = op.apply(init_param)?;
         let r0 = self.b.sub(&ap).mul(&(F::from_f64(-1.0).unwrap()));
         self.r = Some(r0.clone());
         self.p = Some(r0.mul(&(F::from_f64(-1.0).unwrap())));
@@ -109,7 +109,7 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         let p = self.p.as_ref().unwrap();
         let r = self.r.as_ref().unwrap();
@@ -117,7 +117,7 @@ where
         self.p_prev = Some(p.clone());
         let apk = op.apply(p)?;
         let alpha = self.rtr.div(p.dot(&apk.conj()));
-        let new_param = state.get_param().scaled_add(&alpha, p);
+        let new_param = state.get_param_ref().unwrap().scaled_add(&alpha, p);
         let r = r.scaled_add(&alpha, &apk);
         let rtr_n = r.dot(&r.conj());
         let beta = rtr_n.div(self.rtr);

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -90,9 +90,9 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let residuals = op.apply(&param)?;
         let jacobian = op.jacobian(&param)?;
 
@@ -233,7 +233,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -1.0, epsilon = f64::EPSILON.sqrt());
         assert_relative_eq!(param[1], 0.25, epsilon = f64::EPSILON.sqrt());
 
@@ -249,7 +250,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -1.4, epsilon = f64::EPSILON.sqrt());
         assert_relative_eq!(param[1], 0.3, epsilon = f64::EPSILON.sqrt());
 
@@ -265,7 +267,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -0.5, epsilon = f64::EPSILON.sqrt());
         assert_relative_eq!(param[1], 0.125, epsilon = f64::EPSILON.sqrt());
 
@@ -281,7 +284,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -0.7, epsilon = f64::EPSILON.sqrt());
         assert_relative_eq!(param[1], 0.15, epsilon = f64::EPSILON.sqrt());
     }

--- a/argmin/src/solver/landweber/mod.rs
+++ b/argmin/src/solver/landweber/mod.rs
@@ -57,9 +57,9 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let grad = op.gradient(&param)?;
         let new_param = param.scaled_sub(&self.omega, &grad);
         Ok(ArgminIterData::new().param(new_param))

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -231,14 +231,14 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
         check_param!(
             self.search_direction,
             "MoreThuenteLineSearch: Search direction not initialized. Call `set_search_direction`."
         );
 
-        self.init_param = Some(state.get_param());
+        self.init_param = state.get_param();
 
         let cost = state.get_cost();
         self.finit = if cost.is_infinite() {
@@ -249,7 +249,7 @@ where
 
         self.init_grad = Some(
             state
-                .get_grad()
+                .take_grad()
                 .map(Result::Ok)
                 .unwrap_or_else(|| op.gradient(self.init_param.as_ref().unwrap()))?,
         );
@@ -287,7 +287,7 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         // set the minimum and maximum steps to correspond to the present interval of uncertainty
         let mut info = 0;

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -220,7 +220,7 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
         self.params = self
             .params
@@ -243,7 +243,7 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         let num_param = self.params.len();
 

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -77,9 +77,9 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let grad = op.gradient(&param)?;
         let hessian = op.hessian(&param)?;
         let new_param = param.scaled_sub(&self.gamma, &hessian.inv()?.dot(&grad));
@@ -174,7 +174,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -1.0, epsilon = f64::EPSILON);
         assert_relative_eq!(param[1], -2.0, epsilon = f64::EPSILON);
 
@@ -188,7 +189,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -2.0, epsilon = f64::EPSILON);
         assert_relative_eq!(param[1], -4.0, epsilon = f64::EPSILON);
 
@@ -202,7 +204,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -0.5, epsilon = f64::EPSILON);
         assert_relative_eq!(param[1], -1.0, epsilon = f64::EPSILON);
 
@@ -216,7 +219,8 @@ mod tests {
             .run()
             .unwrap()
             .state
-            .best_param;
+            .get_best_param()
+            .unwrap();
         assert_relative_eq!(param[0], -1.0, epsilon = f64::EPSILON);
         assert_relative_eq!(param[1], -2.0, epsilon = f64::EPSILON);
     }

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -144,7 +144,7 @@ where
     fn init(
         &mut self,
         _op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
         self.initialize_particles(_op);
 
@@ -155,7 +155,7 @@ where
     fn next_iter(
         &mut self,
         _op: &mut OpWrapper<O>,
-        _state: &IterState<O>,
+        _state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         let zero = O::Param::zero_like(&self.best_position);
 

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -93,9 +93,9 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let cost = op.apply(&param)?;
         let grad = op.gradient(&param)?;
         Ok(Some(
@@ -106,11 +106,11 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let cur_cost = state.get_cost();
-        let prev_grad = state.get_grad().unwrap();
+        let prev_grad = state.take_grad().unwrap();
 
         let gamma: F = if let (Some(sk), Some(yk)) = (self.s.back(), self.y.back()) {
             sk.dot(yk) / yk.dot(yk)
@@ -144,12 +144,7 @@ where
         // Run solver
         let ArgminResult {
             operator: line_op,
-            state:
-                IterState {
-                    param: xk1,
-                    cost: next_cost,
-                    ..
-                },
+            state: mut linesearch_state,
         } = Executor::new(
             op.take_op().unwrap(),
             self.linesearch.clone(),
@@ -159,6 +154,9 @@ where
         .cost(cur_cost)
         .ctrlc(false)
         .run()?;
+
+        let xk1 = linesearch_state.take_param().unwrap();
+        let next_cost = linesearch_state.get_cost();
 
         // take back operator and take care of function evaluation counts
         op.consume_op(line_op);
@@ -181,7 +179,7 @@ where
     }
 
     fn terminate(&mut self, state: &IterState<O>) -> TerminationReason {
-        if state.get_grad().unwrap().norm() < self.tol_grad {
+        if state.get_grad_ref().unwrap().norm() < self.tol_grad {
             return TerminationReason::TargetPrecisionReached;
         }
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol_cost {

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -102,9 +102,9 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let cost = op.apply(&param)?;
         let grad = op.gradient(&param)?;
         Ok(Some(
@@ -119,16 +119,15 @@ where
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
-        let param = state.get_param();
+        let param = state.take_param().unwrap();
         let cost = state.get_cost();
         let mut inv_hessian = state.get_inv_hessian().unwrap();
-        let prev_grad = if let Some(grad) = state.get_grad() {
-            grad
-        } else {
-            op.gradient(&param)?
-        };
+        let prev_grad = state
+            .take_grad()
+            .map(Result::Ok)
+            .unwrap_or_else(|| op.gradient(&param))?;
 
         let p = inv_hessian.dot(&prev_grad).mul(&F::from_f64(-1.0).unwrap());
 
@@ -137,12 +136,7 @@ where
         // Run solver
         let ArgminResult {
             operator: line_op,
-            state:
-                IterState {
-                    param: xk1,
-                    cost: next_cost,
-                    ..
-                },
+            state: mut linesearch_state,
         } = Executor::new(
             op.take_op().unwrap(),
             self.linesearch.clone(),
@@ -152,6 +146,9 @@ where
         .cost(cost)
         .ctrlc(false)
         .run()?;
+
+        let xk1 = linesearch_state.take_param().unwrap();
+        let next_cost = linesearch_state.get_cost();
 
         // take care of function eval counts
         op.consume_op(line_op);

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -245,35 +245,33 @@ where
     fn init(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<Option<ArgminIterData<O>>, Error> {
-        let cost = op.apply(&state.get_param())?;
-        Ok(Some(
-            ArgminIterData::new()
-                .param(state.get_param())
-                .cost(cost)
-                .kv(make_kv!(
-                    "initial_temperature" => self.init_temp;
-                    "stall_iter_accepted_limit" => self.stall_iter_accepted_limit;
-                    "stall_iter_best_limit" => self.stall_iter_best_limit;
-                    "reanneal_fixed" => self.reanneal_fixed;
-                    "reanneal_accepted" => self.reanneal_accepted;
-                    "reanneal_best" => self.reanneal_best;
-                )),
-        ))
+        let param = state.take_param().unwrap();
+        let cost = op.apply(&param)?;
+        Ok(Some(ArgminIterData::new().param(param).cost(cost).kv(
+            make_kv!(
+                "initial_temperature" => self.init_temp;
+                "stall_iter_accepted_limit" => self.stall_iter_accepted_limit;
+                "stall_iter_best_limit" => self.stall_iter_best_limit;
+                "reanneal_fixed" => self.reanneal_fixed;
+                "reanneal_accepted" => self.reanneal_accepted;
+                "reanneal_best" => self.reanneal_best;
+            ),
+        )))
     }
 
     /// Perform one iteration of SA algorithm
     fn next_iter(
         &mut self,
         op: &mut OpWrapper<O>,
-        state: &IterState<O>,
+        state: &mut IterState<O>,
     ) -> Result<ArgminIterData<O>, Error> {
         // Careful: The order in here is *very* important, even if it may not seem so. Everything
         // is linked to the iteration number, and getting things mixed up will lead to strange
         // behaviour.
 
-        let prev_param = state.get_param();
+        let prev_param = state.take_param().unwrap();
         let prev_cost = state.get_cost();
 
         // Make a move

--- a/argmin/src/tests.rs
+++ b/argmin/src/tests.rs
@@ -103,7 +103,7 @@ macro_rules! entropy_max_tests {
 				.unwrap();
 
 			assert_relative_eq!(
-				cost.apply(&res.state.param).unwrap(),
+				cost.apply(&res.state.get_param().unwrap()).unwrap(),
 				cost.apply(&cost.param_opt).unwrap(),
 				epsilon = 1e-6
 			);
@@ -133,7 +133,7 @@ fn test_lbfgs_func_count() {
         .unwrap();
 
     assert_relative_eq!(
-        cost.apply(&res.state.param).unwrap(),
+        cost.apply(&res.state.get_param().unwrap()).unwrap(),
         cost.apply(&cost.param_opt).unwrap(),
         epsilon = 1e-6
     );


### PR DESCRIPTION
This adds multiple methods to `IterState` which allow one to either move data, or copy data or get a reference to data when retrieving parameter vectors, gradients, Jacobians, and Hessians.

In the past, only copying was possible. All solvers have been adapted to use the new functions.

This also required `state` to be passed as a mutable reference into `init` and `next_iter` of the solvers.