### PR TITLE
Added float! macro for more convenient creation of float constants

### DIFF
--- a/argmin/src/core/macros.rs
+++ b/argmin/src/core/macros.rs
@@ -74,6 +74,17 @@ macro_rules! argmin_error_closure {
     };
 }
 
+/// Convert a constant to a float of given precision
+#[macro_export]
+macro_rules! float {
+    ($t:ident, $val:expr) => {
+        $t::from_f64($val).unwrap()
+    };
+    ($val:expr) => {
+        F::from_f64($val).unwrap()
+    };
+}
+
 /// Implements a simple send and a simple sync test for a given type.
 #[cfg(test)]
 macro_rules! send_sync_test {

--- a/argmin/src/solver/brent/brentopt.rs
+++ b/argmin/src/solver/brent/brentopt.rs
@@ -75,7 +75,7 @@ impl<F: ArgminFloat> BrentOpt<F> {
     pub fn new(min: F, max: F) -> Self {
         BrentOpt {
             eps: F::epsilon().sqrt(),
-            t: F::from_f64(1e-5).unwrap(),
+            t: float!(1e-5),
             a: min,
             b: max,
             u: F::nan(),
@@ -87,7 +87,7 @@ impl<F: ArgminFloat> BrentOpt<F> {
             fx: F::nan(),
             e: F::zero(),
             d: F::zero(),
-            c: F::from_f64((3f64 - 5f64.sqrt()) / 2f64).unwrap(),
+            c: float!((3f64 - 5f64.sqrt()) / 2f64),
         }
     }
 
@@ -136,7 +136,7 @@ where
         // BrentOpt maintains its own state
         state: IterState<F, (), (), (), F>,
     ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
-        let two = F::from_f64(2f64).unwrap();
+        let two = float!(2f64);
         let tol = self.eps * self.x.abs() + self.t;
         let m = (self.a + self.b) / two;
         if (self.x - m).abs() <= two * tol - (self.b - self.a) / two {

--- a/argmin/src/solver/brent/brentroot.rs
+++ b/argmin/src/solver/brent/brentroot.rs
@@ -98,7 +98,7 @@ where
     ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
         self.fa = problem.cost(&self.a)?;
         self.fb = problem.cost(&self.b)?;
-        if self.fa * self.fb > F::from_f64(0.0).unwrap() {
+        if self.fa * self.fb > float!(0.0) {
             return Err(BrentRootError::WrongSign.into());
         }
         self.fc = self.fb;
@@ -111,8 +111,8 @@ where
         // BrentRoot maintains its own state
         state: IterState<F, (), (), (), F>,
     ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
-        if (self.fb > F::from_f64(0.0).unwrap() && self.fc > F::from_f64(0.0).unwrap())
-            || self.fb < F::from_f64(0.0).unwrap() && self.fc < F::from_f64(0.0).unwrap()
+        if (self.fb > float!(0.0) && self.fc > float!(0.0))
+            || self.fb < float!(0.0) && self.fc < float!(0.0)
         {
             self.c = self.a;
             self.fc = self.fa;
@@ -128,10 +128,9 @@ where
             self.fc = self.fa;
         }
         // effective tolerance is double machine precision plus half tolerance as given.
-        let eff_tol = F::from_f64(2.0).unwrap() * F::epsilon() * self.b.abs()
-            + F::from_f64(0.5).unwrap() * self.tol;
-        let mid = F::from_f64(0.5).unwrap() * (self.c - self.b);
-        if mid.abs() <= eff_tol || self.fb == F::from_f64(0.0).unwrap() {
+        let eff_tol = float!(2.0) * F::epsilon() * self.b.abs() + float!(0.5) * self.tol;
+        let mid = float!(0.5) * (self.c - self.b);
+        if mid.abs() <= eff_tol || self.fb == float!(0.0) {
             return Ok((
                 state
                     .termination_reason(TerminationReason::TargetPrecisionReached)
@@ -143,28 +142,22 @@ where
         if self.e.abs() >= eff_tol && self.fa.abs() > self.fb.abs() {
             let s = self.fb / self.fa;
             let (mut p, mut q) = if self.a == self.c {
-                (
-                    F::from_f64(2.0).unwrap() * mid * s,
-                    F::from_f64(1.0).unwrap() - s,
-                )
+                (float!(2.0) * mid * s, float!(1.0) - s)
             } else {
                 let q = self.fa / self.fc;
                 let r = self.fb / self.fc;
                 (
-                    s * (F::from_f64(2.0).unwrap() * mid * q * (q - r)
-                        - (self.b - self.a) * (r - F::from_f64(1.0).unwrap())),
-                    (q - F::from_f64(1.0).unwrap())
-                        * (r - F::from_f64(1.0).unwrap())
-                        * (s - F::from_f64(1.0).unwrap()),
+                    s * (float!(2.0) * mid * q * (q - r) - (self.b - self.a) * (r - float!(1.0))),
+                    (q - float!(1.0)) * (r - float!(1.0)) * (s - float!(1.0)),
                 )
             };
-            if p > F::from_f64(0.0).unwrap() {
+            if p > float!(0.0) {
                 q = -q;
             }
             p = p.abs();
-            let min1 = F::from_f64(3.0).unwrap() * mid * q - (eff_tol * q).abs();
+            let min1 = float!(3.0) * mid * q - (eff_tol * q).abs();
             let min2 = (self.e * q).abs();
-            if F::from_f64(2.0).unwrap() * p < if min1 < min2 { min1 } else { min2 } {
+            if float!(2.0) * p < if min1 < min2 { min1 } else { min2 } {
                 self.e = self.d;
                 self.d = p / q;
             } else {
@@ -181,7 +174,7 @@ where
             self.b = self.b + self.d;
         } else {
             self.b = self.b
-                + if mid >= F::from_f64(0.0).unwrap() {
+                + if mid >= float!(0.0) {
                     eff_tol.abs()
                 } else {
                     -eff_tol.abs()

--- a/argmin/src/solver/conjugategradient/beta.rs
+++ b/argmin/src/solver/conjugategradient/beta.rs
@@ -199,7 +199,7 @@ where
     fn update(&self, dfk: &G, dfk1: &G, _pk: &P) -> F {
         let dfk_norm_sq = dfk.norm().powi(2);
         let beta = dfk1.dot(&dfk1.sub(dfk)) / dfk_norm_sq;
-        F::from_f64(0.0).unwrap().max(beta)
+        float!(0.0).max(beta)
     }
 }
 

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -114,8 +114,8 @@ where
             )
         ))?;
         let ap = problem.apply(init_param)?;
-        let r0 = self.b.sub(&ap).mul(&(F::from_f64(-1.0).unwrap()));
-        self.p = Some(r0.mul(&(F::from_f64(-1.0).unwrap())));
+        let r0 = self.b.sub(&ap).mul(&(float!(-1.0)));
+        self.p = Some(r0.mul(&(float!(-1.0))));
         self.rtr = r0.dot(&r0.conj());
         self.r = Some(r0);
         Ok((state, None))
@@ -147,7 +147,7 @@ where
         let rtr_n = r.dot(&r.conj());
         let beta = rtr_n.div(self.rtr);
         self.rtr = rtr_n;
-        let p_n = r.mul(&(F::from_f64(-1.0).unwrap())).scaled_add(&beta, &p);
+        let p_n = r.mul(&(float!(-1.0))).scaled_add(&beta, &p);
         let norm = r.dot(&r.conj()).norm();
 
         self.p = Some(p_n);

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -147,7 +147,7 @@ where
         ))?;
         let cost = problem.cost(param)?;
         let grad = problem.gradient(param)?;
-        self.p = Some(grad.mul(&(F::from_f64(-1.0).unwrap())));
+        self.p = Some(grad.mul(&(float!(-1.0))));
         Ok((state.cost(cost).grad(grad), None))
     }
 
@@ -209,17 +209,13 @@ where
             (state.get_iter() % self.restart_iter == 0) && state.get_iter() != 0;
 
         if restart_iter || restart_orthogonality {
-            self.beta = F::from_f64(0.0).unwrap();
+            self.beta = float!(0.0);
         } else {
             self.beta = self.beta_method.update(&grad, &new_grad, p);
         }
 
         // Update of p
-        self.p = Some(
-            new_grad
-                .mul(&(F::from_f64(-1.0).unwrap()))
-                .add(&p.mul(&self.beta)),
-        );
+        self.p = Some(new_grad.mul(&(float!(-1.0))).add(&p.mul(&self.beta)));
 
         // Housekeeping
         let cost = problem.cost(&xk1)?;

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -68,7 +68,7 @@ impl<L, F: ArgminFloat> GaussNewtonLS<L, F> {
     /// # }
     /// ```
     pub fn with_tolerance(mut self, tol: F) -> Result<Self, Error> {
-        if tol <= F::from_f64(0.0).unwrap() {
+        if tol <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Gauss-Newton-Linesearch: tol must be positive."
@@ -117,8 +117,7 @@ where
 
         let p: P = jacobian_t.dot(&jacobian).inv()?.dot(&grad);
 
-        self.linesearch
-            .search_direction(p.mul(&(F::from_f64(-1.0).unwrap())));
+        self.linesearch.search_direction(p.mul(&(float!(-1.0))));
 
         // perform linesearch
         let OptimizationResult {

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -45,7 +45,7 @@ impl<F: ArgminFloat> GaussNewton<F> {
     /// ```
     pub fn new() -> Self {
         GaussNewton {
-            gamma: F::from_f64(1.0).unwrap(),
+            gamma: float!(1.0),
             tol: F::epsilon().sqrt(),
         }
     }
@@ -65,7 +65,7 @@ impl<F: ArgminFloat> GaussNewton<F> {
     /// # }
     /// ```
     pub fn with_gamma(mut self, gamma: F) -> Result<Self, Error> {
-        if gamma <= F::from_f64(0.0).unwrap() || gamma > F::from_f64(1.0).unwrap() {
+        if gamma <= float!(0.0) || gamma > float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Gauss-Newton: gamma must be in  (0, 1]."
@@ -90,7 +90,7 @@ impl<F: ArgminFloat> GaussNewton<F> {
     /// # }
     /// ```
     pub fn with_tolerance(mut self, tol: F) -> Result<Self, Error> {
-        if tol <= F::from_f64(0.0).unwrap() {
+        if tol <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Gauss-Newton: tol must be positive."

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -120,7 +120,7 @@ where
     /// # }
     /// ```
     pub fn with_tolerance(mut self, tolerance: F) -> Result<Self, Error> {
-        if tolerance <= F::from_f64(0.0).unwrap() {
+        if tolerance <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`GoldenSectionSearch`: Tolerance must be larger than 0."

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -72,7 +72,7 @@ where
         let new_grad = problem.gradient(&param_new)?;
 
         self.linesearch
-            .search_direction(new_grad.mul(&(F::from_f64(-1.0).unwrap())));
+            .search_direction(new_grad.mul(&(float!(-1.0))));
 
         // Run line search
         let OptimizationResult {

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -65,9 +65,9 @@ where
             init_cost: F::infinity(),
             init_grad: None,
             search_direction: None,
-            rho: F::from_f64(0.9).unwrap(),
+            rho: float!(0.9),
             condition,
-            alpha: F::from_f64(1.0).unwrap(),
+            alpha: float!(1.0),
         }
     }
 
@@ -89,7 +89,7 @@ where
     /// # }
     /// ```
     pub fn rho(mut self, rho: F) -> Result<Self, Error> {
-        if rho <= F::from_f64(0.0).unwrap() || rho >= F::from_f64(1.0).unwrap() {
+        if rho <= float!(0.0) || rho >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "BacktrackingLineSearch: Contraction factor rho must be in (0, 1)."
@@ -111,7 +111,7 @@ where
 
     /// Set initial step length
     fn initial_step_length(&mut self, alpha: F) -> Result<(), Error> {
-        if alpha <= F::from_f64(0.0).unwrap() {
+        if alpha <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "LineSearch: Initial alpha must be > 0."

--- a/argmin/src/solver/linesearch/condition/armijo.rs
+++ b/argmin/src/solver/linesearch/condition/armijo.rs
@@ -33,7 +33,7 @@ where
     /// let armijo = ArmijoCondition::new(0.0001f64);
     /// ```
     pub fn new(c: F) -> Result<Self, Error> {
-        if c <= F::from_f64(0.0).unwrap() || c >= F::from_f64(1.0).unwrap() {
+        if c <= float!(0.0) || c >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "ArmijoCondition: Parameter c must be in (0, 1)"

--- a/argmin/src/solver/linesearch/condition/goldstein.rs
+++ b/argmin/src/solver/linesearch/condition/goldstein.rs
@@ -34,7 +34,7 @@ where
     /// let goldstein = GoldsteinCondition::new(0.1f64);
     /// ```
     pub fn new(c: F) -> Result<Self, Error> {
-        if c <= F::from_f64(0.0).unwrap() || c >= F::from_f64(0.5).unwrap() {
+        if c <= float!(0.0) || c >= float!(0.5) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "GoldsteinCondition: Parameter c must be in (0, 0.5)"
@@ -59,7 +59,7 @@ where
         step_length: F,
     ) -> bool {
         let tmp = step_length * initial_gradient.dot(search_direction);
-        initial_cost + (F::from_f64(1.0).unwrap() - self.c) * tmp <= current_cost
+        initial_cost + (float!(1.0) - self.c) * tmp <= current_cost
             && current_cost <= initial_cost + self.c * tmp
     }
 

--- a/argmin/src/solver/linesearch/condition/strongwolfe.rs
+++ b/argmin/src/solver/linesearch/condition/strongwolfe.rs
@@ -37,13 +37,13 @@ where
     /// let strongwolfe = StrongWolfeCondition::new(0.0001f64, 0.1f64);
     /// ```
     pub fn new(c1: F, c2: F) -> Result<Self, Error> {
-        if c1 <= F::from_f64(0.0).unwrap() || c1 >= F::from_f64(1.0).unwrap() {
+        if c1 <= float!(0.0) || c1 >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "StrongWolfeCondition: Parameter c1 must be in (0, 1)"
             ));
         }
-        if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
+        if c2 <= c1 || c2 >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "StrongWolfeCondition: Parameter c2 must be in (c1, 1)"

--- a/argmin/src/solver/linesearch/condition/wolfe.rs
+++ b/argmin/src/solver/linesearch/condition/wolfe.rs
@@ -37,13 +37,13 @@ where
     /// let wolfe = WolfeCondition::new(0.0001f64, 0.1f64);
     /// ```
     pub fn new(c1: F, c2: F) -> Result<Self, Error> {
-        if c1 <= F::from_f64(0.0).unwrap() || c1 >= F::from_f64(1.0).unwrap() {
+        if c1 <= float!(0.0) || c1 >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "WolfeCondition: Parameter c1 must be in (0, 1)"
             ));
         }
-        if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
+        if c2 <= c1 || c2 >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "WolfeCondition: Parameter c2 must be in (c1, 1)"

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -100,26 +100,26 @@ where
     /// ```
     pub fn new() -> Self {
         HagerZhangLineSearch {
-            delta: F::from_f64(0.1).unwrap(),
-            sigma: F::from_f64(0.9).unwrap(),
-            epsilon: F::from_f64(1e-6).unwrap(),
+            delta: float!(0.1),
+            sigma: float!(0.9),
+            epsilon: float!(1e-6),
             epsilon_k: F::nan(),
-            theta: F::from_f64(0.5).unwrap(),
-            gamma: F::from_f64(0.66).unwrap(),
-            eta: F::from_f64(0.01).unwrap(),
+            theta: float!(0.5),
+            gamma: float!(0.66),
+            eta: float!(0.01),
             a_x_init: F::epsilon(),
             a_x: F::nan(),
             a_f: F::nan(),
             a_g: F::nan(),
-            b_x_init: F::from_f64(1e5).unwrap(),
+            b_x_init: float!(1e5),
             b_x: F::nan(),
             b_f: F::nan(),
             b_g: F::nan(),
-            c_x_init: F::from_f64(1.0).unwrap(),
+            c_x_init: float!(1.0),
             c_x: F::nan(),
             c_f: F::nan(),
             c_g: F::nan(),
-            best_x: F::from_f64(0.0).unwrap(),
+            best_x: float!(0.0),
             best_f: F::infinity(),
             best_g: F::nan(),
             init_param: None,
@@ -150,11 +150,7 @@ where
     /// # }
     /// ```
     pub fn with_delta_sigma(mut self, delta: F, sigma: F) -> Result<Self, Error> {
-        if delta <= F::from_f64(0.0).unwrap()
-            || delta >= F::from_f64(1.0).unwrap()
-            || sigma < delta
-            || sigma >= F::from_f64(1.0).unwrap()
-        {
+        if delta <= float!(0.0) || delta >= float!(1.0) || sigma < delta || sigma >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`HagerZhangLineSearch`: delta must be in (0, 1) and sigma must be in [delta, 1)."
@@ -183,7 +179,7 @@ where
     /// # }
     /// ```
     pub fn with_epsilon(mut self, epsilon: F) -> Result<Self, Error> {
-        if epsilon < F::from_f64(0.0).unwrap() {
+        if epsilon < float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`HagerZhangLineSearch`: epsilon must be >= 0."
@@ -212,7 +208,7 @@ where
     /// # }
     /// ```
     pub fn with_theta(mut self, theta: F) -> Result<Self, Error> {
-        if theta <= F::from_f64(0.0).unwrap() || theta >= F::from_f64(1.0).unwrap() {
+        if theta <= float!(0.0) || theta >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`HagerZhangLineSearch`: theta must be in (0, 1)."
@@ -240,7 +236,7 @@ where
     /// # }
     /// ```
     pub fn with_gamma(mut self, gamma: F) -> Result<Self, Error> {
-        if gamma <= F::from_f64(0.0).unwrap() || gamma >= F::from_f64(1.0).unwrap() {
+        if gamma <= float!(0.0) || gamma >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`HagerZhangLineSearch`: gamma must be in (0, 1)."
@@ -268,7 +264,7 @@ where
     /// # }
     /// ```
     pub fn with_eta(mut self, eta: F) -> Result<Self, Error> {
-        if eta <= F::from_f64(0.0).unwrap() {
+        if eta <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`HagerZhangLineSearch`: eta must be > 0."
@@ -296,7 +292,7 @@ where
     /// # }
     /// ```
     pub fn with_bounds(mut self, step_min: F, step_max: F) -> Result<Self, Error> {
-        if step_min < F::from_f64(0.0).unwrap() || step_max <= step_min {
+        if step_min < float!(0.0) || step_max <= step_min {
             return Err(argmin_error!(
                 InvalidParameter,
                 concat!(
@@ -327,34 +323,34 @@ where
         }
 
         // U1
-        if c_g >= F::from_f64(0.0).unwrap() {
+        if c_g >= float!(0.0) {
             return Ok(((a_x, a_f, a_g), (c_x, c_f, c_g)));
         }
 
         // U2
-        if c_g < F::from_f64(0.0).unwrap() && c_f <= self.finit + self.epsilon_k {
+        if c_g < float!(0.0) && c_f <= self.finit + self.epsilon_k {
             return Ok(((c_x, c_f, c_g), (b_x, b_f, b_g)));
         }
 
         // U3
-        if c_g < F::from_f64(0.0).unwrap() && c_f > self.finit + self.epsilon_k {
+        if c_g < float!(0.0) && c_f > self.finit + self.epsilon_k {
             let mut ah_x = a_x;
             let mut ah_f = a_f;
             let mut ah_g = a_g;
             let mut bh_x = c_x;
             loop {
-                let d_x = (F::from_f64(1.0).unwrap() - self.theta) * ah_x + self.theta * bh_x;
+                let d_x = (float!(1.0) - self.theta) * ah_x + self.theta * bh_x;
                 let d_f = self.calc(problem, d_x)?;
                 let d_g = self.calc_grad(problem, d_x)?;
-                if d_g >= F::from_f64(0.0).unwrap() {
+                if d_g >= float!(0.0) {
                     return Ok(((ah_x, ah_f, ah_g), (d_x, d_f, d_g)));
                 }
-                if d_g < F::from_f64(0.0).unwrap() && d_f <= self.finit + self.epsilon_k {
+                if d_g < float!(0.0) && d_f <= self.finit + self.epsilon_k {
                     ah_x = d_x;
                     ah_f = d_f;
                     ah_g = d_g;
                 }
-                if d_g < F::from_f64(0.0).unwrap() && d_f > self.finit + self.epsilon_k {
+                if d_g < float!(0.0) && d_f > self.finit + self.epsilon_k {
                     bh_x = d_x;
                 }
             }
@@ -386,7 +382,7 @@ where
         let c_x = self.secant(a_x, a_g, b_x, b_g);
         let c_f = self.calc(problem, c_x)?;
         let c_g = self.calc_grad(problem, c_x)?;
-        let mut c_bar_x: F = F::from_f64(0.0).unwrap();
+        let mut c_bar_x: F = float!(0.0);
 
         let ((aa_x, aa_f, aa_g), (bb_x, bb_f, bb_g)) =
             self.update(problem, (a_x, a_f, a_g), (b_x, b_f, b_g), (c_x, c_f, c_g))?;
@@ -580,7 +576,7 @@ where
 
         // L2
         if bt_x - at_x > self.gamma * (self.b_x - self.a_x) {
-            let c_x = (at_x + bt_x) / F::from_f64(2.0).unwrap();
+            let c_x = (at_x + bt_x) / float!(2.0);
             let tmp = self
                 .init_param
                 .as_ref()
@@ -626,8 +622,7 @@ where
         {
             return TerminationReason::LineSearchConditionMet;
         }
-        if (F::from_f64(2.0).unwrap() * self.delta - F::from_f64(1.0).unwrap()) * self.dginit
-            >= self.best_g
+        if (float!(2.0) * self.delta - float!(1.0)) * self.dginit >= self.best_g
             && self.best_g >= self.sigma * self.dginit
             && self.best_f <= self.finit + self.epsilon_k
         {

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -116,9 +116,9 @@ where
 {
     fn default() -> Self {
         Step {
-            x: F::from_f64(0.0).unwrap(),
-            fx: F::from_f64(0.0).unwrap(),
-            gx: F::from_f64(0.0).unwrap(),
+            x: float!(0.0),
+            fx: float!(0.0),
+            gx: float!(0.0),
         }
     }
 }
@@ -141,15 +141,15 @@ where
             init_param: None,
             finit: F::infinity(),
             init_grad: None,
-            dginit: F::from_f64(0.0).unwrap(),
-            dgtest: F::from_f64(0.0).unwrap(),
-            ftol: F::from_f64(1e-4).unwrap(),
-            gtol: F::from_f64(0.9).unwrap(),
-            xtrapf: F::from_f64(4.0).unwrap(),
+            dginit: float!(0.0),
+            dgtest: float!(0.0),
+            ftol: float!(1e-4),
+            gtol: float!(0.9),
+            xtrapf: float!(4.0),
             width: F::nan(),
             width1: F::nan(),
-            xtol: F::from_f64(1e-10).unwrap(),
-            alpha: F::from_f64(1.0).unwrap(),
+            xtol: float!(1e-10),
+            alpha: float!(1.0),
             stpmin: F::epsilon().sqrt(),
             stpmax: F::infinity(),
             stp: Step::default(),
@@ -179,13 +179,13 @@ where
     /// # }
     /// ```
     pub fn with_c(mut self, c1: F, c2: F) -> Result<Self, Error> {
-        if c1 <= F::from_f64(0.0).unwrap() || c1 >= c2 {
+        if c1 <= float!(0.0) || c1 >= c2 {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`MoreThuenteLineSearch`: Parameter c1 must be in (0, c2)."
             ));
         }
-        if c2 <= c1 || c2 >= F::from_f64(1.0).unwrap() {
+        if c2 <= c1 || c2 >= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`MoreThuenteLineSearch`: Parameter c2 must be in (c1, 1)."
@@ -214,7 +214,7 @@ where
     /// # }
     /// ```
     pub fn with_bounds(mut self, step_min: F, step_max: F) -> Result<Self, Error> {
-        if step_min < F::from_f64(0.0).unwrap() {
+        if step_min < float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`MoreThuenteLineSearch`: step_min must be >= 0.0."
@@ -250,7 +250,7 @@ where
     /// # }
     /// ```
     pub fn with_width_tolerance(mut self, xtol: F) -> Result<Self, Error> {
-        if xtol < F::from_f64(0.0).unwrap() {
+        if xtol < float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "`MoreThuenteLineSearch`: relative width tolerance must be >= 0.0."
@@ -281,7 +281,7 @@ where
 
     /// Set initial alpha value
     fn initial_step_length(&mut self, alpha: F) -> Result<(), Error> {
-        if alpha <= F::from_f64(0.0).unwrap() {
+        if alpha <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "MoreThuenteLineSearch: Initial alpha must be > 0."
@@ -343,7 +343,7 @@ where
             .dot(self.search_direction.as_ref().unwrap());
 
         // compute search direction in 1D
-        if self.dginit >= F::from_f64(0.0).unwrap() {
+        if self.dginit >= float!(0.0) {
             return Err(argmin_error!(
                 ConditionViolated,
                 "`MoreThuenteLineSearch`: Search direction must be a descent direction."
@@ -355,12 +355,12 @@ where
 
         self.dgtest = self.ftol * self.dginit;
         self.width = self.stpmax - self.stpmin;
-        self.width1 = F::from_f64(2.0).unwrap() * self.width;
+        self.width1 = float!(2.0) * self.width;
         self.f = self.finit;
 
         self.stp = Step::new(self.alpha, F::nan(), F::nan());
-        self.stx = Step::new(F::from_f64(0.0).unwrap(), self.finit, self.dginit);
-        self.sty = Step::new(F::from_f64(0.0).unwrap(), self.finit, self.dginit);
+        self.stx = Step::new(float!(0.0), self.finit, self.dginit);
+        self.sty = Step::new(float!(0.0), self.finit, self.dginit);
 
         Ok((state, None))
     }
@@ -494,8 +494,8 @@ where
         }
 
         if self.brackt {
-            if (self.sty.x - self.stx.x).abs() >= F::from_f64(0.66).unwrap() * self.width1 {
-                self.stp.x = self.stx.x + F::from_f64(0.5).unwrap() * (self.sty.x - self.stx.x);
+            if (self.sty.x - self.stx.x).abs() >= float!(0.66) * self.width1 {
+                self.stp.x = self.stx.x + float!(0.5) * (self.sty.x - self.stx.x);
             }
             self.width1 = self.width;
             self.width = (self.sty.x - self.stx.x).abs();
@@ -524,7 +524,7 @@ fn cstep<F: ArgminFloat>(
 
     // check inputs
     if (brackt && (stp.x <= stx.x.min(sty.x) || stp.x >= stx.x.max(sty.x)))
-        || stx.gx * (stp.x - stx.x) >= F::from_f64(0.0).unwrap()
+        || stx.gx * (stp.x - stx.x) >= float!(0.0)
         || stpmax < stpmin
     {
         return Ok((stx, sty, stp, brackt, stpmin, stpmax, info));
@@ -539,8 +539,7 @@ fn cstep<F: ArgminFloat>(
         // the quadratic steps is taken.
         info = 1;
         bound = true;
-        let theta =
-            F::from_f64(3.0).unwrap() * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
+        let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
@@ -560,23 +559,21 @@ fn cstep<F: ArgminFloat>(
         let r = p / q;
         stpc = stx.x + r * (stp.x - stx.x);
         stpq = stx.x
-            + ((stx.gx / ((stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx))
-                / F::from_f64(2.0).unwrap())
+            + ((stx.gx / ((stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx)) / float!(2.0))
                 * (stp.x - stx.x);
         if (stpc - stx.x).abs() < (stpq - stx.x).abs() {
             stpf = stpc;
         } else {
-            stpf = stpc + (stpq - stpc) / F::from_f64(2.0).unwrap();
+            stpf = stpc + (stpq - stpc) / float!(2.0);
         }
         brackt = true;
-    } else if sgnd < F::from_f64(0.0).unwrap() {
+    } else if sgnd < float!(0.0) {
         // Second case. A lower function value and derivatives of opposite sign. The minimum is
         // bracketed. If the cubic step is closer to stx.x than the quadtratic (secant) step, the
         // cubic step is taken, else the quadratic step is taken.
         info = 2;
         bound = false;
-        let theta =
-            F::from_f64(3.0).unwrap() * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
+        let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
@@ -610,8 +607,7 @@ fn cstep<F: ArgminFloat>(
         // else the step farthest away is taken.
         info = 3;
         bound = true;
-        let theta =
-            F::from_f64(3.0).unwrap() * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
+        let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
         let tmp = vec![theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
@@ -625,8 +621,7 @@ fn cstep<F: ArgminFloat>(
         // of the step.
 
         let mut gamma = *s
-            * F::from_f64(0.0)
-                .unwrap()
+            * float!(0.0)
                 .max((theta / *s).powi(2) - (stx.gx / *s) * (stp.gx / *s))
                 .sqrt();
         if stp.x > stx.x {
@@ -636,7 +631,7 @@ fn cstep<F: ArgminFloat>(
         let p = (gamma - stp.gx) + theta;
         let q = (gamma + (stx.gx - stp.gx)) + gamma;
         let r = p / q;
-        if r < F::from_f64(0.0).unwrap() && gamma != F::from_f64(0.0).unwrap() {
+        if r < float!(0.0) && gamma != float!(0.0) {
             stpc = stp.x + r * (stx.x - stp.x);
         } else if stp.x > stx.x {
             stpc = stpmax;
@@ -662,8 +657,7 @@ fn cstep<F: ArgminFloat>(
         info = 4;
         bound = false;
         if brackt {
-            let theta =
-                F::from_f64(3.0).unwrap() * (stp.fx - sty.fx) / (sty.x - stp.x) + sty.gx + stp.gx;
+            let theta = float!(3.0) * (stp.fx - sty.fx) / (sty.x - stp.x) + sty.gx + stp.gx;
             let tmp = vec![theta, sty.gx, stp.gx];
             // Check for a NaN or Inf in tmp before sorting
             if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
@@ -697,7 +691,7 @@ fn cstep<F: ArgminFloat>(
     if stp_o.fx > stx_o.fx {
         sty_o = Step::new(stp_o.x, stp_o.fx, stp_o.gx);
     } else {
-        if sgnd < F::from_f64(0.0).unwrap() {
+        if sgnd < float!(0.0) {
             sty_o = Step::new(stx_o.x, stx_o.fx, stx_o.gx);
         }
         stx_o = Step::new(stp_o.x, stp_o.fx, stp_o.gx);
@@ -711,13 +705,9 @@ fn cstep<F: ArgminFloat>(
     stp_o.x = stpf;
     if brackt && bound {
         if sty_o.x > stx_o.x {
-            stp_o.x = stp_o
-                .x
-                .min(stx_o.x + F::from_f64(0.66).unwrap() * (sty_o.x - stx_o.x));
+            stp_o.x = stp_o.x.min(stx_o.x + float!(0.66) * (sty_o.x - stx_o.x));
         } else {
-            stp_o.x = stp_o
-                .x
-                .max(stx_o.x + F::from_f64(0.66).unwrap() * (sty_o.x - stx_o.x));
+            stp_o.x = stp_o.x.max(stx_o.x + float!(0.66) * (sty_o.x - stx_o.x));
         }
     }
 

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -66,10 +66,10 @@ where
     /// Constructor
     pub fn new() -> Self {
         NelderMead {
-            alpha: F::from_f64(1.0).unwrap(),
-            gamma: F::from_f64(2.0).unwrap(),
-            rho: F::from_f64(0.5).unwrap(),
-            sigma: F::from_f64(0.5).unwrap(),
+            alpha: float!(1.0),
+            gamma: float!(2.0),
+            rho: float!(0.5),
+            sigma: float!(0.5),
             params: vec![],
             sd_tolerance: F::epsilon(),
         }
@@ -91,7 +91,7 @@ where
 
     /// set alpha
     pub fn alpha(mut self, alpha: F) -> Result<Self, Error> {
-        if alpha <= F::from_f64(0.0).unwrap() {
+        if alpha <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Nelder-Mead:  must be > 0."
@@ -103,7 +103,7 @@ where
 
     /// set gamma
     pub fn gamma(mut self, gamma: F) -> Result<Self, Error> {
-        if gamma <= F::from_f64(1.0).unwrap() {
+        if gamma <= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Nelder-Mead: gamma must be > 1."
@@ -115,7 +115,7 @@ where
 
     /// set rho
     pub fn rho(mut self, rho: F) -> Result<Self, Error> {
-        if rho <= F::from_f64(0.0).unwrap() || rho > F::from_f64(0.5).unwrap() {
+        if rho <= float!(0.0) || rho > float!(0.5) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Nelder-Mead: rho must be in  (0.0, 0.5]."
@@ -127,7 +127,7 @@ where
 
     /// set sigma
     pub fn sigma(mut self, sigma: F) -> Result<Self, Error> {
-        if sigma <= F::from_f64(0.0).unwrap() || sigma > F::from_f64(1.0).unwrap() {
+        if sigma <= float!(0.0) || sigma > float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Nelder-Mead: sigma must be in  (0.0, 1.0]."
@@ -150,7 +150,7 @@ where
         for idx in 1..num_param {
             x0 = x0.add(&self.params[idx].0)
         }
-        x0.mul(&(F::from_f64(1.0).unwrap() / (F::from_usize(num_param).unwrap())))
+        x0.mul(&(float!(1.0) / (F::from_usize(num_param).unwrap())))
     }
 
     /// Reflect
@@ -302,7 +302,7 @@ where
     fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationReason {
         let n = F::from_usize(self.params.len()).unwrap();
         let c0: F = self.params.iter().map(|(_, c)| *c).sum::<F>() / n;
-        let s: F = (F::from_f64(1.0).unwrap() / (n - F::from_f64(1.0).unwrap())
+        let s: F = (float!(1.0) / (n - float!(1.0))
             * self
                 .params
                 .iter()

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -49,7 +49,7 @@ where
     pub fn new(linesearch: L) -> Self {
         NewtonCG {
             linesearch,
-            curvature_threshold: F::from_f64(0.0).unwrap(),
+            curvature_threshold: float!(0.0),
             tol: F::epsilon(),
         }
     }
@@ -63,7 +63,7 @@ where
 
     /// Set tolerance for the stopping criterion based on cost difference
     pub fn with_tolerance(mut self, tol: F) -> Result<Self, Error> {
-        if tol <= F::from_f64(0.0).unwrap() {
+        if tol <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Newton-CG: tol must be positive."
@@ -108,7 +108,7 @@ where
 
         let mut x_p = param.zero_like();
         let mut x: P = param.zero_like();
-        let mut cg = ConjugateGradient::new(grad.mul(&(F::from_f64(-1.0).unwrap())));
+        let mut cg = ConjugateGradient::new(grad.mul(&(float!(-1.0))));
 
         let cg_state = IterState::new().param(x_p.clone());
         let (mut cg_state, _) = cg.init(&mut cg_problem, cg_state)?;
@@ -122,13 +122,13 @@ where
             let curvature = p.dot(&hessian.dot(p));
             if curvature <= self.curvature_threshold {
                 if iter == 0 {
-                    x = grad.mul(&(F::from_f64(-1.0).unwrap()));
+                    x = grad.mul(&(float!(-1.0)));
                 } else {
                     x = x_p;
                 }
                 break;
             }
-            if cost <= F::from_f64(0.5).unwrap().min(grad_norm.sqrt()) * grad_norm {
+            if cost <= float!(0.5).min(grad_norm.sqrt()) * grad_norm {
                 break;
             }
             cg_state = cg_state.param(x.clone()).cost(cost);

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -36,14 +36,12 @@ where
 {
     /// Constructor
     pub fn new() -> Self {
-        Newton {
-            gamma: F::from_f64(1.0).unwrap(),
-        }
+        Newton { gamma: float!(1.0) }
     }
 
     /// set gamma
     pub fn set_gamma(mut self, gamma: F) -> Result<Self, Error> {
-        if gamma <= F::from_f64(0.0).unwrap() || gamma > F::from_f64(1.0).unwrap() {
+        if gamma <= float!(0.0) || gamma > float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Newton: gamma must be in  (0, 1]."

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -97,7 +97,7 @@ where
     ) -> Particle<P, F> {
         let (min, max) = &self.search_region;
         let delta = max.sub(min);
-        let delta_neg = delta.mul(&F::from_f64(-1.0).unwrap());
+        let delta_neg = delta.mul(&float!(-1.0));
 
         let initial_position = O::Param::rand_from_range(min, max);
         let initial_cost = problem.cost(&initial_position).unwrap(); // FIXME do not unwrap

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -126,7 +126,7 @@ where
         let prev_grad = state.take_grad().unwrap();
         let inv_hessian = state.take_inv_hessian().unwrap();
 
-        let p = inv_hessian.dot(&prev_grad).mul(&F::from_f64(-1.0).unwrap());
+        let p = inv_hessian.dot(&prev_grad).mul(&float!(-1.0));
 
         self.linesearch.search_direction(p);
 
@@ -158,7 +158,7 @@ where
         let sk = xk1.sub(&param);
 
         let yksk: F = yk.dot(&sk);
-        let rhok = F::from_f64(1.0).unwrap() / yksk;
+        let rhok = float!(1.0) / yksk;
 
         let e = inv_hessian.eye_like();
         let mat1: H = sk.dot(&yk);

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -114,7 +114,7 @@ where
             .map(Result::Ok)
             .unwrap_or_else(|| problem.gradient(&param))?;
         let inv_hessian = state.take_inv_hessian().unwrap();
-        let p = inv_hessian.dot(&prev_grad).mul(&F::from_f64(-1.0).unwrap());
+        let p = inv_hessian.dot(&prev_grad).mul(&float!(-1.0));
 
         self.linesearch.search_direction(p);
 
@@ -150,11 +150,9 @@ where
         let tmp3: P = inv_hessian.dot(&yk);
         let tmp4: F = tmp3.dot(&yk);
         let tmp3: H = tmp3.dot(&tmp3);
-        let tmp3: H = tmp3.mul(&(F::from_f64(1.0).unwrap() / tmp4));
+        let tmp3: H = tmp3.mul(&(float!(1.0) / tmp4));
 
-        let inv_hessian = inv_hessian
-            .sub(&tmp3)
-            .add(&sksk.mul(&(F::from_f64(1.0).unwrap() / yksk)));
+        let inv_hessian = inv_hessian.sub(&tmp3).add(&sksk.mul(&(float!(1.0) / yksk)));
 
         Ok((
             state

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -122,17 +122,17 @@ where
         let gamma: F = if let (Some(sk), Some(yk)) = (self.s.back(), self.y.back()) {
             sk.dot(yk) / yk.dot(yk)
         } else {
-            F::from_f64(1.0).unwrap()
+            float!(1.0)
         };
 
         // L-BFGS two-loop recursion
         let mut q = prev_grad.clone();
         let cur_m = self.s.len();
-        let mut alpha: Vec<F> = vec![F::from_f64(0.0).unwrap(); cur_m];
-        let mut rho: Vec<F> = vec![F::from_f64(0.0).unwrap(); cur_m];
+        let mut alpha: Vec<F> = vec![float!(0.0); cur_m];
+        let mut rho: Vec<F> = vec![float!(0.0); cur_m];
         for (i, (sk, yk)) in self.s.iter().rev().zip(self.y.iter().rev()).enumerate() {
             let yksk: F = yk.dot(sk);
-            let rho_t = F::from_f64(1.0).unwrap() / yksk;
+            let rho_t = float!(1.0) / yksk;
             let skq: F = sk.dot(&q);
             let alpha_t = skq.mul(rho_t);
             q = q.sub(&yk.mul(&alpha_t));
@@ -146,8 +146,7 @@ where
             r = r.add(&sk.mul(&(alpha[i] - beta)));
         }
 
-        self.linesearch
-            .search_direction(r.mul(&F::from_f64(-1.0).unwrap()));
+        self.linesearch.search_direction(r.mul(&float!(-1.0)));
 
         // Run solver
         let OptimizationResult {

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -46,7 +46,7 @@ where
     /// Constructor
     pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
         SR1 {
-            r: F::from_f64(1e-8).unwrap(),
+            r: float!(1e-8),
             init_inv_hessian: Some(init_inverse_hessian),
             linesearch,
             tol_grad: F::epsilon().sqrt(),
@@ -56,7 +56,7 @@ where
 
     /// Set r
     pub fn r(mut self, r: F) -> Result<Self, Error> {
-        if r < F::from_f64(0.0).unwrap() || r > F::from_f64(1.0).unwrap() {
+        if r < float!(0.0) || r > float!(1.0) {
             Err(argmin_error!(
                 InvalidParameter,
                 "SR1: r must be between 0 and 1."
@@ -131,7 +131,7 @@ where
             .map(Result::Ok)
             .unwrap_or_else(|| problem.gradient(&param))?;
 
-        let p = inv_hessian.dot(&prev_grad).mul(&F::from_f64(-1.0).unwrap());
+        let p = inv_hessian.dot(&prev_grad).mul(&float!(-1.0));
 
         self.linesearch.search_direction(p);
 
@@ -176,7 +176,7 @@ where
         // let hessian_update = tmp.abs() >= self.r * sksk.sqrt() * blah.sqrt();
 
         if hessian_update {
-            inv_hessian = inv_hessian.add(&a.mul(&(F::from_f64(1.0).unwrap() / b)));
+            inv_hessian = inv_hessian.add(&a.mul(&(float!(1.0) / b)));
         }
 
         Ok((

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -51,12 +51,12 @@ where
     /// Constructor
     pub fn new(subproblem: R) -> Self {
         SR1TrustRegion {
-            r: F::from_f64(1e-8).unwrap(),
+            r: float!(1e-8),
             init_hessian: None,
             subproblem,
-            radius: F::from_f64(1.0).unwrap(),
-            eta: F::from_f64(0.5 * 1e-3).unwrap(),
-            tol_grad: F::from_f64(1e-3).unwrap(),
+            radius: float!(1.0),
+            eta: float!(0.5 * 1e-3),
+            tol_grad: float!(1e-3),
         }
     }
 
@@ -69,7 +69,7 @@ where
 
     /// Set r
     pub fn r(mut self, r: F) -> Result<Self, Error> {
-        if r <= F::from_f64(0.0).unwrap() || r >= F::from_f64(1.0).unwrap() {
+        if r <= float!(0.0) || r >= float!(1.0) {
             Err(argmin_error!(
                 InvalidParameter,
                 "SR1TrustRegion: r must be in (0, 1)."
@@ -89,7 +89,7 @@ where
 
     /// Set eta
     pub fn eta(mut self, eta: F) -> Result<Self, Error> {
-        if eta >= F::from_f64(10e-3).unwrap() || eta <= F::from_f64(0.0).unwrap() {
+        if eta >= float!(10e-3) || eta <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "SR1TrustRegion: eta must be in (0, 10^-3)."
@@ -198,7 +198,7 @@ where
         let ared = cost - fk1;
         let tmp1: F = prev_grad.dot(&sk);
         let tmp2: F = sk.weighted_dot(&hessian, &sk);
-        let tmp2: F = tmp2.mul(F::from_f64(0.5).unwrap());
+        let tmp2: F = tmp2.mul(float!(0.5));
         let pred = -tmp1 - tmp2;
         let ap = ared / pred;
 
@@ -208,16 +208,16 @@ where
             (xk, cost, prev_grad)
         };
 
-        self.radius = if ap > F::from_f64(0.75).unwrap() {
-            if sk.norm() <= F::from_f64(0.8).unwrap() * self.radius {
+        self.radius = if ap > float!(0.75) {
+            if sk.norm() <= float!(0.8) * self.radius {
                 self.radius
             } else {
-                F::from_f64(2.0).unwrap() * self.radius
+                float!(2.0) * self.radius
             }
-        } else if ap <= F::from_f64(0.75).unwrap() && ap >= F::from_f64(0.1).unwrap() {
+        } else if ap <= float!(0.75) && ap >= float!(0.1) {
             self.radius
         } else {
-            F::from_f64(0.5).unwrap() * self.radius
+            float!(0.5) * self.radius
         };
 
         let bksk = hessian.dot(&sk);
@@ -228,7 +228,7 @@ where
         let hessian = if hessian_update {
             let a: B = ykbksk.dot(&ykbksk);
             let b: F = sk.dot(&ykbksk);
-            hessian.add(&a.mul(&(F::from_f64(1.0).unwrap() / b)))
+            hessian.add(&a.mul(&(float!(1.0) / b)))
         } else {
             hessian
         };

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -158,7 +158,7 @@ where
     /// * `init_temp`: initial temperature
     /// * `rng`: an RNG (must implement Serialize when `serde1` feature is activated)
     pub fn new(init_temp: F, rng: R) -> Result<Self, Error> {
-        if init_temp <= F::from_f64(0.0).unwrap() {
+        if init_temp <= float!(0.0) {
             Err(argmin_error!(
                 InvalidParameter,
                 "Initial temperature must be > 0."
@@ -345,10 +345,9 @@ where
         //
         // which will always be between 0 and 0.5.
         let prob: f64 = self.rng.gen();
-        let prob = F::from_f64(prob).unwrap();
+        let prob = float!(prob);
         let accepted = (new_cost < prev_cost)
-            || (F::from_f64(1.0).unwrap()
-                / (F::from_f64(1.0).unwrap() + ((new_cost - prev_cost) / self.cur_temp).exp())
+            || (float!(1.0) / (float!(1.0) + ((new_cost - prev_cost) / self.cur_temp).exp())
                 > prob);
 
         let new_best_found = new_cost < state.best_cost;

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -69,12 +69,10 @@ where
             .unwrap_or_else(|| problem.hessian(&param))?;
 
         let wdp = grad.weighted_dot(&hessian, &grad);
-        let tau: F = if wdp <= F::from_f64(0.0).unwrap() {
-            F::from_f64(1.0).unwrap()
+        let tau: F = if wdp <= float!(0.0) {
+            float!(1.0)
         } else {
-            F::from_f64(1.0)
-                .unwrap()
-                .min(grad_norm.powi(3) / (self.radius * wdp))
+            float!(1.0).min(grad_norm.powi(3) / (self.radius * wdp))
         };
 
         let new_param = grad.mul(&(-tau * self.radius / grad_norm));

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -76,7 +76,7 @@ where
         let pstar;
 
         // pb = -H^-1g
-        let pb = (h.inv()?).dot(&g).mul(&F::from_f64(-1.0).unwrap());
+        let pb = (h.inv()?).dot(&g).mul(&float!(-1.0));
 
         if pb.norm() <= self.radius {
             pstar = pb;
@@ -91,12 +91,11 @@ where
 
             // compute tau
             let delta = self.radius.powi(2);
-            let t1 = F::from_f64(3.0).unwrap() * utb - btb - F::from_f64(2.0).unwrap() * utu;
-            let t2 = (utb.powi(2) - F::from_f64(2.0).unwrap() * utb * delta + delta * btb
-                - btb * utu
+            let t1 = float!(3.0) * utb - btb - float!(2.0) * utu;
+            let t2 = (utb.powi(2) - float!(2.0) * utb * delta + delta * btb - btb * utu
                 + delta * utu)
                 .sqrt();
-            let t3 = F::from_f64(-2.0).unwrap() * utb + btb + utu;
+            let t3 = float!(-2.0) * utb + btb + utu;
             let tau1: F = -(t1 + t2) / t3;
             let tau2: F = -(t1 - t2) / t3;
 
@@ -105,13 +104,13 @@ where
 
             // if calculation failed because t3 is too small, use the third option
             if tau.is_nan() || tau.is_infinite() {
-                tau = (delta + btb - F::from_f64(2.0).unwrap() * utu) / (btb - utu);
+                tau = (delta + btb - float!(2.0) * utu) / (btb - utu);
             }
 
-            if tau >= F::from_f64(0.0).unwrap() && tau < F::from_f64(1.0).unwrap() {
+            if tau >= float!(0.0) && tau < float!(1.0) {
                 pstar = pu.mul(&tau);
-            } else if tau >= F::from_f64(1.0).unwrap() && tau <= F::from_f64(2.0).unwrap() {
-                pstar = pu.add(&pb.sub(&pu).mul(&(tau - F::from_f64(1.0).unwrap())));
+            } else if tau >= float!(1.0) && tau <= float!(2.0) {
+                pstar = pu.add(&pb.sub(&pu).mul(&(tau - float!(1.0))));
             } else {
                 return Err(argmin_error!(
                     PotentialBug,

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -55,7 +55,7 @@ where
     pub fn new() -> Self {
         Steihaug {
             radius: F::nan(),
-            epsilon: F::from_f64(10e-10).unwrap(),
+            epsilon: float!(10e-10),
             p: None,
             r: None,
             rtr: F::nan(),
@@ -67,7 +67,7 @@ where
 
     /// Set epsilon
     pub fn epsilon(mut self, epsilon: F) -> Result<Self, Error> {
-        if epsilon <= F::from_f64(0.0).unwrap() {
+        if epsilon <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "Steihaug: epsilon must be > 0.0."
@@ -89,7 +89,7 @@ where
     where
         P: ArgminWeightedDot<P, F, H>,
     {
-        g.dot(p) + F::from_f64(0.5).unwrap() * p.weighted_dot(h, p)
+        g.dot(p) + float!(0.5) * p.weighted_dot(h, p)
     }
 
     /// calculate all possible step lengths
@@ -111,7 +111,7 @@ where
         let mut t = vec![tau1, tau2];
         // Maybe calculating tau3 should only be done if b is close to zero?
         if tau1.is_nan() || tau2.is_nan() || tau1.is_infinite() || tau2.is_infinite() {
-            let tau3 = (delta - a) / (F::from_f64(2.0).unwrap() * c);
+            let tau3 = (delta - a) / (float!(2.0) * c);
             t.push(tau3);
         }
         let v = if eval {
@@ -168,7 +168,7 @@ where
 
         self.r_0_norm = r.norm();
         self.rtr = r.dot(&r);
-        self.d = Some(r.mul(&F::from_f64(-1.0).unwrap()));
+        self.d = Some(r.mul(&float!(-1.0)));
         let p = r.zero_like();
         self.p = Some(p.clone());
 
@@ -189,7 +189,7 @@ where
 
         // Current search direction d is a direction of zero curvature or negative curvature
         let p = self.p.as_ref().unwrap();
-        if dhd <= F::from_f64(0.0).unwrap() {
+        if dhd <= float!(0.0) {
             let tau = self.tau(|_| true, true, &grad, &h);
             return Ok((
                 state
@@ -204,7 +204,7 @@ where
 
         // new p violates trust region bound
         if p_n.norm() >= self.radius {
-            let tau = self.tau(|x| x >= F::from_f64(0.0).unwrap(), false, &grad, &h);
+            let tau = self.tau(|x| x >= float!(0.0), false, &grad, &h);
             return Ok((
                 state
                     .param(p.add(&d.mul(&tau)))
@@ -227,7 +227,7 @@ where
 
         let rjtrj = r_n.dot(&r_n);
         let beta = rjtrj / self.rtr;
-        self.d = Some(r_n.mul(&F::from_f64(-1.0).unwrap()).add(&d.mul(&beta)));
+        self.d = Some(r_n.mul(&float!(-1.0)).add(&d.mul(&beta)));
         self.r = Some(r_n);
         self.p = Some(p_n.clone());
         self.rtr = rjtrj;

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -62,9 +62,9 @@ where
     /// Constructor
     pub fn new(subproblem: R) -> Self {
         TrustRegion {
-            radius: F::from_f64(1.0).unwrap(),
-            max_radius: F::from_f64(100.0).unwrap(),
-            eta: F::from_f64(0.125).unwrap(),
+            radius: float!(1.0),
+            max_radius: float!(100.0),
+            eta: float!(0.125),
             subproblem,
             fxk: F::nan(),
             mk0: F::nan(),
@@ -87,7 +87,7 @@ where
 
     /// Set eta
     pub fn eta(mut self, eta: F) -> Result<Self, Error> {
-        if eta >= F::from_f64(0.25).unwrap() || eta < F::from_f64(0.0).unwrap() {
+        if eta >= float!(0.25) || eta < float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
                 "TrustRegion: eta must be in [0, 1/4)."
@@ -175,20 +175,18 @@ where
 
         let new_param = pk.add(&param);
         let fxkpk = problem.cost(&new_param)?;
-        let mkpk =
-            self.fxk + pk.dot(&grad) + F::from_f64(0.5).unwrap() * pk.weighted_dot(&hessian, &pk);
+        let mkpk = self.fxk + pk.dot(&grad) + float!(0.5) * pk.weighted_dot(&hessian, &pk);
 
         let rho = reduction_ratio(self.fxk, fxkpk, self.mk0, mkpk);
 
         let pk_norm = pk.norm();
 
         let cur_radius = self.radius;
-        self.radius = if rho < F::from_f64(0.25).unwrap() {
-            F::from_f64(0.25).unwrap() * pk_norm
-        } else if rho > F::from_f64(0.75).unwrap()
-            && (pk_norm - self.radius).abs() <= F::from_f64(10.0).unwrap() * F::epsilon()
+        self.radius = if rho < float!(0.25) {
+            float!(0.25) * pk_norm
+        } else if rho > float!(0.75) && (pk_norm - self.radius).abs() <= float!(10.0) * F::epsilon()
         {
-            self.max_radius.min(F::from_f64(2.0).unwrap() * self.radius)
+            self.max_radius.min(float!(2.0) * self.radius)
         } else {
             self.radius
         };


### PR DESCRIPTION
When using generics with floats, creating a constant value from a literal (such as `3.14`) is cumbersome:

`F::from_f64(3.14).unwrap()`

Not only does this take up quite a lot of space and is difficult to read, it also comes with an `.unwrap()` which is not very pleasent on the eyes (even though it is optimized away by the compiler).

The `float!` trait takes either a value:

`float!(<val>)`

which turns into this:

`F::from_f64(<val>).unwrap()`.

(This assumes that the generic parameter is `F` (which is typically the case in argmin).)
Or it additionally takes a generic parameter as input:

`float!(<generic>, <val>)`

which turns into this:

`<generic>::from_f64(<val>).unwrap().

Overall this macro reduces the clutter in the code.