### PR TITLE
Cleanup of NelderMead, documentation and doc and unit tests

### DIFF
--- a/argmin/examples/neldermead.rs
+++ b/argmin/examples/neldermead.rs
@@ -30,16 +30,15 @@ fn run() -> Result<(), Error> {
     let cost = Rosenbrock { a: 1.0, b: 100.0 };
 
     // Set up solver -- note that the proper choice of the vertices is very important!
-    let solver = NelderMead::new()
-        .with_initial_params(vec![
-            // array![-2.0, 3.0],
-            // array![-2.0, -1.0],
-            // array![2.0, -1.0],
-            array![-1.0, 3.0],
-            array![2.0, 1.5],
-            array![2.0, -1.0],
-        ])
-        .sd_tolerance(0.0001);
+    let solver = NelderMead::new(vec![
+        // array![-2.0, 3.0],
+        // array![-2.0, -1.0],
+        // array![2.0, -1.0],
+        array![-1.0, 3.0],
+        array![2.0, 1.5],
+        array![2.0, -1.0],
+    ])
+    .with_sd_tolerance(0.0001)?;
 
     // Run solver
     let res = Executor::new(cost, solver)

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -5,11 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! Nelder Mead method
+//! # Nelder-Mead method
 //!
-//! # References:
+//! The Nelder-Mead method a heuristic search method for nonlinear optimization problems which does
+//! not require derivatives.
 //!
-//! [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
+//! See [`NelderMead`] for details.
+//!
+//! ## Reference
+//!
+//! <https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method>
 
 use crate::core::{
     ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
@@ -20,7 +25,7 @@ use argmin_math::{ArgminAdd, ArgminMul, ArgminSub};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-/// Nelder-Mead method
+/// # Nelder-Mead method
 ///
 /// The Nelder-Mead method a heuristic search method for nonlinear optimization problems which does
 /// not require derivatives.
@@ -33,12 +38,12 @@ use std::fmt;
 ///
 /// The following actions are possible:
 ///
-/// 1) Reflection: (Parameter `alpha`, default `1`)
-/// 2) Expansion: (Parameter `gamma`, default `2`)
-/// 3) Contraction: (Parameter `rho`, default `0.5`)
-/// 4) Shrink: (Parameter `sigma`, default `0.5`)
+/// 1) Reflection (Parameter `alpha`, defaults to `1`)
+/// 2) Expansion (Parameter `gamma`, defaults to `2`)
+/// 3) Contraction (Parameter `rho`, defaults to `0.5`)
+/// 4) Shrink (Parameter `sigma`, defaults to `0.5`)
 ///
-/// # References:
+/// ## Reference
 ///
 /// [Wikipedia](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
 #[derive(Clone)]
@@ -63,74 +68,155 @@ where
     P: Clone + ArgminAdd<P, P> + ArgminSub<P, P> + ArgminMul<F, P>,
     F: ArgminFloat,
 {
-    /// Constructor
-    pub fn new() -> Self {
+    /// Construct a new instance of `NelderMead`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(vec_of_parameters);
+    /// ```
+    pub fn new(params: Vec<P>) -> Self {
         NelderMead {
             alpha: float!(1.0),
             gamma: float!(2.0),
             rho: float!(0.5),
             sigma: float!(0.5),
-            params: vec![],
+            params: params.into_iter().map(|p| (p, F::nan())).collect(),
             sd_tolerance: F::epsilon(),
         }
     }
 
-    /// Add initial parameters
-    #[must_use]
-    pub fn with_initial_params(mut self, params: Vec<P>) -> Self {
-        self.params = params.into_iter().map(|p| (p, F::nan())).collect();
-        self
-    }
-
-    /// Set Sample standard deviation tolerance
-    #[must_use]
-    pub fn sd_tolerance(mut self, tol: F) -> Self {
+    /// Set sample standard deviation tolerance
+    ///
+    /// Must be non-negative and defaults to `EPSILON`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> =
+    ///     NelderMead::new(vec_of_parameters).with_sd_tolerance(1e-6)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_sd_tolerance(mut self, tol: F) -> Result<Self, Error> {
+        if tol < float!(0.0) {
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`Nelder-Mead`: sd_tolerance must be >= 0."
+            ));
+        }
         self.sd_tolerance = tol;
-        self
+        Ok(self)
     }
 
-    /// set alpha
-    pub fn alpha(mut self, alpha: F) -> Result<Self, Error> {
+    /// Set alpha parameter for reflection
+    ///
+    /// Must be larger than 0 and defaults to 1.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> =
+    ///     NelderMead::new(vec_of_parameters).with_alpha(0.9)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_alpha(mut self, alpha: F) -> Result<Self, Error> {
         if alpha <= float!(0.0) {
             return Err(argmin_error!(
                 InvalidParameter,
-                "Nelder-Mead:  must be > 0."
+                "`Nelder-Mead`: alpha must be > 0."
             ));
         }
         self.alpha = alpha;
         Ok(self)
     }
 
-    /// set gamma
-    pub fn gamma(mut self, gamma: F) -> Result<Self, Error> {
+    /// Set gamma for expansion
+    ///
+    /// Must be larger than 1 and defaults to 2.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> =
+    ///     NelderMead::new(vec_of_parameters).with_gamma(1.9)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_gamma(mut self, gamma: F) -> Result<Self, Error> {
         if gamma <= float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
-                "Nelder-Mead: gamma must be > 1."
+                "`Nelder-Mead`: gamma must be > 1."
             ));
         }
         self.gamma = gamma;
         Ok(self)
     }
 
-    /// set rho
-    pub fn rho(mut self, rho: F) -> Result<Self, Error> {
+    /// Set rho for contraction
+    ///
+    /// Must be in (0, 0.5] and defaults to 0.5.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> =
+    ///     NelderMead::new(vec_of_parameters).with_rho(0.4)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_rho(mut self, rho: F) -> Result<Self, Error> {
         if rho <= float!(0.0) || rho > float!(0.5) {
             return Err(argmin_error!(
                 InvalidParameter,
-                "Nelder-Mead: rho must be in  (0.0, 0.5]."
+                "`Nelder-Mead`: rho must be in (0, 0.5]."
             ));
         }
         self.rho = rho;
         Ok(self)
     }
 
-    /// set sigma
-    pub fn sigma(mut self, sigma: F) -> Result<Self, Error> {
+    /// Set sigma for shrinking
+    ///
+    /// Must be in (0, 1] and defaults to 0.5.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::neldermead::NelderMead;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let vec_of_parameters = vec![vec![1.0], vec![2.0], vec![3.0]];
+    /// let nm: NelderMead<Vec<f64>, f64> =
+    ///     NelderMead::new(vec_of_parameters).with_sigma(0.4)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_sigma(mut self, sigma: F) -> Result<Self, Error> {
         if sigma <= float!(0.0) || sigma > float!(1.0) {
             return Err(argmin_error!(
                 InvalidParameter,
-                "Nelder-Mead: sigma must be in  (0.0, 1.0]."
+                "`Nelder-Mead`: sigma must be in (0, 1]."
             ));
         }
         self.sigma = sigma;
@@ -185,16 +271,6 @@ where
         }
         self.params = out;
         Ok(())
-    }
-}
-
-impl<P, F> Default for NelderMead<P, F>
-where
-    P: Clone + ArgminAdd<P, P> + ArgminSub<P, P> + ArgminMul<F, P>,
-    F: ArgminFloat,
-{
-    fn default() -> NelderMead<P, F> {
-        NelderMead::new()
     }
 }
 
@@ -319,8 +395,149 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::test_utils::TestProblem;
+    use crate::core::{test_utils::TestProblem, ArgminError};
     use crate::test_trait_impl;
 
     test_trait_impl!(nelder_mead, NelderMead<TestProblem, f64>);
+
+    #[test]
+    fn test_new() {
+        let params = vec![vec![1.0], vec![2.0]];
+        let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+
+        let NelderMead {
+            alpha,
+            gamma,
+            rho,
+            sigma,
+            params,
+            sd_tolerance,
+        } = nm;
+
+        assert_eq!(alpha.to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_eq!(gamma.to_ne_bytes(), 2.0f64.to_ne_bytes());
+        assert_eq!(rho.to_ne_bytes(), 0.5f64.to_ne_bytes());
+        assert_eq!(sigma.to_ne_bytes(), 0.5f64.to_ne_bytes());
+        assert_eq!(params[0].0[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_eq!(params[1].0[0].to_ne_bytes(), 2.0f64.to_ne_bytes());
+        assert_eq!(params[0].1.to_ne_bytes(), f64::NAN.to_ne_bytes());
+        assert_eq!(params[1].1.to_ne_bytes(), f64::NAN.to_ne_bytes());
+        assert_eq!(sd_tolerance.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+    }
+
+    #[test]
+    fn test_with_sd_tolerance() {
+        // correct parameters
+        for tol in [1e-6, 0.0, 1e-2, 1.0, 2.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_sd_tolerance(tol);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.sd_tolerance.to_ne_bytes(), tol.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for tol in [-f64::EPSILON, -1.0, -100.0, -42.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_sd_tolerance(tol);
+            assert_error!(
+                res,
+                ArgminError,
+                concat!(
+                    "Invalid parameter: \"`Nelder-Mead`: ",
+                    "sd_tolerance must be >= 0.\""
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_alpha() {
+        // correct parameters
+        for alpha in [f64::EPSILON, 1e-6, 1e-2, 1.0, 2.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_alpha(alpha);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.alpha.to_ne_bytes(), alpha.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for alpha in [-f64::EPSILON, -1.0, -100.0, -42.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_alpha(alpha);
+            assert_error!(
+                res,
+                ArgminError,
+                concat!(
+                    "Invalid parameter: \"`Nelder-Mead`: ",
+                    "alpha must be > 0.\""
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_rho() {
+        // correct parameters
+        for rho in [f64::EPSILON, 0.1, 0.3, 0.5] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_rho(rho);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.rho.to_ne_bytes(), rho.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for rho in [-1.0, 0.0, 0.5 + f64::EPSILON, 1.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_rho(rho);
+            assert_error!(
+                res,
+                ArgminError,
+                concat!(
+                    "Invalid parameter: \"`Nelder-Mead`: ",
+                    "rho must be in (0, 0.5].\""
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_sigma() {
+        // correct parameters
+        for sigma in [f64::EPSILON, 0.3, 0.5, 0.9, 1.0 - f64::EPSILON] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_sigma(sigma);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.sigma.to_ne_bytes(), sigma.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for sigma in [-1.0, 0.0, 1.0 + f64::EPSILON, 10.0] {
+            let params = vec![vec![1.0], vec![2.0]];
+            let nm: NelderMead<Vec<f64>, f64> = NelderMead::new(params);
+            let res = nm.with_sigma(sigma);
+            assert_error!(
+                res,
+                ArgminError,
+                concat!(
+                    "Invalid parameter: \"`Nelder-Mead`: ",
+                    "sigma must be in (0, 1].\""
+                )
+            );
+        }
+    }
 }


### PR DESCRIPTION
* [x] Improved documentation. 
* [x] It is mandatory to initialize the solver with multiple parameter vectors, therefore they now must be provided to the constructor.
* [x] Add doc tests
* [x] Add unit tests for setters
* [x] Method `sd_tolerance` was renamed to `with_sd_tolerance`.
* [x] Method `alpha` was renamed to `with_alpha`.
* [x] Method `gamma` was renamed to `with_gamma`.
* [x] Method `rho` was renamed to `with_rho`.
* [x] Method `sigma` was renamed to `with_sigma`.
* [x] The Nelder-Mead example was updated accordingly.
* [x] Add unit tests for Solver impl
* [x] Add unit tests for other methods
* [x] Fix #201 