### PR TITLE
version 0.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: argmin CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## argmin unreleased (xx xxxxxx xxxx)
 
+## argmin v0.5.1 (16 February 2022)
+
+- Fixed Bug in HagerZhang line search (#2, #184, @wfsteiner)
+- Removed Default trait bounds on TrustRegion and Steihaug implementations (#187, #192, @cfunky)
+- Inverse Hessians are now part of IterState, therefore the final inverse Hessian can be retrieved after an optimization run (#185, #186, @stefan-k)
+
 ## argmin v0.5.0 (10 January 2022)
 
 - Faster CI pipeline (#179, @stefan-k)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argmin"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Stefan Kroboth <stefan.kroboth@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ problems), developing tests, adding observers, implementing a C interface or
 ## Examples
 
 Examples for each solver can be found
-[here (current released version)](https://github.com/argmin-rs/argmin/tree/v0.5.0/examples) and
+[here (current released version)](https://github.com/argmin-rs/argmin/tree/v0.5.1/examples) and
 [here (main branch)](https://github.com/argmin-rs/argmin/tree/main/examples).
 
 ## Usage
@@ -85,7 +85,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-argmin = "0.5.0"
+argmin = "0.5.1"
 ```
 
 ### Optional features
@@ -96,7 +96,7 @@ There are additional features which can be activated in `Cargo.toml`:
 
 ```toml
 [dependencies]
-argmin = { version = "0.5.0", features = ["ctrlc", "ndarrayl", "nalgebral"] }
+argmin = { version = "0.5.1", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 ```
 
 These may become default features in the future. Without these features compilation to
@@ -119,11 +119,11 @@ ndarray-linalg = { version = "*", features = ["intel-mkl-static"] }
 When compiling to WASM, one of the following features must be used:
 
 ```toml
-argmin = { version = "0.5.0", features = ["wasm-bindgen"] }
+argmin = { version = "0.5.1", features = ["wasm-bindgen"] }
 ```
 
 ```toml
-argmin = { version = "0.5.0", features = ["stdweb"] }
+argmin = { version = "0.5.1", features = ["stdweb"] }
 ```
 
 Note that WASM support is still experimental. Please report any issues you encounter when compiling argmin to WASM.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //! # Examples
 //!
 //! Examples for each solver can be found
-//! [here (current released version)](https://github.com/argmin-rs/argmin/tree/v0.5.0/examples) and
+//! [here (current released version)](https://github.com/argmin-rs/argmin/tree/v0.5.1/examples) and
 //! [here (main branch)](https://github.com/argmin-rs/argmin/tree/main/examples).
 //!
 //! # Usage
@@ -85,7 +85,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argmin = "0.5.0"
+//! argmin = "0.5.1"
 //! ```
 //!
 //! ## Optional features
@@ -96,7 +96,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! argmin = { version = "0.5.0", features = ["ctrlc", "ndarrayl", "nalgebral"] }
+//! argmin = { version = "0.5.1", features = ["ctrlc", "ndarrayl", "nalgebral"] }
 //! ```
 //!
 //! These may become default features in the future. Without these features compilation to
@@ -119,11 +119,11 @@
 //! When compiling to WASM, one of the following features must be used:
 //!
 //! ```toml
-//! argmin = { version = "0.5.0", features = ["wasm-bindgen"] }
+//! argmin = { version = "0.5.1", features = ["wasm-bindgen"] }
 //! ```
 //!
 //! ```toml
-//! argmin = { version = "0.5.0", features = ["stdweb"] }
+//! argmin = { version = "0.5.1", features = ["stdweb"] }
 //! ```
 //!
 //! Note that WASM support is still experimental. Please report any issues you encounter when compiling argmin to WASM.
@@ -535,6 +535,8 @@
 // Explicitly disallow EQ comparison of floats. (This clippy lint is denied by default; however,
 // this is just to make sure that it will always stay this way.)
 #![deny(clippy::float_cmp)]
+#![allow(clippy::return_self_not_must_use)]
+#![allow(clippy::nonminimal_bool)]
 
 extern crate rand;
 


### PR DESCRIPTION
- Fixed Bug in HagerZhang line search (@wfsteiner)
  - #2 
  - #184 
- Removed Default trait bounds on TrustRegion and Steihaug implementations (@cfunky)
  - #187 
  - #192
- Inverse Hessians are now part of IterState, therefore the final inverse Hessian can be retrieved after an optimization run (@stefan-k)
  - #185
  - #186