### PR TITLE
Cleanup and improve documentation of `ConjugateGradient` and `NonlinearConjugateGradient`

### DIFF
--- a/argmin-math/src/nalgebra_m/dot.rs
+++ b/argmin-math/src/nalgebra_m/dot.rs
@@ -32,6 +32,7 @@ where
     ShapeConstraint: DimEq<R1, R2> + DimEq<C1, C2>,
 {
     #[inline]
+    #[allow(clippy::only_used_in_recursion)]
     fn dot(&self, other: &Matrix<N, R2, C2, SB>) -> N {
         self.dot(other)
     }

--- a/argmin/examples/conjugategradient.rs
+++ b/argmin/examples/conjugategradient.rs
@@ -31,7 +31,7 @@ fn run() -> Result<(), Error> {
     let operator = MyProblem {};
 
     // Set up the solver
-    let solver: ConjugateGradient<_, f64> = ConjugateGradient::new(b)?;
+    let solver: ConjugateGradient<_, f64> = ConjugateGradient::new(b);
 
     // Run solver
     let res = Executor::new(operator, solver)

--- a/argmin/examples/nonlinear_cg.rs
+++ b/argmin/examples/nonlinear_cg.rs
@@ -7,8 +7,7 @@
 
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor, Gradient};
-use argmin::solver::conjugategradient::NonlinearConjugateGradient;
-use argmin::solver::conjugategradient::PolakRibiere;
+use argmin::solver::conjugategradient::{beta::PolakRibiere, NonlinearConjugateGradient};
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin_testfunctions::{rosenbrock_2d, rosenbrock_2d_derivative};
 

--- a/argmin/examples/nonlinear_cg.rs
+++ b/argmin/examples/nonlinear_cg.rs
@@ -43,7 +43,7 @@ fn run() -> Result<(), Error> {
     let beta_method = PolakRibiere::new();
 
     // Set up nonlinear conjugate gradient method
-    let solver = NonlinearConjugateGradient::new(linesearch, beta_method)?
+    let solver = NonlinearConjugateGradient::new(linesearch, beta_method)
         // Set the number of iterations when a restart should be performed
         // This allows the algorithm to "forget" previous information which may not be helpful anymore.
         .restart_iters(10)

--- a/argmin/src/core/errors.rs
+++ b/argmin/src/core/errors.rs
@@ -47,6 +47,13 @@ pub enum ArgminError {
         text: String,
     },
 
+    /// For errors which are likely bugs.
+    #[error("Potential bug: {text:?}. This is potentially a bug. Please file a report on https://github.com/argmin-rs/argmin/issues")]
+    PotentialBug {
+        /// Text
+        text: String,
+    },
+
     /// Indicates an impossible error
     #[error("Impossible Error: {text:?}")]
     ImpossibleError {

--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -40,7 +40,7 @@ mod termination;
 /// Convenience utilities for testing
 pub mod test_utils;
 
-pub use crate::solver::conjugategradient::NLCGBetaUpdate;
+pub use crate::solver::conjugategradient::beta::NLCGBetaUpdate;
 pub use crate::solver::linesearch::LineSearch;
 pub use crate::solver::trustregion::TrustRegionRadius;
 pub use anyhow::Error;

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 ///   annealing,...)
 /// * elapsed time
 /// * termination reason (set to [`TerminationReason::NotTerminated`] if not terminated yet)
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct IterState<P, G, J, H, F> {
     /// Current parameter vector

--- a/argmin/src/solver/conjugategradient/beta.rs
+++ b/argmin/src/solver/conjugategradient/beta.rs
@@ -7,7 +7,10 @@
 
 //! # Beta update methods for [`NonlinearConjugateGradient`](`crate::solver::conjugategradient::NonlinearConjugateGradient`)
 //!
-//! TODO: Proper documentation.
+//! These methods define the update procedure for
+//! [`NonlinearConjugateGradient`](`crate::solver::conjugategradient::NonlinearConjugateGradient`).
+//! They are based on the [`NLCGBetaUpdate`] trait which enables users to implement their own beta
+//! update methods.
 //!
 //! # Reference
 //!
@@ -19,24 +22,55 @@ use argmin_math::{ArgminDot, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// Common interface for beta update methods (Nonlinear-CG)
+/// Interface for beta update methods ([`NonlinearConjugateGradient`](`crate::solver::conjugategradient::NonlinearConjugateGradient`))
+///
+/// # Example
+///
+/// ```
+/// # use argmin::core::{ArgminFloat, NLCGBetaUpdate};
+/// #[cfg(feature = "serde1")]
+/// use serde::{Deserialize, Serialize};
+///
+/// #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
+/// struct MyBetaMethod {}
+///
+/// impl<G, P, F> NLCGBetaUpdate<G, P, F> for MyBetaMethod
+/// where
+///     F: ArgminFloat,
+/// {
+///     fn update(&self, dfk: &G, dfk1: &G, p_k: &P) -> F {
+///         // Compute updated beta
+/// #       F::nan()
+///     }
+/// }
+/// ```
 pub trait NLCGBetaUpdate<G, P, F>: SerializeAlias {
-    /// Update beta
-    /// Parameter 1: \nabla f_k
-    /// Parameter 2: \nabla f_{k+1}
-    /// Parameter 3: p_k
+    /// Update beta.
+    ///
+    /// # Parameters
+    ///
+    /// * `\nabla f_k`
+    /// * `\nabla f_{k+1}`
+    /// * `p_k`
     fn update(&self, nabla_f_k: &G, nabla_f_k_p_1: &G, p_k: &P) -> F;
 }
 
 /// Fletcher and Reeves (FR) method
 ///
-/// TODO: Reference
+/// Formula: `<\nabla f_{k+1}, \nabla f_{k+1}> / <\nabla f_k, \nabla f_k>`
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct FletcherReeves {}
 
 impl FletcherReeves {
-    /// Constructor
+    /// Construct a new instance of `FletcherReeves`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::beta::FletcherReeves;
+    /// let beta_method = FletcherReeves::new();
+    /// ```
     pub fn new() -> Self {
         FletcherReeves {}
     }
@@ -47,20 +81,41 @@ where
     G: ArgminDot<G, F>,
     F: ArgminFloat,
 {
+    /// Update beta using the Fletcher-Reeves method.
+    ///
+    /// Formula: `<\nabla f_{k+1}, \nabla f_{k+1}> / <\nabla f_k, \nabla f_k>`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate approx;
+    /// # use approx::assert_relative_eq;
+    /// # use argmin::solver::conjugategradient::beta::{NLCGBetaUpdate, FletcherReeves};
+    /// # let dfk = vec![1f64, 2.0];
+    /// # let dfk1 = vec![3f64, 4.0];
+    /// let beta_method = FletcherReeves::new();
+    /// let beta: f64 = beta_method.update(&dfk, &dfk1, &());
+    /// # assert_relative_eq!(beta, 5.0, epsilon = f64::EPSILON);
+    /// ```
     fn update(&self, dfk: &G, dfk1: &G, _pk: &P) -> F {
         dfk1.dot(dfk1) / dfk.dot(dfk)
     }
 }
 
 /// Polak and Ribiere (PR) method
-///
-/// TODO: Reference
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibiere {}
 
 impl PolakRibiere {
-    /// Constructor
+    /// Construct a new instance of `PolakRibiere`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::beta::PolakRibiere;
+    /// let beta_method = PolakRibiere::new();
+    /// ```
     pub fn new() -> Self {
         PolakRibiere {}
     }
@@ -71,6 +126,22 @@ where
     G: ArgminDot<G, F> + ArgminSub<G, G> + ArgminNorm<F>,
     F: ArgminFloat,
 {
+    /// Update beta using the Polak-Ribiere method.
+    ///
+    /// Formula: `<\nabla f_{k+1}, (\nabla f_{k+1} - \nabla f_k)> / ||\nabla f_k||^2`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate approx;
+    /// # use approx::assert_relative_eq;
+    /// # use argmin::solver::conjugategradient::beta::{NLCGBetaUpdate, PolakRibiere};
+    /// # let dfk = vec![1f64, 2.0];
+    /// # let dfk1 = vec![3f64, 4.0];
+    /// let beta_method = PolakRibiere::new();
+    /// let beta = beta_method.update(&dfk, &dfk1, &());
+    /// # assert_relative_eq!(beta, 14.0/5.0, epsilon = f64::EPSILON);
+    /// ```
     fn update(&self, dfk: &G, dfk1: &G, _pk: &P) -> F {
         let dfk_norm_sq = dfk.norm().powi(2);
         dfk1.dot(&dfk1.sub(dfk)) / dfk_norm_sq
@@ -79,13 +150,20 @@ where
 
 /// Polak and Ribiere Plus (PR+) method
 ///
-/// TODO: Reference
+/// Formula: `max(0, <\nabla f_{k+1}, (\nabla f_{k+1} - \nabla f_k)> / ||\nabla f_k||^2)`
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PolakRibierePlus {}
 
 impl PolakRibierePlus {
-    /// Constructor
+    /// Construct a new instance of `PolakRibierePlus`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::beta::PolakRibierePlus;
+    /// let beta_method = PolakRibierePlus::new();
+    /// ```
     pub fn new() -> Self {
         PolakRibierePlus {}
     }
@@ -96,6 +174,28 @@ where
     G: ArgminDot<G, F> + ArgminSub<G, G> + ArgminNorm<F>,
     F: ArgminFloat,
 {
+    /// Update beta using the Polak-Ribiere+ (PR+) method.
+    ///
+    /// Formula: `max(0, <\nabla f_{k+1}, (\nabla f_{k+1} - \nabla f_k)> / ||\nabla f_k||^2)`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate approx;
+    /// # use approx::assert_relative_eq;
+    /// # use argmin::solver::conjugategradient::beta::{NLCGBetaUpdate, PolakRibierePlus};
+    /// # let dfk = vec![1f64, 2.0];
+    /// # let dfk1 = vec![3f64, 4.0];
+    /// let beta_method = PolakRibierePlus::new();
+    /// let beta = beta_method.update(&dfk, &dfk1, &());
+    /// # assert_relative_eq!(beta, 14.0/5.0, epsilon = f64::EPSILON);
+    /// #
+    /// # let dfk = vec![5f64, 6.0];
+    /// # let dfk1 = vec![3f64, 4.0];
+    /// # let beta_method = PolakRibierePlus::new();
+    /// # let beta = beta_method.update(&dfk, &dfk1, &());
+    /// # assert_relative_eq!(beta, 0.0, epsilon = f64::EPSILON);
+    /// ```
     fn update(&self, dfk: &G, dfk1: &G, _pk: &P) -> F {
         let dfk_norm_sq = dfk.norm().powi(2);
         let beta = dfk1.dot(&dfk1.sub(dfk)) / dfk_norm_sq;
@@ -105,13 +205,20 @@ where
 
 /// Hestenes and Stiefel (HS) method
 ///
-/// TODO: Reference
+/// Formula: `<\nabla f_{k+1}, (\nabla f_{k+1} - \nabla f_k)> / <(\nabla f_{k+1} - \nabla f_k), p_k>`
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct HestenesStiefel {}
 
 impl HestenesStiefel {
-    /// Constructor
+    /// Construct a new instance of `HestenesStiefel`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::beta::HestenesStiefel;
+    /// let beta_method = HestenesStiefel::new();
+    /// ```
     pub fn new() -> Self {
         HestenesStiefel {}
     }
@@ -122,6 +229,23 @@ where
     G: ArgminDot<G, F> + ArgminDot<P, F> + ArgminSub<G, G>,
     F: ArgminFloat,
 {
+    /// Update beta using the Hestenes-Stiefel method.
+    ///
+    /// Formula: `<\nabla f_{k+1}, (\nabla f_{k+1} - \nabla f_k)> / <(\nabla f_{k+1} - \nabla f_k), p_k>`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate approx;
+    /// # use approx::assert_relative_eq;
+    /// # use argmin::solver::conjugategradient::beta::{NLCGBetaUpdate, HestenesStiefel};
+    /// # let dfk = vec![1f64, 2.0];
+    /// # let dfk1 = vec![3f64, 4.0];
+    /// # let pk = vec![5f64, 6.0];
+    /// let beta_method = HestenesStiefel::new();
+    /// let beta: f64 = beta_method.update(&dfk, &dfk1, &pk);
+    /// # assert_relative_eq!(beta, 14.0/22.0, epsilon = f64::EPSILON);
+    /// ```
     fn update(&self, dfk: &G, dfk1: &G, pk: &P) -> F {
         let d = dfk1.sub(dfk);
         dfk1.dot(&d) / d.dot(pk)

--- a/argmin/src/solver/conjugategradient/beta.rs
+++ b/argmin/src/solver/conjugategradient/beta.rs
@@ -5,21 +5,31 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # Beta update methods
+//! # Beta update methods for [`NonlinearConjugateGradient`](`crate::solver::conjugategradient::NonlinearConjugateGradient`)
 //!
 //! TODO: Proper documentation.
 //!
-//! # References:
+//! # Reference
 //!
 //! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-use crate::core::{ArgminFloat, NLCGBetaUpdate};
+use crate::core::{ArgminFloat, SerializeAlias};
 use argmin_math::{ArgminDot, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
+/// Common interface for beta update methods (Nonlinear-CG)
+pub trait NLCGBetaUpdate<G, P, F>: SerializeAlias {
+    /// Update beta
+    /// Parameter 1: \nabla f_k
+    /// Parameter 2: \nabla f_{k+1}
+    /// Parameter 3: p_k
+    fn update(&self, nabla_f_k: &G, nabla_f_k_p_1: &G, p_k: &P) -> F;
+}
+
 /// Fletcher and Reeves (FR) method
+///
 /// TODO: Reference
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
@@ -43,6 +53,7 @@ where
 }
 
 /// Polak and Ribiere (PR) method
+///
 /// TODO: Reference
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
@@ -67,6 +78,7 @@ where
 }
 
 /// Polak and Ribiere Plus (PR+) method
+///
 /// TODO: Reference
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
@@ -92,6 +104,7 @@ where
 }
 
 /// Hestenes and Stiefel (HS) method
+///
 /// TODO: Reference
 #[derive(Default, Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -5,74 +5,84 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # References:
-//!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
-//! Springer. ISBN 0-387-30303-0.
-
 use crate::core::{
-    ArgminFloat, Error, IterState, Operator, Problem, SerializeAlias, Solver, State, KV,
+    ArgminError, ArgminFloat, Error, IterState, Operator, Problem, SerializeAlias, Solver, State,
+    KV,
 };
 use argmin_math::{ArgminConj, ArgminDot, ArgminMul, ArgminNorm, ArgminScaledAdd, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// The conjugate gradient method is a solver for systems of linear equations with a symmetric and
+/// A solver for systems of linear equations with a symmetric and positive-definite matrix.
+///
+/// Solves systems of the form `A * x = b` where `x` and `b` are vectors and `A` is a symmetric and
 /// positive-definite matrix.
 ///
-/// # References:
+/// Requires that the provided optimization problem implements [`Operator`].
+///
+/// # Reference
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct ConjugateGradient<P, F> {
-    /// b (right hand side)
+    /// b (right hand side of `A * x = b`)
     b: P,
-    /// residual
+    /// Residual
     r: Option<P>,
     /// p
     p: Option<P>,
     /// previous p
     p_prev: Option<P>,
     /// r^T * r
-    #[cfg_attr(feature = "serde1", serde(skip))]
     rtr: F,
 }
 
 impl<P, F> ConjugateGradient<P, F>
 where
-    P: Clone,
     F: ArgminFloat,
 {
-    /// Constructor
+    /// Constructs an instance of [`ConjugateGradient`]
     ///
-    /// Parameters:
+    /// Takes `b`, the right hand side of `A * x = b` as input.
     ///
-    /// `b`: right hand side of `A * x = b`
-    pub fn new(b: P) -> Result<Self, Error> {
-        Ok(ConjugateGradient {
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::ConjugateGradient;
+    /// # let b = vec![1.0f64, 1.0];
+    /// let cg: ConjugateGradient<_, f64> = ConjugateGradient::new(b);
+    /// ```
+    pub fn new(b: P) -> Self {
+        ConjugateGradient {
             b,
             r: None,
             p: None,
             p_prev: None,
             rtr: F::nan(),
+        }
+    }
+
+    /// Return the previous search direction (Needed by [`NewtonCG`](`crate::solver::newton::NewtonCG`))
+    ///
+    /// Returns an error if the field `p_prev` is not initialized.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::ConjugateGradient;
+    /// # use argmin::core::Error;
+    /// # let cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 1.0]);
+    /// let p_prev: Result<_, _> = cg.get_prev_p();
+    /// ```
+    pub fn get_prev_p(&self) -> Result<&P, Error> {
+        self.p_prev.as_ref().ok_or_else(|| {
+            ArgminError::NotInitialized {
+                text: "Field `p_prev` of `ConjugateGradient` not initialized.".to_string(),
+            }
+            .into()
         })
-    }
-
-    /// Return the current search direction (This is needed by NewtonCG for instance)
-    pub fn p(&self) -> &P {
-        self.p.as_ref().unwrap()
-    }
-
-    /// Return the previous search direction (This is needed by NewtonCG for instance)
-    pub fn p_prev(&self) -> &P {
-        self.p_prev.as_ref().unwrap()
-    }
-
-    /// Return the current residual (This is needed by NewtonCG for instance)
-    pub fn residual(&self) -> &P {
-        self.r.as_ref().unwrap()
     }
 }
 
@@ -95,12 +105,21 @@ where
         problem: &mut Problem<O>,
         state: IterState<P, (), (), (), F>,
     ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
-        let init_param = state.get_param().unwrap();
+        let init_param = state.get_param().ok_or_else(|| -> Error {
+            ArgminError::NotInitialized {
+                text: concat!(
+                    "`ConjugateGradient` requires an initial parameter vector. ",
+                    "Please provide an initial guess via `Executor`s `configure` method."
+                )
+                .to_string(),
+            }
+            .into()
+        })?;
         let ap = problem.apply(init_param)?;
         let r0 = self.b.sub(&ap).mul(&(F::from_f64(-1.0).unwrap()));
-        self.r = Some(r0.clone());
         self.p = Some(r0.mul(&(F::from_f64(-1.0).unwrap())));
         self.rtr = r0.dot(&r0.conj());
+        self.r = Some(r0);
         Ok((state, None))
     }
 
@@ -110,25 +129,41 @@ where
         problem: &mut Problem<O>,
         state: IterState<P, (), (), (), F>,
     ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
-        let p = self.p.as_ref().unwrap();
-        let r = self.r.as_ref().unwrap();
+        let p = self.p.take().ok_or_else(|| -> Error {
+            ArgminError::PotentialBug {
+                text: "`ConjugateGradient`: Field `p` not set".to_string(),
+            }
+            .into()
+        })?;
+        let r = self.r.as_ref().ok_or_else(|| -> Error {
+            ArgminError::PotentialBug {
+                text: "`ConjugateGradient`: Field `r` not set".to_string(),
+            }
+            .into()
+        })?;
 
-        self.p_prev = Some(p.clone());
-        let apk = problem.apply(p)?;
+        let apk = problem.apply(&p)?;
         let alpha = self.rtr.div(p.dot(&apk.conj()));
-        let new_param = state.get_param().unwrap().scaled_add(&alpha, p);
+        let state_param = state.get_param().ok_or_else(|| -> Error {
+            ArgminError::PotentialBug {
+                text: "`ConjugateGradient`: Parameter vector in `state` not set".to_string(),
+            }
+            .into()
+        })?;
+        let new_param = state_param.scaled_add(&alpha, &p);
         let r = r.scaled_add(&alpha, &apk);
         let rtr_n = r.dot(&r.conj());
         let beta = rtr_n.div(self.rtr);
         self.rtr = rtr_n;
-        let p = r.mul(&(F::from_f64(-1.0).unwrap())).scaled_add(&beta, p);
-        let norm = r.dot(&r.conj());
+        let p_n = r.mul(&(F::from_f64(-1.0).unwrap())).scaled_add(&beta, &p);
+        let norm = r.dot(&r.conj()).norm();
 
-        self.p = Some(p);
+        self.p = Some(p_n);
+        self.p_prev = Some(p);
         self.r = Some(r);
 
         Ok((
-            state.param(new_param).cost(norm.norm()),
+            state.param(new_param).cost(norm),
             Some(make_kv!("alpha" => alpha; "beta" => beta;)),
         ))
     }
@@ -137,7 +172,180 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{test_utils::TestProblem, IterState, Problem};
     use crate::test_trait_impl;
+    use approx::assert_relative_eq;
 
     test_trait_impl!(conjugate_gradient, ConjugateGradient<Vec<f64>, f64>);
+
+    #[test]
+    fn test_new() {
+        let cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let ConjugateGradient {
+            b,
+            r,
+            p,
+            p_prev,
+            rtr,
+        } = cg;
+        assert_eq!(b[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_eq!(b[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+        assert!(r.is_none());
+        assert!(p.is_none());
+        assert!(p_prev.is_none());
+        assert!(rtr.is_nan());
+    }
+
+    #[test]
+    fn test_get_prev_p_not_initialized() {
+        let cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let res: Result<_, _> = cg.get_prev_p();
+        assert_error!(
+            res,
+            ArgminError,
+            "Not initialized: \"Field `p_prev` of `ConjugateGradient` not initialized.\""
+        );
+    }
+
+    #[test]
+    fn test_get_prev_p() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        cg.p_prev = Some(vec![3.0f64, 4.0]);
+        let res: Result<_, _> = cg.get_prev_p();
+        assert!(res.is_ok());
+        let p_prev = res.unwrap();
+        assert_eq!(p_prev[0].to_ne_bytes(), 3.0f64.to_ne_bytes());
+        assert_eq!(p_prev[1].to_ne_bytes(), 4.0f64.to_ne_bytes());
+    }
+
+    #[test]
+    fn test_init_param_not_initialized() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let res = cg.init(&mut Problem::new(TestProblem::new()), IterState::new());
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Not initialized: \"`ConjugateGradient` requires an initial parameter vector. ",
+                "Please provide an initial guess via `Executor`s `configure` method.\""
+            )
+        );
+    }
+
+    #[test]
+    fn test_init() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new().param(vec![3.0, 4.0]);
+        let (state_out, kv) = cg
+            .init(&mut Problem::new(TestProblem::new()), state.clone())
+            .unwrap();
+        assert!(kv.is_none());
+        // State remains unchanged in `init`.
+        assert_eq!(state_out, state);
+
+        let ConjugateGradient {
+            b,
+            r,
+            p,
+            p_prev,
+            rtr,
+        } = cg;
+
+        assert_relative_eq!(b[0], 1.0, epsilon = f64::EPSILON);
+        assert_relative_eq!(b[1], 2.0, epsilon = f64::EPSILON);
+        let r0 = vec![2.0f64, 2.0];
+        assert_relative_eq!(r0[0], r.as_ref().unwrap()[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(r0[1], r.as_ref().unwrap()[1], epsilon = f64::EPSILON);
+        let pp = vec![-2.0f64, -2.0];
+        assert_relative_eq!(pp[0], p.as_ref().unwrap()[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(pp[1], p.as_ref().unwrap()[1], epsilon = f64::EPSILON);
+        assert_relative_eq!(rtr, 8.0, epsilon = f64::EPSILON);
+        assert!(p_prev.is_none());
+    }
+
+    #[test]
+    fn test_next_iter_p_not_set() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let state = IterState::new().param(vec![1.0f64]);
+        cg.r = Some(vec![]);
+        assert!(cg.p.is_none());
+        let res = cg.next_iter(&mut Problem::new(TestProblem::new()), state);
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Potential bug: \"`ConjugateGradient`: ",
+                "Field `p` not set\". This is potentially a bug. ",
+                "Please file a report on https://github.com/argmin-rs/argmin/issues"
+            )
+        );
+    }
+
+    #[test]
+    fn test_next_iter_r_not_set() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let state = IterState::new().param(vec![1.0f64]);
+        cg.p = Some(vec![]);
+        assert!(cg.r.is_none());
+        let res = cg.next_iter(&mut Problem::new(TestProblem::new()), state);
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Potential bug: \"`ConjugateGradient`: ",
+                "Field `r` not set\". This is potentially a bug. ",
+                "Please file a report on https://github.com/argmin-rs/argmin/issues"
+            )
+        );
+    }
+
+    #[test]
+    fn test_next_iter_state_param_not_set() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
+        let state = IterState::new();
+        cg.p = Some(vec![]);
+        cg.r = Some(vec![]);
+        assert!(state.param.is_none());
+        let res = cg.next_iter(&mut Problem::new(TestProblem::new()), state);
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Potential bug: \"`ConjugateGradient`: ",
+                "Parameter vector in `state` not set\". This is potentially a bug. ",
+                "Please file a report on https://github.com/argmin-rs/argmin/issues"
+            )
+        );
+    }
+
+    #[test]
+    fn test_next_iter() {
+        let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![2.0f64]);
+        let state = IterState::new().param(vec![1.0f64]);
+        let mut problem = Problem::new(TestProblem::new());
+        let (state, _) = cg.init(&mut problem, state).unwrap();
+        let rtr = cg.rtr;
+        let p = cg.p.clone().unwrap()[0];
+        let r = cg.r.clone().unwrap()[0];
+
+        let apk = p;
+        let alpha = rtr / (p * apk);
+        let new_param = 1.0 + alpha * p;
+        let r = r + alpha * apk;
+        let rtr_n = -r * r;
+        let beta = rtr_n / rtr;
+        let p_n = -r + beta * p;
+        let norm = (r * r).norm();
+
+        let (state, kv) = cg.next_iter(&mut problem, state).unwrap();
+        assert!(kv.is_some());
+
+        assert_relative_eq!(r, cg.r.as_ref().unwrap()[0]);
+        assert_relative_eq!(p_n, cg.p.as_ref().unwrap()[0]);
+        assert_relative_eq!(p, cg.p_prev.as_ref().unwrap()[0]);
+        assert_relative_eq!(rtr_n, cg.rtr);
+
+        assert_relative_eq!(norm, state.get_cost());
+        assert_relative_eq!(new_param, state.get_param().unwrap()[0]);
+    }
 }

--- a/argmin/src/solver/conjugategradient/mod.rs
+++ b/argmin/src/solver/conjugategradient/mod.rs
@@ -5,36 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! Conjugate Gradient methods
+//! # Conjugate Gradient methods
 //!
-//! * [Conjugate Gradients](cg/struct.ConjugateGradient.html)
-//! * [Nonlinear Conjugate Gradients](nonlinear_cg/struct.NonlinearConjugateGradient.html)
+//! * [Conjugate Gradient](`ConjugateGradient`)
+//! * [Nonlinear Conjugate Gradient](`NonlinearConjugateGradient`)
 //!
-//! # References:
+//! # Reference
 //!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
+//! Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-/// Conjugate gradient method
-pub mod cg;
+mod cg;
+mod nonlinear_cg;
 
-/// Nonlinear conjugate gradient method
-pub mod nonlinear_cg;
-
-/// Beta update methods for nonlinear CG
 pub mod beta;
 
-pub use self::beta::*;
-pub use self::cg::*;
-pub use self::nonlinear_cg::*;
-
-use crate::core::SerializeAlias;
-
-/// Common interface for beta update methods (Nonlinear-CG)
-pub trait NLCGBetaUpdate<G, P, F>: SerializeAlias {
-    /// Update beta
-    /// Parameter 1: \nabla f_k
-    /// Parameter 2: \nabla f_{k+1}
-    /// Parameter 3: p_k
-    fn update(&self, nabla_f_k: &G, nabla_f_k_p_1: &G, p_k: &P) -> F;
-}
+pub use self::cg::ConjugateGradient;
+pub use self::nonlinear_cg::NonlinearConjugateGradient;

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -5,11 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # References:
-//!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
-//! Springer. ISBN 0-387-30303-0.
-
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, NLCGBetaUpdate, OptimizationResult, Problem, SerializeAlias, Solver, State, KV,
@@ -18,10 +13,9 @@ use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// The nonlinear conjugate gradient is a generalization of the conjugate gradient method for
-/// nonlinear optimization problems.
+/// A generalization of the conjugate gradient method for nonlinear optimization problems.
 ///
-/// # References:
+/// # Reference
 ///
 /// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
@@ -46,7 +40,7 @@ impl<P, L, B, F> NonlinearConjugateGradient<P, L, B, F>
 where
     F: ArgminFloat,
 {
-    /// Constructor (Polak Ribiere Conjugate Gradient (PR-CG))
+    /// Constructor
     pub fn new(linesearch: L, beta_method: B) -> Result<Self, Error> {
         Ok(NonlinearConjugateGradient {
             p: None,

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -40,21 +40,44 @@ impl<P, L, B, F> NonlinearConjugateGradient<P, L, B, F>
 where
     F: ArgminFloat,
 {
-    /// Constructor
-    pub fn new(linesearch: L, beta_method: B) -> Result<Self, Error> {
-        Ok(NonlinearConjugateGradient {
+    /// Construct a new instance of `NonlinearConjugateGradient`.
+    ///
+    /// Takes a [`LineSearch`] and a [`NLCGBetaUpdate`] as input.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::NonlinearConjugateGradient;
+    /// # let linesearch = ();
+    /// # let beta_method = ();
+    /// let nlcg: NonlinearConjugateGradient<Vec<f64>, _, _, f64> =
+    ///     NonlinearConjugateGradient::new(linesearch, beta_method);
+    /// ```
+    pub fn new(linesearch: L, beta_method: B) -> Self {
+        NonlinearConjugateGradient {
             p: None,
             beta: F::nan(),
             linesearch,
             beta_method,
             restart_iter: std::u64::MAX,
             restart_orthogonality: None,
-        })
+        }
     }
 
-    /// Specifiy the number of iterations after which a restart should be performed
+    /// Specifiy the number of iterations after which a restart should be performed.
+    ///
     /// This allows the algorithm to "forget" previous information which may not be helpful
     /// anymore.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::NonlinearConjugateGradient;
+    /// # let linesearch = ();
+    /// # let beta_method = ();
+    /// # let nlcg: NonlinearConjugateGradient<Vec<f64>, _, _, f64> = NonlinearConjugateGradient::new(linesearch, beta_method);
+    /// let nlcg = nlcg.restart_iters(100);
+    /// ```
     #[must_use]
     pub fn restart_iters(mut self, iters: u64) -> Self {
         self.restart_iter = iters;
@@ -62,13 +85,24 @@ where
     }
 
     /// Set the value for the orthogonality measure.
-    /// Setting this parameter leads to a restart of the algorithm (setting beta = 0) after two
-    /// consecutive search directions are not orthogonal anymore. In other words, if this condition
+    ///
+    /// Setting this parameter leads to a restart of the algorithm (setting beta = 0) after
+    /// consecutive search directions stop being orthogonal. In other words, if this condition
     /// is met:
     ///
-    /// `|\nabla f_k^T * \nabla f_{k-1}| / | \nabla f_k ||^2 >= v`
+    /// `|\nabla f_k^T * \nabla f_{k-1}| / | \nabla f_k |^2 >= v`
     ///
     /// A typical value for `v` is 0.1.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::conjugategradient::NonlinearConjugateGradient;
+    /// # let linesearch = ();
+    /// # let beta_method = ();
+    /// # let nlcg: NonlinearConjugateGradient<Vec<f64>, _, _, f64> = NonlinearConjugateGradient::new(linesearch, beta_method);
+    /// let nlcg = nlcg.restart_orthogonality(0.1);
+    /// ```
     #[must_use]
     pub fn restart_orthogonality(mut self, v: F) -> Self {
         self.restart_orthogonality = Some(v);

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -109,7 +109,7 @@ where
 
         let mut x_p = param.zero_like();
         let mut x: P = param.zero_like();
-        let mut cg = ConjugateGradient::new(grad.mul(&(F::from_f64(-1.0).unwrap())))?;
+        let mut cg = ConjugateGradient::new(grad.mul(&(F::from_f64(-1.0).unwrap())));
 
         let cg_state = IterState::new().param(x_p.clone());
         let (mut cg_state, _) = cg.init(&mut cg_problem, cg_state)?;
@@ -119,7 +119,7 @@ where
             cg_state = state_tmp;
             let cost = cg_state.get_cost();
             x = cg_state.take_param().unwrap();
-            let p = cg.p_prev();
+            let p = cg.get_prev_p()?;
             let curvature = p.dot(&hessian.dot(p));
             if curvature <= self.curvature_threshold {
                 if iter == 0 {


### PR DESCRIPTION
* [x] Properly document `ConjugateGradient`
* [x] Doctests for `ConjugateGradient` methods
* [x] Test `ConjugateGradient`
* [x] Properly document beta methods
* [x] Doctests for beta methods
* [x] Properly document `NonlinearConjugateGradient`
* [x] Doctests for `NonlinearConjugateGradient` methods
* [x] Test `NonlinearConjugateGradient`
* [x] Remove all `.unwrap()`s