### PR TITLE
`argmin_error!` and `argmin_error_closure!` macros for easier error creation

### DIFF
--- a/argmin/src/core/macros.rs
+++ b/argmin/src/core/macros.rs
@@ -41,7 +41,7 @@ macro_rules! check_param {
     ($param:expr, $msg:expr, $error:ident) => {
         match $param {
             None => {
-                return Err(ArgminError::$error {
+                return Err($crate::core::ArgminError::$error {
                     text: $msg.to_string(),
                 }
                 .into());
@@ -51,6 +51,26 @@ macro_rules! check_param {
     };
     ($param:expr, $msg:expr) => {
         check_param!($param, $msg, NotInitialized)
+    };
+}
+
+/// Create an `ArgminError` with a provided message.
+#[macro_export]
+macro_rules! argmin_error {
+    ($error_type:ident, $msg:expr) => {
+        $crate::core::ArgminError::$error_type {
+            text: $msg.to_string(),
+        }
+        .into()
+    };
+}
+
+/// Create an `ArgminError` with a provided message wrapped in a closure for use in
+/// `.ok_or_else(...)` methods on `Option`s.
+#[macro_export]
+macro_rules! argmin_error_closure {
+    ($error_type:ident, $msg:expr) => {
+        || -> $crate::core::Error { argmin_error!($error_type, $msg) }
     };
 }
 

--- a/argmin/src/core/problem.rs
+++ b/argmin/src/core/problem.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{ArgminError, ArgminFloat, Error};
+use crate::core::{ArgminFloat, Error};
 use std::collections::HashMap;
 
 /// Wrapper around problems defined by users.
@@ -484,27 +484,27 @@ pub trait LinearProgram {
     /// TODO c for linear programs
     /// Those three could maybe be merged into a single function; name unclear
     fn c(&self) -> Result<Vec<Self::Float>, Error> {
-        Err(ArgminError::NotImplemented {
-            text: "Method `c` of LinearProgram trait not implemented!".to_string(),
-        }
-        .into())
+        Err(argmin_error!(
+            NotImplemented,
+            "Method `c` of LinearProgram trait not implemented!"
+        ))
     }
 
     /// TODO b for linear programs
     fn b(&self) -> Result<Vec<Self::Float>, Error> {
-        Err(ArgminError::NotImplemented {
-            text: "Method `b` of LinearProgram trait not implemented!".to_string(),
-        }
-        .into())
+        Err(argmin_error!(
+            NotImplemented,
+            "Method `b` of LinearProgram trait not implemented!"
+        ))
     }
 
     /// TODO A for linear programs
     #[allow(non_snake_case)]
     fn A(&self) -> Result<Vec<Vec<Self::Float>>, Error> {
-        Err(ArgminError::NotImplemented {
-            text: "Method `A` of LinearProgram trait not implemented!".to_string(),
-        }
-        .into())
+        Err(argmin_error!(
+            NotImplemented,
+            "Method `A` of LinearProgram trait not implemented!"
+        ))
     }
 }
 

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -6,8 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::{
-    ArgminError, ArgminFloat, Error, IterState, Jacobian, Operator, Problem, Solver, State,
-    TerminationReason, KV,
+    ArgminFloat, Error, IterState, Jacobian, Operator, Problem, Solver, State, TerminationReason,
+    KV,
 };
 use argmin_math::{ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminSub, ArgminTranspose};
 #[cfg(feature = "serde1")]
@@ -66,10 +66,10 @@ impl<F: ArgminFloat> GaussNewton<F> {
     /// ```
     pub fn with_gamma(mut self, gamma: F) -> Result<Self, Error> {
         if gamma <= F::from_f64(0.0).unwrap() || gamma > F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Gauss-Newton: gamma must be in  (0, 1].".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Gauss-Newton: gamma must be in  (0, 1]."
+            ));
         }
         self.gamma = gamma;
         Ok(self)
@@ -91,10 +91,10 @@ impl<F: ArgminFloat> GaussNewton<F> {
     /// ```
     pub fn with_tolerance(mut self, tol: F) -> Result<Self, Error> {
         if tol <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Gauss-Newton: tol must be positive.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Gauss-Newton: tol must be positive."
+            ));
         }
         self.tol = tol;
         Ok(self)
@@ -127,16 +127,13 @@ where
         problem: &mut Problem<O>,
         state: IterState<P, (), J, (), F>,
     ) -> Result<(IterState<P, (), J, (), F>, Option<KV>), Error> {
-        let param = state.get_param().ok_or_else(|| -> Error {
-            ArgminError::NotInitialized {
-                text: concat!(
-                    "`GaussNewton` requires an initial parameter vector. ",
-                    "Please provide an initial guess via `Executor`s `configure` method."
-                )
-                .to_string(),
-            }
-            .into()
-        })?;
+        let param = state.get_param().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`GaussNewton` requires an initial parameter vector. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
         let residuals = problem.apply(param)?;
         let jacobian = problem.jacobian(param)?;
 
@@ -163,6 +160,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::ArgminError;
     #[cfg(feature = "ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -17,8 +17,7 @@
 //! <https://en.wikipedia.org/wiki/Golden-section_search>
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, IterState, Problem, Solver, TerminationReason,
-    KV,
+    ArgminFloat, CostFunction, Error, IterState, Problem, Solver, TerminationReason, KV,
 };
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -86,11 +85,10 @@ where
     /// ```
     pub fn new(min_bound: F, max_bound: F) -> Result<Self, Error> {
         if max_bound <= min_bound {
-            return Err(ArgminError::InvalidParameter {
-                text: "`GoldenSectionSearch`: `min_bound` must be smaller than `max_bound`."
-                    .to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`GoldenSectionSearch`: `min_bound` must be smaller than `max_bound`."
+            ));
         }
         Ok(GoldenSectionSearch {
             g1: F::from(G1).unwrap(),
@@ -123,10 +121,10 @@ where
     /// ```
     pub fn with_tolerance(mut self, tolerance: F) -> Result<Self, Error> {
         if tolerance <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "`GoldenSectionSearch`: Tolerance must be larger than 0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`GoldenSectionSearch`: Tolerance must be larger than 0."
+            ));
         }
         self.tolerance = tolerance;
         Ok(self)
@@ -145,22 +143,18 @@ where
         problem: &mut Problem<O>,
         mut state: IterState<F, (), (), (), F>,
     ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
-        let init_estimate = state.take_param().ok_or_else(|| -> Error {
-            ArgminError::NotInitialized {
-                text: concat!(
-                    "`GoldenSectionSearch` requires an initial estimate. ",
-                    "Please provide an initial guess via `Executor`s `configure` method."
-                )
-                .to_string(),
-            }
-            .into()
-        })?;
+        let init_estimate = state.take_param().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`GoldenSectionSearch` requires an initial estimate. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
         if init_estimate < self.min_bound || init_estimate > self.max_bound {
-            Err(ArgminError::InvalidParameter {
-                text: "`GoldenSectionSearch`: Initial estimate must be ∈ [min_bound, max_bound]."
-                    .to_string(),
-            }
-            .into())
+            Err(argmin_error!(
+                InvalidParameter,
+                "`GoldenSectionSearch`: Initial estimate must be ∈ [min_bound, max_bound]."
+            ))
         } else {
             let ie_min = init_estimate - self.min_bound;
             let max_ie = self.max_bound - init_estimate;
@@ -217,7 +211,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::State;
+    use crate::core::{ArgminError, State};
     use crate::test_trait_impl;
     use approx::assert_relative_eq;
 

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -8,8 +8,8 @@
 //! * [Backtracking line search](struct.BacktrackingLineSearch.html)
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem,
-    SerializeAlias, Solver, State, TerminationReason, KV,
+    ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
+    Solver, State, TerminationReason, KV,
 };
 use crate::solver::linesearch::condition::*;
 use argmin_math::ArgminScaledAdd;
@@ -64,11 +64,10 @@ where
     /// Set rho
     pub fn rho(mut self, rho: F) -> Result<Self, Error> {
         if rho <= F::from_f64(0.0).unwrap() || rho >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "BacktrackingLineSearch: Contraction factor rho must be in (0, 1)."
-                    .to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "BacktrackingLineSearch: Contraction factor rho must be in (0, 1)."
+            ));
         }
         self.rho = rho;
         Ok(self)
@@ -87,10 +86,10 @@ where
     /// Set initial alpha value
     fn set_init_alpha(&mut self, alpha: F) -> Result<(), Error> {
         if alpha <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "LineSearch: Inital alpha must be > 0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "LineSearch: Inital alpha must be > 0."
+            ));
         }
         self.alpha = alpha;
         Ok(())
@@ -162,10 +161,10 @@ where
             .unwrap_or_else(|| problem.gradient(&init_param))?;
 
         if self.search_direction.is_none() {
-            return Err(ArgminError::NotInitialized {
-                text: "BacktrackingLineSearch: search_direction must be set.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                NotInitialized,
+                "BacktrackingLineSearch: search_direction must be set."
+            ));
         }
 
         self.init_param = Some(init_param);
@@ -204,7 +203,7 @@ where
 mod tests {
     use super::*;
     use crate::assert_error;
-    use crate::core::{test_utils::TestProblem, Executor, State};
+    use crate::core::{test_utils::TestProblem, ArgminError, Executor, State};
     use crate::test_trait_impl;
     use approx::assert_relative_eq;
     use num_traits::Float;

--- a/argmin/src/solver/linesearch/condition.rs
+++ b/argmin/src/solver/linesearch/condition.rs
@@ -10,7 +10,7 @@
 //! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-use crate::core::{ArgminError, ArgminFloat, Error, SerializeAlias};
+use crate::core::{ArgminFloat, Error, SerializeAlias};
 use argmin_math::ArgminDot;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -46,10 +46,10 @@ where
     /// Constructor
     pub fn new(c: F) -> Result<Self, Error> {
         if c <= F::from_f64(0.0).unwrap() || c >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "ArmijoCondition: Parameter c must be in (0, 1)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "ArmijoCondition: Parameter c must be in (0, 1)"
+            ));
         }
         Ok(ArmijoCondition { c })
     }
@@ -92,16 +92,16 @@ where
     /// Constructor
     pub fn new(c1: F, c2: F) -> Result<Self, Error> {
         if c1 <= F::from_f64(0.0).unwrap() || c1 >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "WolfeCondition: Parameter c1 must be in (0, 1)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "WolfeCondition: Parameter c1 must be in (0, 1)"
+            ));
         }
         if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "WolfeCondition: Parameter c2 must be in (c1, 1)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "WolfeCondition: Parameter c2 must be in (c1, 1)"
+            ));
         }
         Ok(WolfeCondition { c1, c2 })
     }
@@ -146,16 +146,16 @@ where
     /// Constructor
     pub fn new(c1: F, c2: F) -> Result<Self, Error> {
         if c1 <= F::from_f64(0.0).unwrap() || c1 >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "StrongWolfeCondition: Parameter c1 must be in (0, 1)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "StrongWolfeCondition: Parameter c1 must be in (0, 1)"
+            ));
         }
         if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "StrongWolfeCondition: Parameter c2 must be in (c1, 1)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "StrongWolfeCondition: Parameter c2 must be in (c1, 1)"
+            ));
         }
         Ok(StrongWolfeCondition { c1, c2 })
     }
@@ -199,10 +199,10 @@ where
     /// Constructor
     pub fn new(c: F) -> Result<Self, Error> {
         if c <= F::from_f64(0.0).unwrap() || c >= F::from_f64(0.5).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "GoldsteinCondition: Parameter c must be in (0, 0.5)".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "GoldsteinCondition: Parameter c must be in (0, 0.5)"
+            ));
         }
         Ok(GoldsteinCondition { c })
     }
@@ -236,6 +236,7 @@ where
 mod tests {
     use super::*;
     use crate::assert_error;
+    use crate::core::ArgminError;
     use crate::test_trait_impl;
 
     test_trait_impl!(goldstein, GoldsteinCondition<f64>);

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -14,8 +14,8 @@
 //! DOI: <https://doi.org/10.1137/030601880>
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem,
-    SerializeAlias, Solver, TerminationReason, KV,
+    ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
+    Solver, TerminationReason, KV,
 };
 use argmin_math::{ArgminDot, ArgminScaledAdd};
 #[cfg(feature = "serde1")]
@@ -137,16 +137,16 @@ where
     /// set delta
     pub fn delta(mut self, delta: F) -> Result<Self, Error> {
         if delta <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: delta must be > 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: delta must be > 0.0."
+            ));
         }
         if delta >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: delta must be < 1.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: delta must be < 1.0."
+            ));
         }
         self.delta = delta;
         Ok(self)
@@ -155,16 +155,16 @@ where
     /// set sigma
     pub fn sigma(mut self, sigma: F) -> Result<Self, Error> {
         if sigma < self.delta {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: sigma must be >= delta.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: sigma must be >= delta."
+            ));
         }
         if sigma >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: sigma must be < 1.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: sigma must be < 1.0."
+            ));
         }
         self.sigma = sigma;
         Ok(self)
@@ -173,10 +173,10 @@ where
     /// set epsilon
     pub fn epsilon(mut self, epsilon: F) -> Result<Self, Error> {
         if epsilon < F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: epsilon must be >= 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: epsilon must be >= 0.0."
+            ));
         }
         self.epsilon = epsilon;
         Ok(self)
@@ -185,16 +185,16 @@ where
     /// set theta
     pub fn theta(mut self, theta: F) -> Result<Self, Error> {
         if theta <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: theta must be > 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: theta must be > 0.0."
+            ));
         }
         if theta >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: theta must be < 1.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: theta must be < 1.0."
+            ));
         }
         self.theta = theta;
         Ok(self)
@@ -203,16 +203,16 @@ where
     /// set gamma
     pub fn gamma(mut self, gamma: F) -> Result<Self, Error> {
         if gamma <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: gamma must be > 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: gamma must be > 0.0."
+            ));
         }
         if gamma >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: gamma must be < 1.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: gamma must be < 1.0."
+            ));
         }
         self.gamma = gamma;
         Ok(self)
@@ -221,10 +221,10 @@ where
     /// set eta
     pub fn eta(mut self, eta: F) -> Result<Self, Error> {
         if eta <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: eta must be > 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: eta must be > 0.0."
+            ));
         }
         self.eta = eta;
         Ok(self)
@@ -233,16 +233,16 @@ where
     /// set alpha limits
     pub fn alpha(mut self, alpha_min: F, alpha_max: F) -> Result<Self, Error> {
         if alpha_min < F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: alpha_min must be >= 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: alpha_min must be >= 0.0."
+            ));
         }
         if alpha_max <= alpha_min {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: alpha_min must be smaller than alpha_max.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: alpha_min must be smaller than alpha_max."
+            ));
         }
         self.a_x_init = alpha_min;
         self.b_x_init = alpha_max;
@@ -300,10 +300,10 @@ where
         }
 
         // return Ok(((a_x, a_f, a_g), (b_x, b_f, b_g)));
-        Err(ArgminError::InvalidParameter {
-            text: "HagerZhangLineSearch: Reached unreachable point in `update` method.".to_string(),
-        }
-        .into())
+        Err(argmin_error!(
+            PotentialBug,
+            "HagerZhangLineSearch: Reached unreachable point in `update` method."
+        ))
     }
 
     /// secant step
@@ -440,10 +440,10 @@ where
         mut state: IterState<P, G, (), (), F>,
     ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
         if self.sigma < self.delta {
-            return Err(ArgminError::InvalidParameter {
-                text: "HagerZhangLineSearch: sigma must be >= delta.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "HagerZhangLineSearch: sigma must be >= delta."
+            ));
         }
 
         check_param!(

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -22,8 +22,8 @@
 #![allow(clippy::nonminimal_bool)]
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem,
-    SerializeAlias, Solver, State, TerminationReason, KV,
+    ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
+    Solver, State, TerminationReason, KV,
 };
 use argmin_math::{ArgminDot, ArgminScaledAdd};
 #[cfg(feature = "serde1")]
@@ -152,16 +152,16 @@ where
     /// Set c1 and c2 where 0 < c1 < c2 < 1.
     pub fn c(mut self, c1: F, c2: F) -> Result<Self, Error> {
         if c1 <= F::from_f64(0.0).unwrap() || c1 >= c2 {
-            return Err(ArgminError::InvalidParameter {
-                text: "MoreThuenteLineSearch: Parameter c1 must be in (0, c2).".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "MoreThuenteLineSearch: Parameter c1 must be in (0, c2)."
+            ));
         }
         if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "MoreThuenteLineSearch: Parameter c2 must be in (c1, 1).".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "MoreThuenteLineSearch: Parameter c2 must be in (c1, 1)."
+            ));
         }
         self.ftol = c1;
         self.gtol = c2;
@@ -171,17 +171,16 @@ where
     /// set alpha limits
     pub fn alpha(mut self, alpha_min: F, alpha_max: F) -> Result<Self, Error> {
         if alpha_min < F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "MoreThuenteLineSearch: alpha_min must be >= 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "MoreThuenteLineSearch: alpha_min must be >= 0.0."
+            ));
         }
         if alpha_max <= alpha_min {
-            return Err(ArgminError::InvalidParameter {
-                text: "MoreThuenteLineSearch: alpha_min must be smaller than alpha_max."
-                    .to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "MoreThuenteLineSearch: alpha_min must be smaller than alpha_max."
+            ));
         }
         self.stpmin = alpha_min;
         self.stpmax = alpha_max;
@@ -210,10 +209,10 @@ where
     /// Set initial alpha value
     fn set_init_alpha(&mut self, alpha: F) -> Result<(), Error> {
         if alpha <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "MoreThuenteLineSearch: Initial alpha must be > 0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "MoreThuenteLineSearch: Initial alpha must be > 0."
+            ));
         }
         self.alpha = alpha;
         Ok(())
@@ -263,11 +262,10 @@ where
 
         // compute search direction in 1D
         if self.dginit >= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::ConditionViolated {
-                text: "MoreThuenteLineSearch: Search direction must be a descent direction."
-                    .to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                ConditionViolated,
+                "MoreThuenteLineSearch: Search direction must be a descent direction."
+            ));
         }
 
         self.stage1 = true;
@@ -464,10 +462,10 @@ fn cstep<F: ArgminFloat>(
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
-            return Err(ArgminError::ConditionViolated {
-                text: "MoreThuenteLineSearch: NaN or Inf encountered during iteration".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                ConditionViolated,
+                "MoreThuenteLineSearch: NaN or Inf encountered during iteration"
+            ));
         }
         let s = tmp.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
         let mut gamma = *s * ((theta / *s).powi(2) - (stx.gx / *s) * (stp.gx / *s)).sqrt();
@@ -500,10 +498,10 @@ fn cstep<F: ArgminFloat>(
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
-            return Err(ArgminError::ConditionViolated {
-                text: "MoreThuenteLineSearch: NaN or Inf encountered during iteration".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                ConditionViolated,
+                "MoreThuenteLineSearch: NaN or Inf encountered during iteration"
+            ));
         }
         let s = tmp.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
         let mut gamma = *s * ((theta / *s).powi(2) - (stx.gx / *s) * (stp.gx / *s)).sqrt();
@@ -535,10 +533,10 @@ fn cstep<F: ArgminFloat>(
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
-            return Err(ArgminError::ConditionViolated {
-                text: "MoreThuenteLineSearch: NaN or Inf encountered during iteration".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                ConditionViolated,
+                "MoreThuenteLineSearch: NaN or Inf encountered during iteration"
+            ));
         }
         let s = tmp.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
         // the case gamma == 0 only arises if the cubic does not tend to infinity in the direction
@@ -587,11 +585,10 @@ fn cstep<F: ArgminFloat>(
             let tmp = vec![theta, sty.gx, stp.gx];
             // Check for a NaN or Inf in tmp before sorting
             if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
-                return Err(ArgminError::ConditionViolated {
-                    text: "MoreThuenteLineSearch: NaN or Inf encountered during iteration"
-                        .to_string(),
-                }
-                .into());
+                return Err(argmin_error!(
+                    ConditionViolated,
+                    "MoreThuenteLineSearch: NaN or Inf encountered during iteration"
+                ));
             }
             let s = tmp.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap();
             let mut gamma = *s * ((theta / *s).powi(2) - (sty.gx / *s) * (stp.gx / *s)).sqrt();

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -12,7 +12,7 @@
 //! [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
+    ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
     TerminationReason, KV,
 };
 use argmin_math::{ArgminAdd, ArgminMul, ArgminSub};
@@ -92,10 +92,10 @@ where
     /// set alpha
     pub fn alpha(mut self, alpha: F) -> Result<Self, Error> {
         if alpha <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Nelder-Mead:  must be > 0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Nelder-Mead:  must be > 0."
+            ));
         }
         self.alpha = alpha;
         Ok(self)
@@ -104,10 +104,10 @@ where
     /// set gamma
     pub fn gamma(mut self, gamma: F) -> Result<Self, Error> {
         if gamma <= F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Nelder-Mead: gamma must be > 1.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Nelder-Mead: gamma must be > 1."
+            ));
         }
         self.gamma = gamma;
         Ok(self)
@@ -116,10 +116,10 @@ where
     /// set rho
     pub fn rho(mut self, rho: F) -> Result<Self, Error> {
         if rho <= F::from_f64(0.0).unwrap() || rho > F::from_f64(0.5).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Nelder-Mead: rho must be in  (0.0, 0.5].".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Nelder-Mead: rho must be in  (0.0, 0.5]."
+            ));
         }
         self.rho = rho;
         Ok(self)
@@ -128,10 +128,10 @@ where
     /// set sigma
     pub fn sigma(mut self, sigma: F) -> Result<Self, Error> {
         if sigma <= F::from_f64(0.0).unwrap() || sigma > F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Nelder-Mead: sigma must be in  (0.0, 1.0].".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Nelder-Mead: sigma must be in  (0.0, 1.0]."
+            ));
         }
         self.sigma = sigma;
         Ok(self)

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -13,9 +13,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian, IterState,
-    LineSearch, Operator, OptimizationResult, Problem, SerializeAlias, Solver, State,
-    TerminationReason, KV,
+    ArgminFloat, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian, IterState, LineSearch,
+    Operator, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason, KV,
 };
 use crate::solver::conjugategradient::ConjugateGradient;
 use argmin_math::{
@@ -65,10 +64,10 @@ where
     /// Set tolerance for the stopping criterion based on cost difference
     pub fn with_tolerance(mut self, tol: F) -> Result<Self, Error> {
         if tol <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Newton-CG: tol must be positive.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Newton-CG: tol must be positive."
+            ));
         }
         self.tol = tol;
         Ok(self)

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -10,9 +10,7 @@
 //! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-use crate::core::{
-    ArgminError, ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, KV,
-};
+use crate::core::{ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, KV};
 use argmin_math::{ArgminDot, ArgminInv, ArgminScaledSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -46,10 +44,10 @@ where
     /// set gamma
     pub fn set_gamma(mut self, gamma: F) -> Result<Self, Error> {
         if gamma <= F::from_f64(0.0).unwrap() || gamma > F::from_f64(1.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Newton: gamma must be in  (0, 1].".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Newton: gamma must be in  (0, 1]."
+            ));
         }
         self.gamma = gamma;
         Ok(self)
@@ -90,6 +88,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::ArgminError;
     #[cfg(feature = "ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -11,9 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient,
-    IterState, LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
-    KV,
+    ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
+    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
 };
 use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
@@ -58,10 +57,10 @@ where
     /// Set r
     pub fn r(mut self, r: F) -> Result<Self, Error> {
         if r < F::from_f64(0.0).unwrap() || r > F::from_f64(1.0).unwrap() {
-            Err(ArgminError::InvalidParameter {
-                text: "SR1: r must be between 0 and 1.".to_string(),
-            }
-            .into())
+            Err(argmin_error!(
+                InvalidParameter,
+                "SR1: r must be between 0 and 1."
+            ))
         } else {
             self.r = r;
             Ok(self)

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -11,8 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient,
-    Hessian, IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian,
+    IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
     TrustRegionRadius, KV,
 };
 use argmin_math::{
@@ -70,10 +70,10 @@ where
     /// Set r
     pub fn r(mut self, r: F) -> Result<Self, Error> {
         if r <= F::from_f64(0.0).unwrap() || r >= F::from_f64(1.0).unwrap() {
-            Err(ArgminError::InvalidParameter {
-                text: "SR1: r must be in (0, 1).".to_string(),
-            }
-            .into())
+            Err(argmin_error!(
+                InvalidParameter,
+                "SR1TrustRegion: r must be in (0, 1)."
+            ))
         } else {
             self.r = r;
             Ok(self)
@@ -90,10 +90,10 @@ where
     /// Set eta
     pub fn eta(mut self, eta: F) -> Result<Self, Error> {
         if eta >= F::from_f64(10e-3).unwrap() || eta <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "SR1TrustRegion: eta must be in (0, 10^-3).".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "SR1TrustRegion: eta must be in (0, 10^-3)."
+            ));
         }
         self.eta = eta;
         Ok(self)

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -16,7 +16,7 @@
 //! DOI: 10.1126/science.220.4598.671
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
+    ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
     TerminationReason, KV,
 };
 use rand::prelude::*;
@@ -159,10 +159,10 @@ where
     /// * `rng`: an RNG (must implement Serialize when `serde1` feature is activated)
     pub fn new(init_temp: F, rng: R) -> Result<Self, Error> {
         if init_temp <= F::from_f64(0.0).unwrap() {
-            Err(ArgminError::InvalidParameter {
-                text: "Initial temperature must be > 0.".to_string(),
-            }
-            .into())
+            Err(argmin_error!(
+                InvalidParameter,
+                "Initial temperature must be > 0."
+            ))
         } else {
             Ok(SimulatedAnnealing {
                 init_temp,

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -11,8 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, State,
-    TerminationReason, TrustRegionRadius, KV,
+    ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, State, TerminationReason,
+    TrustRegionRadius, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminInv, ArgminMul, ArgminNorm, ArgminSub, ArgminWeightedDot,
@@ -113,10 +113,10 @@ where
             } else if tau >= F::from_f64(1.0).unwrap() && tau <= F::from_f64(2.0).unwrap() {
                 pstar = pu.add(&pb.sub(&pu).mul(&(tau - F::from_f64(1.0).unwrap())));
             } else {
-                return Err(ArgminError::ImpossibleError {
-                    text: "tau is bigger than 2, this is not supposed to happen.".to_string(),
-                }
-                .into());
+                return Err(argmin_error!(
+                    PotentialBug,
+                    "tau is bigger than 2, this is not supposed to happen."
+                ));
             }
         }
         Ok((state.param(pstar).grad(g).hessian(h), None))

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -11,8 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, Error, IterState, Problem, SerializeAlias, Solver, State,
-    TerminationReason, TrustRegionRadius, KV,
+    ArgminFloat, Error, IterState, Problem, SerializeAlias, Solver, State, TerminationReason,
+    TrustRegionRadius, KV,
 };
 use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminWeightedDot, ArgminZeroLike};
 #[cfg(feature = "serde1")]
@@ -68,10 +68,10 @@ where
     /// Set epsilon
     pub fn epsilon(mut self, epsilon: F) -> Result<Self, Error> {
         if epsilon <= F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "Steihaug: epsilon must be > 0.0.".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "Steihaug: epsilon must be > 0.0."
+            ));
         }
         self.epsilon = epsilon;
         Ok(self)

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -11,8 +11,8 @@
 //! Springer. ISBN 0-387-30303-0.
 
 use crate::core::{
-    ArgminError, ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient,
-    Hessian, IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian,
+    IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
     TrustRegionRadius, KV,
 };
 use crate::solver::trustregion::reduction_ratio;
@@ -88,10 +88,10 @@ where
     /// Set eta
     pub fn eta(mut self, eta: F) -> Result<Self, Error> {
         if eta >= F::from_f64(0.25).unwrap() || eta < F::from_f64(0.0).unwrap() {
-            return Err(ArgminError::InvalidParameter {
-                text: "TrustRegion: eta must be in [0, 1/4).".to_string(),
-            }
-            .into());
+            return Err(argmin_error!(
+                InvalidParameter,
+                "TrustRegion: eta must be in [0, 1/4)."
+            ));
         }
         self.eta = eta;
         Ok(self)


### PR DESCRIPTION
This PR adds two macros `argmin_error!` and `argmin_error_closure!` which make it more convenient to create `ArgminError`s. 
The latter is meant to be used in `.ok_or_else(...)` methods of `Option`s.