### PR TITLE
Hessian in DFP and SR1 needs to implement Clone

### DIFF
--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -64,7 +64,8 @@ where
         + ArgminDot<O::Param, O::Hessian>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    H: SerializeAlias
+    H: Clone
+        + SerializeAlias
         + ArgminSub<O::Hessian, O::Hessian>
         + ArgminDot<O::Param, O::Param>
         + ArgminAdd<O::Hessian, O::Hessian>

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -90,7 +90,8 @@ where
         + ArgminDot<O::Param, O::Hessian>
         + ArgminNorm<O::Float>
         + ArgminMul<O::Float, O::Param>,
-    O::Hessian: SerializeAlias
+    O::Hessian: Clone
+        + SerializeAlias
         + ArgminDot<O::Param, O::Param>
         + ArgminAdd<O::Hessian, O::Hessian>
         + ArgminMul<F, O::Hessian>,


### PR DESCRIPTION
When merging #186 somehow a problem was introduced. The Clone trait bound in DFP and SR1 got lost.