### PR TITLE
Parallel/bulk evaluation of problem functions

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -27,6 +27,7 @@ bincode = { version = "1.3.3", optional = true }
 ctrlc = { version = "3.1.2", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 gnuplot = { version = "0.0.37", optional = true }
+rayon = { version = "1.5.2", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0", optional = true }
 slog = { version = "2.4.1", optional = true, features = ["dynamic-keys"] }

--- a/argmin/examples/particleswarm.rs
+++ b/argmin/examples/particleswarm.rs
@@ -23,15 +23,11 @@ impl CostFunction for Himmelblau {
 fn run() -> Result<(), Error> {
     let cost_function = Himmelblau {};
 
-    // let solver = ParticleSwarm::new((vec![-4.0, -4.0], vec![4.0, 4.0]), 100, 0.5, 0.9, 0.5)?;
     let solver = ParticleSwarm::new((vec![-4.0, -4.0], vec![4.0, 4.0]), 40);
 
     let res = Executor::new(cost_function, solver)
         .configure(|state| state.max_iters(100))
         .run()?;
-
-    // Wait a second (lets the logger flush everything before printing again)
-    std::thread::sleep(std::time::Duration::from_secs(1));
 
     // Print Result
     println!("{}", res);

--- a/argmin/src/core/float.rs
+++ b/argmin/src/core/float.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{DeserializeOwnedAlias, SerializeAlias};
+use crate::core::{DeserializeOwnedAlias, SendAlias, SerializeAlias};
 use num_traits::{Float, FloatConst, FromPrimitive, ToPrimitive};
 use std::fmt::{Debug, Display};
 
@@ -23,6 +23,7 @@ pub trait ArgminFloat:
     + Display
     + SerializeAlias
     + DeserializeOwnedAlias
+    + SendAlias
 {
 }
 
@@ -37,5 +38,6 @@ impl<I> ArgminFloat for I where
         + Display
         + SerializeAlias
         + DeserializeOwnedAlias
+        + SendAlias
 {
 }

--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -25,6 +25,8 @@ mod float;
 mod kv;
 /// Observers
 pub mod observers;
+/// Trait alias for `Send` and `Sync`
+mod parallelization;
 /// Traits and structs for defining and handling optimization problems
 mod problem;
 /// Definition of the return type of the solvers
@@ -48,6 +50,7 @@ pub use errors::ArgminError;
 pub use executor::Executor;
 pub use float::ArgminFloat;
 pub use kv::KV;
+pub use parallelization::{SendAlias, SyncAlias};
 pub use problem::{CostFunction, Gradient, Hessian, Jacobian, LinearProgram, Operator, Problem};
 pub use result::OptimizationResult;
 pub use serialization::{DeserializeOwnedAlias, SerializeAlias};

--- a/argmin/src/core/parallelization.rs
+++ b/argmin/src/core/parallelization.rs
@@ -1,0 +1,50 @@
+// Copyright 2018-2022 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+/// Trait alias for `Send`
+///
+/// If the `rayon` feature is set, it acts as an alias for `Send` and is implemented for all
+/// types which implement `Send`. If `rayon` is not set, it will be an "empty" trait
+/// implemented for all types.
+#[cfg(feature = "rayon")]
+pub trait SendAlias: Send {}
+
+/// Trait alias for `Send`
+///
+/// If the `rayon` feature is set, it acts as an alias for `Send` and is implemented for all
+/// types which implement `Send`. If `rayon` is not set, it will be an "empty" trait
+/// implemented for all types.
+#[cfg(not(feature = "rayon"))]
+pub trait SendAlias {}
+
+#[cfg(feature = "rayon")]
+impl<T> SendAlias for T where T: Send {}
+
+#[cfg(not(feature = "rayon"))]
+impl<T> SendAlias for T {}
+
+/// Trait alias for `Sync`
+///
+/// If the `rayon` feature is set, it acts as an alias for `Sync` and is implemented for all types
+/// which implement `Sync`. If `rayon` is not set, it will be an "empty" trait implemented for all
+/// types.
+#[cfg(feature = "rayon")]
+pub trait SyncAlias: Sync {}
+
+/// Trait alias for `Sync`
+///
+/// If the `rayon` feature is set, it acts as an alias for `Sync` and is implemented for all types
+/// which implement `Sync`. If `rayon` is not set, it will be an "empty" trait implemented for all
+/// types.
+#[cfg(not(feature = "rayon"))]
+pub trait SyncAlias {}
+
+#[cfg(feature = "rayon")]
+impl<T> SyncAlias for T where T: Sync {}
+
+#[cfg(not(feature = "rayon"))]
+impl<T> SyncAlias for T {}

--- a/argmin/src/lib.rs
+++ b/argmin/src/lib.rs
@@ -132,6 +132,16 @@
 #![doc = concat!(" argmin = { version = \"", env!("CARGO_PKG_VERSION"), "\", features = [\"ctrlc\"] }")]
 //! ```
 //!
+//! The `rayon` feature adds `rayon` as a depenceny and allows for parallel computation of cost
+//! functions, operators, gradients, Jacobians and Hessians. Note that only solvers that operate on
+//! multiple parameter vectors per iteration benefit from this feature (e.g. Particle Swarm
+//! Optimization).
+//!
+//! ```toml
+//! [dependencies]
+#![doc = concat!(" argmin = { version = \"", env!("CARGO_PKG_VERSION"), "\", features = [\"rayon\"] }")]
+//! ```
+//!
 //! ### Experimental support for compiling to WebAssembly
 //!
 //! When compiling to WASM, the feature `wasm-bindgen` must be used.
@@ -161,7 +171,7 @@
 //!
 //! # Defining a problem
 //!
-//! TODO TODO TODO TODO Rewrite!
+//! TODO TODO TODO TODO Rewrite! Also mention bulk methods.
 //! A problem can be defined by implementing the `ArgminOp` trait which comes with the
 //! associated types `Param`, `Output` and `Hessian`. `Param` is the type of your
 //! parameter vector (i.e. the input to your cost function), `Output` is the type returned


### PR DESCRIPTION
This PR adds `bulk_X` methods to  the `Operator`, `CostFunction`, `Gradient`, `Jacobian`, `Hessian`, ... traits. These methods take multiple parameter vectors as input and evaluate them either in parallel or sequentially, depending on whether the `rayon` feature is enabled or not. The `rayon` feature adds (as suggested by the name) `rayon` as a dependency. 
These default implementation of these methods can be overwritten by users if needed. 

So far only PSO makes use of this feature.

The implementation requires certain types to be `Send` and/or `Sync`. In order to avoid having these type constraints when the `rayon` feature is off, `Send` and `Sync` are hidden behind `SendAlias` and `SyncAlias`. This follows the approach taken with `Serialize` and `DeserializeOwned`.  

This PR is the result of long discussions in #6 and #142. Thanks to @TheIronBorn for the valuable input, discussion and patience!