### PR TITLE
Made `ArgminError` non_exhaustive

### DIFF
--- a/argmin/src/core/errors.rs
+++ b/argmin/src/core/errors.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 
 /// Argmin error type
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ArgminError {
     /// Indicates and invalid parameter
     #[error("Invalid parameter: {text:?}")]


### PR DESCRIPTION
Making the `ArgminError` enum `non_exhaustive` avoids that additions to the enum will be breaking changes. It forces downstream crates to add a wildcard arm to match expressions. 

Details: https://rust-lang.github.io/rfcs/2008-non-exhaustive.html