### PR TITLE
Cleanup of Quasi-Newton methods

### DIFF
--- a/argmin-math/src/ndarray_m/dot.rs
+++ b/argmin-math/src/ndarray_m/dot.rs
@@ -25,7 +25,7 @@ macro_rules! make_dot_ndarray {
             }
         }
 
-        impl<'a> ArgminDot<Array1<$t>, Array1<$t>> for $t {
+        impl ArgminDot<Array1<$t>, Array1<$t>> for $t {
             #[inline]
             fn dot(&self, other: &Array1<$t>) -> Array1<$t> {
                 other * *self
@@ -66,7 +66,7 @@ macro_rules! make_dot_ndarray {
             }
         }
 
-        impl<'a> ArgminDot<Array2<$t>, Array2<$t>> for $t {
+        impl ArgminDot<Array2<$t>, Array2<$t>> for $t {
             #[inline]
             fn dot(&self, other: &Array2<$t>) -> Array2<$t> {
                 other * *self
@@ -91,7 +91,7 @@ macro_rules! make_dot_complex_ndarray {
             }
         }
 
-        impl<'a> ArgminDot<Array1<Complex<$t>>, Array1<Complex<$t>>> for Complex<$t> {
+        impl ArgminDot<Array1<Complex<$t>>, Array1<Complex<$t>>> for Complex<$t> {
             #[inline]
             fn dot(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
                 other * *self
@@ -132,7 +132,7 @@ macro_rules! make_dot_complex_ndarray {
             }
         }
 
-        impl<'a> ArgminDot<Array2<Complex<$t>>, Array2<Complex<$t>>> for Complex<$t> {
+        impl ArgminDot<Array2<Complex<$t>>, Array2<Complex<$t>>> for Complex<$t> {
             #[inline]
             fn dot(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
                 other * *self

--- a/argmin-math/src/ndarray_m/inv.rs
+++ b/argmin-math/src/ndarray_m/inv.rs
@@ -13,7 +13,7 @@ use num_complex::Complex;
 
 macro_rules! make_inv {
     ($t:ty) => {
-        impl<'a> ArgminInv<Array2<$t>> for Array2<$t>
+        impl ArgminInv<Array2<$t>> for Array2<$t>
         where
             Array2<$t>: Inverse,
         {

--- a/argmin-math/src/primitives/dot.rs
+++ b/argmin-math/src/primitives/dot.rs
@@ -10,7 +10,7 @@ use num_complex::Complex;
 
 macro_rules! make_dot_vec {
     ($t:ty) => {
-        impl<'a> ArgminDot<$t, $t> for $t {
+        impl ArgminDot<$t, $t> for $t {
             #[inline]
             fn dot(&self, other: &$t) -> $t {
                 self * other

--- a/argmin-math/src/vec/dot.rs
+++ b/argmin-math/src/vec/dot.rs
@@ -11,21 +11,21 @@ use num_complex::Complex;
 
 macro_rules! make_dot_vec {
     ($t:ty) => {
-        impl<'a> ArgminDot<Vec<$t>, $t> for Vec<$t> {
+        impl ArgminDot<Vec<$t>, $t> for Vec<$t> {
             #[inline]
             fn dot(&self, other: &Vec<$t>) -> $t {
                 self.iter().zip(other.iter()).map(|(a, b)| a * b).sum()
             }
         }
 
-        impl<'a> ArgminDot<$t, Vec<$t>> for Vec<$t> {
+        impl ArgminDot<$t, Vec<$t>> for Vec<$t> {
             #[inline]
             fn dot(&self, other: &$t) -> Vec<$t> {
                 self.iter().map(|a| a * other).collect()
             }
         }
 
-        impl<'a> ArgminDot<Vec<$t>, Vec<$t>> for $t {
+        impl ArgminDot<Vec<$t>, Vec<$t>> for $t {
             #[inline]
             fn dot(&self, other: &Vec<$t>) -> Vec<$t> {
                 other.iter().map(|a| a * self).collect()
@@ -74,7 +74,7 @@ macro_rules! make_dot_vec {
             }
         }
 
-        impl<'a> ArgminDot<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
+        impl ArgminDot<$t, Vec<Vec<$t>>> for Vec<Vec<$t>> {
             #[inline]
             fn dot(&self, other: &$t) -> Vec<Vec<$t>> {
                 (0..self.len())
@@ -83,7 +83,7 @@ macro_rules! make_dot_vec {
             }
         }
 
-        impl<'a> ArgminDot<Vec<Vec<$t>>, Vec<Vec<$t>>> for $t {
+        impl ArgminDot<Vec<Vec<$t>>, Vec<Vec<$t>>> for $t {
             #[inline]
             fn dot(&self, other: &Vec<Vec<$t>>) -> Vec<Vec<$t>> {
                 (0..other.len())

--- a/argmin/examples/bfgs.rs
+++ b/argmin/examples/bfgs.rs
@@ -49,11 +49,16 @@ fn run() -> Result<(), Error> {
     let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9)?;
 
     // Set up solver
-    let solver = BFGS::new(init_hessian, linesearch);
+    let solver = BFGS::new(linesearch);
 
     // Run solver
     let res = Executor::new(cost, solver)
-        .configure(|state| state.param(init_param).max_iters(60))
+        .configure(|state| {
+            state
+                .param(init_param)
+                .inv_hessian(init_hessian)
+                .max_iters(60)
+        })
         .add_observer(SlogLogger::term(), ObserverMode::Always)
         .run()?;
 

--- a/argmin/examples/dfp.rs
+++ b/argmin/examples/dfp.rs
@@ -49,11 +49,16 @@ fn run() -> Result<(), Error> {
     let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9)?;
 
     // Set up solver
-    let solver = DFP::new(init_hessian, linesearch);
+    let solver = DFP::new(linesearch);
 
     // Run solver
     let res = Executor::new(cost, solver)
-        .configure(|state| state.param(init_param).max_iters(1000))
+        .configure(|state| {
+            state
+                .param(init_param)
+                .inv_hessian(init_hessian)
+                .max_iters(1000)
+        })
         .add_observer(SlogLogger::term(), ObserverMode::Always)
         .run()?;
 

--- a/argmin/examples/sr1.rs
+++ b/argmin/examples/sr1.rs
@@ -7,53 +7,56 @@
 
 use argmin::core::observers::{ObserverMode, SlogLogger};
 use argmin::core::{CostFunction, Error, Executor, Gradient};
+// use argmin::solver::linesearch::HagerZhangLineSearch;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::SR1;
-use argmin_testfunctions::rosenbrock;
+use argmin_testfunctions::styblinski_tang;
 use finitediff::FiniteDiff;
 use ndarray::{array, Array1, Array2};
 
-struct Rosenbrock {
-    a: f64,
-    b: f64,
-}
+struct StyblinskiTang {}
 
-impl CostFunction for Rosenbrock {
+impl CostFunction for StyblinskiTang {
     type Param = Array1<f64>;
     type Output = f64;
 
     fn cost(&self, p: &Self::Param) -> Result<Self::Output, Error> {
-        Ok(rosenbrock(&p.to_vec(), self.a, self.b))
+        Ok(styblinski_tang(&p.to_vec()))
     }
 }
-impl Gradient for Rosenbrock {
+impl Gradient for StyblinskiTang {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
     fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
-        Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
+        Ok((*p).forward_diff(&|x| styblinski_tang(&x.to_vec())))
     }
 }
 
 fn run() -> Result<(), Error> {
     // Define cost function
-    let cost = Rosenbrock { a: 1.0, b: 100.0 };
+    let cost = StyblinskiTang {};
 
     // Define initial parameter vector
-    // let init_param: Array1<f64> = array![-1.2, 1.0];
-    // let init_hessian: Array2<f64> = Array2::eye(2);
-    let init_param: Array1<f64> = array![-1.2, 1.0, -10.0, 2.0, 3.0, 2.0, 4.0, 10.0];
+    // let init_param: Array1<f64> = array![-1.2, 1.0, -5.0, 2.0, 3.0, 2.0, 4.0, 5.0];
+    let init_param: Array1<f64> = array![5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0];
     let init_hessian: Array2<f64> = Array2::eye(8);
 
     // set up a line search
     let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9)?;
+    // let linesearch = HagerZhangLineSearch::new();
 
     // Set up solver
-    let solver = SR1::new(init_hessian, linesearch);
+    let solver = SR1::new(linesearch);
 
     // Run solver
     let res = Executor::new(cost, solver)
-        .configure(|state| state.param(init_param).max_iters(1000))
+        .configure(|state| {
+            state
+                .param(init_param)
+                .inv_hessian(init_hessian)
+                .max_iters(1000)
+        })
         .add_observer(SlogLogger::term(), ObserverMode::Always)
         .run()?;
 

--- a/argmin/examples/writers.rs
+++ b/argmin/examples/writers.rs
@@ -49,7 +49,7 @@ fn run() -> Result<(), Error> {
     let linesearch = MoreThuenteLineSearch::new();
 
     // Set up solver
-    let solver = BFGS::new(init_hessian, linesearch);
+    let solver = BFGS::new(linesearch);
 
     // Create writer
     // Set serializer to Bincode
@@ -60,7 +60,12 @@ fn run() -> Result<(), Error> {
     let writer2 = WriteToFile::new("params", "best", WriteToFileSerializer::JSON);
 
     let res = Executor::new(cost, solver)
-        .configure(|state| state.param(init_param).max_iters(10))
+        .configure(|state| {
+            state
+                .param(init_param)
+                .inv_hessian(init_hessian)
+                .max_iters(10)
+        })
         .add_observer(SlogLogger::term(), ObserverMode::Always)
         .add_observer(writer, ObserverMode::Every(3))
         .add_observer(writer2, ObserverMode::NewBest)

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -232,6 +232,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::let_unit_value)]
+
     use super::*;
     use crate::core::test_utils::TestProblem;
     use crate::core::ArgminError;

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -220,6 +220,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::let_unit_value)]
+
     use super::*;
     use crate::core::ArgminError;
     #[cfg(feature = "ndarrayl")]

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -243,6 +243,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::let_unit_value)]
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError};
     use crate::solver::linesearch::MoreThuenteLineSearch;

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -568,7 +568,7 @@ mod tests {
             ParticleSwarm::new((lower_bound, upper_bound), num_particles);
 
         struct PsoProblem {
-            counter: std::sync::Mutex<usize>,
+            counter: std::sync::Arc<std::sync::Mutex<usize>>,
             values: [f64; 10],
         }
 
@@ -577,16 +577,17 @@ mod tests {
             type Output = f64;
 
             fn cost(&self, _param: &Self::Param) -> Result<Self::Output, Error> {
-                let cost = self.values[*self.counter.lock().unwrap()];
-                *self.counter.lock().unwrap() += 1;
+                let mut counter = self.counter.lock().unwrap();
+                let cost = self.values[*counter];
+                *counter += 1;
                 Ok(cost)
             }
         }
 
-        let mut values = [1.0, 4.0, 10.0, 2.0, -3.0, 8.0, 4.4, 8.1, 6.4, 4.4];
+        let mut values = [1.0, 4.0, 10.0, 2.0, -3.0, 8.0, 4.4, 8.1, 6.4, 4.5];
 
         let mut problem = Problem::new(PsoProblem {
-            counter: std::sync::Mutex::new(0),
+            counter: std::sync::Arc::new(std::sync::Mutex::new(0)),
             values,
         });
 

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -5,11 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # References:
-//!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
-//! Springer. ISBN 0-387-30303-0.
-
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
@@ -18,45 +13,85 @@ use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// DFP method
+/// # Davidon-Fletcher-Powell (DFP) method
 ///
-/// # References:
+/// The Davidon-Fletcher-Powell algorithm (DFP) is a method for solving unconstrained nonlinear
+/// optimization problems.
 ///
-/// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
+/// The algorithm requires a line search which is provided via the constructor. Additionally an
+/// initial guess for the parameter vector and an initial inverse Hessian is required, which are to
+/// be provided via the [`configure`](`crate::core::Executor::configure`) method of the
+/// [`Executor`](`crate::core::Executor`) (See [`IterState`], in particular [`IterState::param`]
+/// and [`IterState::inv_hessian`]).
+/// In the same way the initial gradient and cost function corresponding to the initial parameter
+/// vector can be provided. If these are not provided, they will be computed during initialization
+/// of the algorithm.
+///
+/// A tolerance on the gradient can be configured with
+/// [`with_tolerance_grad`](`DFP::with_tolerance_grad`): If the norm of the gradient is below
+/// said tolerance, the algorithm stops. It defaults to `sqrt(EPSILON)`.
+///
+/// ## Reference
+///
+/// Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-pub struct DFP<L, H, F> {
-    /// Initial inverse Hessian
-    init_inv_hessian: H,
+pub struct DFP<L, F> {
     /// line search
     linesearch: L,
     /// Tolerance for the stopping criterion based on the change of the norm on the gradient
     tol_grad: F,
 }
 
-impl<L, H, F> DFP<L, H, F>
+impl<L, F> DFP<L, F>
 where
     F: ArgminFloat,
 {
-    /// Constructor
-    pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
+    /// Construct a new instance of [`DFP`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::DFP;
+    /// # let linesearch = ();
+    /// let dfp: DFP<_, f64> = DFP::new(linesearch);
+    /// ```
+    pub fn new(linesearch: L) -> Self {
         DFP {
-            init_inv_hessian: init_inverse_hessian,
             linesearch,
             tol_grad: F::epsilon().sqrt(),
         }
     }
 
-    /// Sets tolerance for the stopping criterion based on the change of the norm on the gradient
-    #[must_use]
-    pub fn with_tolerance_grad(mut self, tol_grad: F) -> Self {
+    /// The algorithm stops if the norm of the gradient is below `tol_grad`.
+    ///
+    /// The provided value must be non-negative. Defaults to `sqrt(EPSILON)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::DFP;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let linesearch = ();
+    /// let dfp: DFP<_, f64> = DFP::new(linesearch).with_tolerance_grad(1e-6)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_tolerance_grad(mut self, tol_grad: F) -> Result<Self, Error> {
+        if tol_grad < float!(0.0) {
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`DFP`: gradient tolerance must be >= 0."
+            ));
+        }
         self.tol_grad = tol_grad;
-        self
+        Ok(self)
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for DFP<L, H, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for DFP<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -89,15 +124,40 @@ where
         problem: &mut Problem<O>,
         mut state: IterState<P, G, (), H, F>,
     ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
-        let param = state.take_param().unwrap();
-        let cost = problem.cost(&param)?;
-        let grad = problem.gradient(&param)?;
+        let param = state.take_param().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`DFP` requires an initial parameter vector. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
+
+        let inv_hessian = state.take_inv_hessian().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`DFP` requires an initial inverse Hessian. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
+
+        let cost = state.get_cost();
+        let cost = if cost.is_infinite() {
+            problem.cost(&param)?
+        } else {
+            cost
+        };
+
+        let grad = state
+            .take_grad()
+            .map(Result::Ok)
+            .unwrap_or_else(|| problem.gradient(&param))?;
+
         Ok((
             state
                 .param(param)
                 .cost(cost)
                 .grad(grad)
-                .inv_hessian(self.init_inv_hessian.clone()),
+                .inv_hessian(inv_hessian),
             None,
         ))
     }
@@ -107,13 +167,22 @@ where
         problem: &mut Problem<O>,
         mut state: IterState<P, G, (), H, F>,
     ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
-        let param = state.take_param().unwrap();
+        let param = state.take_param().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`DFP`: Parameter vector in state not set."
+        ))?;
         let cost = state.get_cost();
-        let prev_grad = state
-            .take_grad()
-            .map(Result::Ok)
-            .unwrap_or_else(|| problem.gradient(&param))?;
-        let inv_hessian = state.take_inv_hessian().unwrap();
+
+        let prev_grad = state.take_grad().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`DFP`: Gradient in state not set."
+        ))?;
+
+        let inv_hessian = state.take_inv_hessian().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`DFP`: Inverse Hessian in state not set."
+        ))?;
+
         let p = inv_hessian.dot(&prev_grad).mul(&float!(-1.0));
 
         self.linesearch.search_direction(p);
@@ -132,7 +201,13 @@ where
             .ctrlc(false)
             .run()?;
 
-        let xk1 = linesearch_state.take_param().unwrap();
+        let xk1 = linesearch_state
+            .take_param()
+            .ok_or_else(argmin_error_closure!(
+                PotentialBug,
+                "`DFP`: No parameters returned by line search."
+            ))?;
+
         let next_cost = linesearch_state.get_cost();
 
         // take care of function eval counts
@@ -175,24 +250,174 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
     use crate::test_trait_impl;
 
     test_trait_impl!(
         dfp,
-        DFP<MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64>, Vec<Vec<f64>>, f64>
+        DFP<MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64>, f64>
     );
 
     #[test]
-    fn test_tolerances() {
-        let linesearch: MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64> =
-            MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
-        let init_hessian: Vec<Vec<f64>> = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+    fn test_new() {
+        #[derive(Eq, PartialEq, Debug)]
+        struct MyFakeLineSearch {}
 
-        let tol: f64 = 1e-4;
+        let dfp: DFP<_, f64> = DFP::new(MyFakeLineSearch {});
+        let DFP {
+            linesearch,
+            tol_grad,
+        } = dfp;
 
-        let DFP { tol_grad: t, .. } = DFP::new(init_hessian, linesearch).with_tolerance_grad(tol);
+        assert_eq!(linesearch, MyFakeLineSearch {});
+        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+    }
 
-        assert!((t - tol).abs() < std::f64::EPSILON);
+    #[test]
+    fn test_with_tolerance_grad() {
+        #[derive(Eq, PartialEq, Debug, Clone, Copy)]
+        struct MyFakeLineSearch {}
+
+        // correct parameters
+        for tol in [1e-6, 0.0, 1e-2, 1.0, 2.0] {
+            let dfp: DFP<_, f64> = DFP::new(MyFakeLineSearch {});
+            let res = dfp.with_tolerance_grad(tol);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for tol in [-f64::EPSILON, -1.0, -100.0, -42.0] {
+            let dfp: DFP<_, f64> = DFP::new(MyFakeLineSearch {});
+            let res = dfp.with_tolerance_grad(tol);
+            assert_error!(
+                res,
+                ArgminError,
+                "Invalid parameter: \"`DFP`: gradient tolerance must be >= 0.\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_init() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut dfp: DFP<_, f64> = DFP::new(linesearch);
+
+        // Forgot to initialize the parameter vector
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let problem = TestProblem::new();
+        let res = dfp.init(&mut Problem::new(problem), state);
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Not initialized: \"`DFP` requires an initial parameter vector. Please ",
+                "provide an initial guess via `Executor`s `configure` method.\""
+            )
+        );
+
+        // Forgot initial inverse Hessian guess
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+            IterState::new().param(param.clone());
+        let problem = TestProblem::new();
+        let res = dfp.init(&mut Problem::new(problem), state);
+
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Not initialized: \"`DFP` requires an initial inverse Hessian. Please ",
+                "provide an initial guess via `Executor`s `configure` method.\""
+            )
+        );
+
+        // All good.
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param.clone())
+            .inv_hessian(inv_hessian.clone());
+        let problem = TestProblem::new();
+        let (mut state_out, kv) = dfp.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        let s_param = state_out.take_param().unwrap();
+
+        for (s, p) in s_param.iter().zip(param.iter()) {
+            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+        }
+
+        let s_grad = state_out.take_grad().unwrap();
+
+        for (s, p) in s_grad.iter().zip(param.iter()) {
+            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+        }
+
+        let s_inv_hessian = state_out.take_inv_hessian().unwrap();
+
+        for (s, h) in s_inv_hessian
+            .iter()
+            .flatten()
+            .zip(inv_hessian.iter().flatten())
+        {
+            assert_eq!(s.to_ne_bytes(), h.to_ne_bytes());
+        }
+
+        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+    }
+
+    #[test]
+    fn test_init_provided_cost() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut dfp: DFP<_, f64> = DFP::new(linesearch);
+
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param)
+            .inv_hessian(inv_hessian)
+            .cost(1234.0);
+
+        let problem = TestProblem::new();
+        let (state_out, kv) = dfp.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+    }
+
+    #[test]
+    fn test_init_provided_grad() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let gradient: Vec<f64> = vec![4.0, 9.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut dfp: DFP<_, f64> = DFP::new(linesearch);
+
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param)
+            .inv_hessian(inv_hessian)
+            .grad(gradient.clone());
+
+        let problem = TestProblem::new();
+        let (mut state_out, kv) = dfp.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        let s_grad = state_out.take_grad().unwrap();
+
+        for (s, g) in s_grad.iter().zip(gradient.iter()) {
+            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+        }
     }
 }

--- a/argmin/src/solver/quasinewton/mod.rs
+++ b/argmin/src/solver/quasinewton/mod.rs
@@ -5,23 +5,26 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! Quasi-Newton methods
+//! # Quasi-Newton methods
 //!
-//! [BFGS](BFGS/struct.BFGS.html)
+//! * [`BFGS`]
+//! * [`DFP`]
+//! * [`LBFGS`]
+//! * [`SR1TrustRegion`]
 //!
-//! # References:
+//! ## Reference
 //!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
+//! Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 //! Springer. ISBN 0-387-30303-0.
 
-pub mod bfgs;
-pub mod dfp;
-pub mod lbfgs;
-pub mod sr1;
-pub mod sr1_trustregion;
+mod bfgs;
+mod dfp;
+mod lbfgs;
+mod sr1;
+mod sr1_trustregion;
 
-pub use self::bfgs::*;
-pub use self::dfp::*;
-pub use self::lbfgs::*;
-pub use self::sr1::*;
-pub use self::sr1_trustregion::*;
+pub use self::bfgs::BFGS;
+pub use self::dfp::DFP;
+pub use self::lbfgs::LBFGS;
+pub use self::sr1::SR1;
+pub use self::sr1_trustregion::SR1TrustRegion;

--- a/argmin/src/solver/quasinewton/mod.rs
+++ b/argmin/src/solver/quasinewton/mod.rs
@@ -10,6 +10,7 @@
 //! * [`BFGS`]
 //! * [`DFP`]
 //! * [`LBFGS`]
+//! * [`SR1`]
 //! * [`SR1TrustRegion`]
 //!
 //! ## Reference

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -5,11 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # References:
-//!
-//! \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
-//! Springer. ISBN 0-387-30303-0.
-
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
@@ -18,19 +13,19 @@ use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
-/// SR1 method (broken!)
+/// # Symmetric rank-one (SR1) method
 ///
-/// # References:
+/// This method currently has problems: <https://github.com/argmin-rs/argmin/issues/221>.
 ///
-/// \[0\] Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
+/// ## Reference
+///
+/// Jorge Nocedal and Stephen J. Wright (2006). Numerical Optimization.
 /// Springer. ISBN 0-387-30303-0.
 #[derive(Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-pub struct SR1<L, H, F> {
+pub struct SR1<L, F> {
     /// parameter for skipping rule
-    r: F,
-    /// Init inverse Hessian
-    init_inv_hessian: Option<H>,
+    denominator_factor: F,
     /// line search
     linesearch: L,
     /// Tolerance for the stopping criterion based on the change of the norm on the gradient
@@ -39,50 +34,113 @@ pub struct SR1<L, H, F> {
     tol_cost: F,
 }
 
-impl<L, H, F> SR1<L, H, F>
+impl<L, F> SR1<L, F>
 where
     F: ArgminFloat,
 {
-    /// Constructor
-    pub fn new(init_inverse_hessian: H, linesearch: L) -> Self {
+    /// Construct a new instance of [`SR1`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::SR1;
+    /// # let linesearch = ();
+    /// let sr1: SR1<_, f64> = SR1::new(linesearch);
+    /// ```
+    pub fn new(linesearch: L) -> Self {
         SR1 {
-            r: float!(1e-8),
-            init_inv_hessian: Some(init_inverse_hessian),
+            denominator_factor: float!(1e-8),
             linesearch,
             tol_grad: F::epsilon().sqrt(),
             tol_cost: F::epsilon(),
         }
     }
 
-    /// Set r
-    pub fn r(mut self, r: F) -> Result<Self, Error> {
-        if r < float!(0.0) || r > float!(1.0) {
+    /// Set denominator factor
+    ///
+    /// If the denominator of the update is below the `demoninator_factor` (scaled with other
+    /// factors derived from the parameter vectors and the gradients), then the update of the
+    /// inverse Hessian will be skipped.
+    ///
+    /// Must be in `(0, 1)` and defaults to `1e-8`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::SR1;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let linesearch = ();
+    /// let sr1: SR1<_, f64> = SR1::new(linesearch).with_denominator_factor(1e-7)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_denominator_factor(mut self, denominator_factor: F) -> Result<Self, Error> {
+        if denominator_factor <= float!(0.0) || denominator_factor >= float!(1.0) {
             Err(argmin_error!(
                 InvalidParameter,
-                "SR1: r must be between 0 and 1."
+                "`SR1`: denominator_factor must be in (0, 1)."
             ))
         } else {
-            self.r = r;
+            self.denominator_factor = denominator_factor;
             Ok(self)
         }
     }
 
-    /// Sets tolerance for the stopping criterion based on the change of the norm on the gradient
-    #[must_use]
-    pub fn with_tolerance_grad(mut self, tol_grad: F) -> Self {
+    /// The algorithm stops if the norm of the gradient is below `tol_grad`.
+    ///
+    /// The provided value must be non-negative. Defaults to `sqrt(EPSILON)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::SR1;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let linesearch = ();
+    /// let sr1: SR1<_, f64> = SR1::new(linesearch).with_tolerance_grad(1e-6)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_tolerance_grad(mut self, tol_grad: F) -> Result<Self, Error> {
+        if tol_grad < float!(0.0) {
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`SR1`: gradient tolerance must be >= 0."
+            ));
+        }
         self.tol_grad = tol_grad;
-        self
+        Ok(self)
     }
 
     /// Sets tolerance for the stopping criterion based on the change of the cost stopping criterion
-    #[must_use]
-    pub fn with_tolerance_cost(mut self, tol_cost: F) -> Self {
+    ///
+    /// The provided value must be non-negative. Defaults to `EPSILON`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::solver::quasinewton::SR1;
+    /// # use argmin::core::Error;
+    /// # fn main() -> Result<(), Error> {
+    /// # let linesearch = ();
+    /// let sr1: SR1<_, f64> = SR1::new(linesearch).with_tolerance_cost(1e-6)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_tolerance_cost(mut self, tol_cost: F) -> Result<Self, Error> {
+        if tol_cost < float!(0.0) {
+            return Err(argmin_error!(
+                InvalidParameter,
+                "`SR1`: cost tolerance must be >= 0."
+            ));
+        }
         self.tol_cost = tol_cost;
-        self
+        Ok(self)
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for SR1<L, H, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for SR1<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -90,11 +148,22 @@ where
         + DeserializeOwnedAlias
         + ArgminSub<P, P>
         + ArgminDot<G, F>
+        + ArgminDot<P, F>
         + ArgminDot<P, H>
         + ArgminNorm<F>
         + ArgminMul<F, P>,
-    G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminNorm<F> + ArgminSub<G, G>,
-    H: SerializeAlias + DeserializeOwnedAlias + ArgminDot<G, P> + ArgminAdd<H, H> + ArgminMul<F, H>,
+    G: Clone
+        + SerializeAlias
+        + DeserializeOwnedAlias
+        + ArgminSub<P, P>
+        + ArgminNorm<F>
+        + ArgminSub<G, G>,
+    H: SerializeAlias
+        + DeserializeOwnedAlias
+        + ArgminDot<G, P>
+        + ArgminDot<P, P>
+        + ArgminAdd<H, H>
+        + ArgminMul<F, H>,
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
     F: ArgminFloat,
 {
@@ -105,15 +174,39 @@ where
         problem: &mut Problem<O>,
         mut state: IterState<P, G, (), H, F>,
     ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
-        let param = state.take_param().unwrap();
-        let cost = problem.cost(&param)?;
-        let grad = problem.gradient(&param)?;
+        let param = state.take_param().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`SR1` requires an initial parameter vector. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
+
+        let inv_hessian = state.take_inv_hessian().ok_or_else(argmin_error_closure!(
+            NotInitialized,
+            concat!(
+                "`SR1` requires an initial inverse Hessian. ",
+                "Please provide an initial guess via `Executor`s `configure` method."
+            )
+        ))?;
+
+        let cost = state.get_cost();
+        let cost = if cost.is_infinite() {
+            problem.cost(&param)?
+        } else {
+            cost
+        };
+
+        let grad = state
+            .take_grad()
+            .map(Result::Ok)
+            .unwrap_or_else(|| problem.gradient(&param))?;
         Ok((
             state
                 .param(param)
                 .cost(cost)
                 .grad(grad)
-                .inv_hessian(self.init_inv_hessian.take().unwrap()),
+                .inv_hessian(inv_hessian),
             None,
         ))
     }
@@ -123,13 +216,21 @@ where
         problem: &mut Problem<O>,
         mut state: IterState<P, G, (), H, F>,
     ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
-        let param = state.take_param().unwrap();
-        let cost = state.cost;
-        let mut inv_hessian = state.take_inv_hessian().unwrap();
-        let prev_grad = state
-            .take_grad()
-            .map(Result::Ok)
-            .unwrap_or_else(|| problem.gradient(&param))?;
+        let param = state.take_param().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`SR1`: Parameter vector in state not set."
+        ))?;
+        let cost = state.get_cost();
+
+        let prev_grad = state.take_grad().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`SR1`: Gradient in state not set."
+        ))?;
+
+        let mut inv_hessian = state.take_inv_hessian().ok_or_else(argmin_error_closure!(
+            PotentialBug,
+            "`SR1`: Inverse Hessian in state not set."
+        ))?;
 
         let p = inv_hessian.dot(&prev_grad).mul(&float!(-1.0));
 
@@ -151,7 +252,7 @@ where
             .run()?;
 
         let xk1 = linesearch_state.take_param().unwrap();
-        let next_cost = linesearch_state.cost;
+        let next_cost = linesearch_state.get_cost();
 
         // take care of function eval counts
         problem.consume_problem(line_problem);
@@ -161,19 +262,15 @@ where
 
         let sk = xk1.sub(&param);
 
-        let skmhkyk: P = sk.sub(&inv_hessian.dot(&yk));
-        let a: H = skmhkyk.dot(&skmhkyk);
-        let b: F = skmhkyk.dot(&yk);
+        // let skmhkyk: P = sk.sub(&inv_hessian.dot(&yk));
+        // let a: H = skmhkyk.dot(&skmhkyk);
+        // let b: F = skmhkyk.dot(&yk);
+        let ykmbksk: P = yk.sub(&inv_hessian.dot(&sk));
+        let a: H = ykmbksk.dot(&ykmbksk);
+        let b: F = ykmbksk.dot(&sk);
 
-        let hessian_update = b.abs() >= self.r * yk.norm() * skmhkyk.norm();
-
-        // a try to see whether the skipping rule based on B_k makes any difference (seems not)
-        // let bk = self.inv_hessian.inv()?;
-        // let ykmbksk = yk.sub(&bk.dot(&sk));
-        // let tmp: f64 = sk.dot(&ykmbksk);
-        // let sksk: f64 = sk.dot(&sk);
-        // let blah: f64 = ykmbksk.dot(&ykmbksk);
-        // let hessian_update = tmp.abs() >= self.r * sksk.sqrt() * blah.sqrt();
+        // let hessian_update = b.abs() >= self.r * yk.norm() * skmhkyk.norm();
+        let hessian_update = b.abs() >= self.denominator_factor * sk.norm() * ykmbksk.norm();
 
         if hessian_update {
             inv_hessian = inv_hessian.add(&a.mul(&(float!(1.0) / b)));
@@ -185,7 +282,7 @@ where
                 .cost(next_cost)
                 .grad(grad)
                 .inv_hessian(inv_hessian),
-            Some(make_kv!["denom" => b; "hessian_update" => hessian_update;]),
+            Some(make_kv!["denominator" => b; "hessian_update" => hessian_update;]),
         ))
     }
 
@@ -203,32 +300,232 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
     use crate::test_trait_impl;
 
     test_trait_impl!(
         sr1,
-        SR1<MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64>, Vec<Vec<f64>>, f64>
+        SR1<MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64>, f64>
     );
 
     #[test]
-    fn test_tolerances() {
-        let linesearch: MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64> =
-            MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
-        let init_hessian: Vec<Vec<f64>> = vec![vec![1.0, 0.0], vec![0.0, 1.0]];
+    fn test_new() {
+        #[derive(Eq, PartialEq, Debug)]
+        struct MyFakeLineSearch {}
 
-        let tol1: f64 = 1e-4;
-        let tol2: f64 = 1e-2;
-
+        let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
         let SR1 {
-            tol_grad: t1,
-            tol_cost: t2,
-            ..
-        } = SR1::new(init_hessian, linesearch)
-            .with_tolerance_grad(tol1)
-            .with_tolerance_cost(tol2);
+            denominator_factor,
+            linesearch,
+            tol_grad,
+            tol_cost,
+        } = sr1;
 
-        assert!((t1 - tol1).abs() < std::f64::EPSILON);
-        assert!((t2 - tol2).abs() < std::f64::EPSILON);
+        assert_eq!(linesearch, MyFakeLineSearch {});
+        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+        assert_eq!(tol_cost.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_eq!(denominator_factor.to_ne_bytes(), 1e-8f64.to_ne_bytes());
+    }
+
+    #[test]
+    fn test_with_denominator_factor() {
+        #[derive(Eq, PartialEq, Debug, Clone, Copy)]
+        struct MyFakeLineSearch {}
+
+        // correct parameters
+        for tol in [f64::EPSILON, 1e-8, 1e-6, 1e-2, 1.0 - f64::EPSILON] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_denominator_factor(tol);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.denominator_factor.to_ne_bytes(), tol.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for tol in [-f64::EPSILON, 0.0, -1.0, 1.0] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_denominator_factor(tol);
+            assert_error!(
+                res,
+                ArgminError,
+                "Invalid parameter: \"`SR1`: denominator_factor must be in (0, 1).\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_tolerance_grad() {
+        #[derive(Eq, PartialEq, Debug, Clone, Copy)]
+        struct MyFakeLineSearch {}
+
+        // correct parameters
+        for tol in [1e-6, 0.0, 1e-2, 1.0, 2.0] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_tolerance_grad(tol);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for tol in [-f64::EPSILON, -1.0, -100.0, -42.0] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_tolerance_grad(tol);
+            assert_error!(
+                res,
+                ArgminError,
+                "Invalid parameter: \"`SR1`: gradient tolerance must be >= 0.\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_with_tolerance_cost() {
+        #[derive(Eq, PartialEq, Debug, Clone, Copy)]
+        struct MyFakeLineSearch {}
+
+        // correct parameters
+        for tol in [1e-6, 0.0, 1e-2, 1.0, 2.0] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_tolerance_cost(tol);
+            assert!(res.is_ok());
+
+            let nm = res.unwrap();
+            assert_eq!(nm.tol_cost.to_ne_bytes(), tol.to_ne_bytes());
+        }
+
+        // incorrect parameters
+        for tol in [-f64::EPSILON, -1.0, -100.0, -42.0] {
+            let sr1: SR1<_, f64> = SR1::new(MyFakeLineSearch {});
+            let res = sr1.with_tolerance_cost(tol);
+            assert_error!(
+                res,
+                ArgminError,
+                "Invalid parameter: \"`SR1`: cost tolerance must be >= 0.\""
+            );
+        }
+    }
+
+    #[test]
+    fn test_init() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut sr1: SR1<_, f64> = SR1::new(linesearch);
+
+        // Forgot to initialize the parameter vector
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let problem = TestProblem::new();
+        let res = sr1.init(&mut Problem::new(problem), state);
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Not initialized: \"`SR1` requires an initial parameter vector. Please ",
+                "provide an initial guess via `Executor`s `configure` method.\""
+            )
+        );
+
+        // Forgot initial inverse Hessian guess
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+            IterState::new().param(param.clone());
+        let problem = TestProblem::new();
+        let res = sr1.init(&mut Problem::new(problem), state);
+
+        assert_error!(
+            res,
+            ArgminError,
+            concat!(
+                "Not initialized: \"`SR1` requires an initial inverse Hessian. Please ",
+                "provide an initial guess via `Executor`s `configure` method.\""
+            )
+        );
+
+        // All good.
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param.clone())
+            .inv_hessian(inv_hessian.clone());
+        let problem = TestProblem::new();
+        let (mut state_out, kv) = sr1.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        let s_param = state_out.take_param().unwrap();
+
+        for (s, p) in s_param.iter().zip(param.iter()) {
+            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+        }
+
+        let s_grad = state_out.take_grad().unwrap();
+
+        for (s, p) in s_grad.iter().zip(param.iter()) {
+            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+        }
+
+        let s_inv_hessian = state_out.take_inv_hessian().unwrap();
+
+        for (s, h) in s_inv_hessian
+            .iter()
+            .flatten()
+            .zip(inv_hessian.iter().flatten())
+        {
+            assert_eq!(s.to_ne_bytes(), h.to_ne_bytes());
+        }
+
+        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+    }
+
+    #[test]
+    fn test_init_provided_cost() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut sr1: SR1<_, f64> = SR1::new(linesearch);
+
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param)
+            .inv_hessian(inv_hessian)
+            .cost(1234.0);
+
+        let problem = TestProblem::new();
+        let (state_out, kv) = sr1.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+    }
+
+    #[test]
+    fn test_init_provided_grad() {
+        let linesearch = MoreThuenteLineSearch::new().with_c(1e-4, 0.9).unwrap();
+
+        let param: Vec<f64> = vec![-1.0, 1.0];
+        let gradient: Vec<f64> = vec![4.0, 9.0];
+        let inv_hessian: Vec<Vec<f64>> = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+
+        let mut sr1: SR1<_, f64> = SR1::new(linesearch);
+
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+            .param(param)
+            .inv_hessian(inv_hessian)
+            .grad(gradient.clone());
+
+        let problem = TestProblem::new();
+        let (mut state_out, kv) = sr1.init(&mut Problem::new(problem), state).unwrap();
+
+        assert!(kv.is_none());
+
+        let s_grad = state_out.take_grad().unwrap();
+
+        for (s, g) in s_grad.iter().zip(gradient.iter()) {
+            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+        }
     }
 }

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -533,7 +533,7 @@ mod tests {
 
         let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
             .param(param)
-            .grad(gradient.clone())
+            .grad(gradient)
             .hessian(hessian.clone());
 
         let problem = TestProblem::new();

--- a/argmin/src/tests.rs
+++ b/argmin/src/tests.rs
@@ -150,13 +150,13 @@ macro_rules! entropy_max_tests_with_inv_hessian {
 entropy_max_tests! {
      test_max_entropy_lbfgs_morethuente: LBFGS::new(MoreThuenteLineSearch::new(), 10),
      test_max_entropy_lbfgs_hagerzhang: LBFGS::new(HagerZhangLineSearch::new(), 10),
-     test_max_entropy_dfp: DFP::new(Array2::eye(3), MoreThuenteLineSearch::new()),
      test_max_entropy_newton_cg: NewtonCG::new(MoreThuenteLineSearch::new()),
      test_max_entropy_steepest_descent: SteepestDescent::new(MoreThuenteLineSearch::new()),
 }
 
 entropy_max_tests_with_inv_hessian! {
      test_max_entropy_bfgs: BFGS::new(MoreThuenteLineSearch::new()),
+     test_max_entropy_dfp: DFP::new(MoreThuenteLineSearch::new()),
 }
 
 #[test]


### PR DESCRIPTION
* [x] Cleanup general structure
* [x] BFGS
  * [x] Improved documentation
  * [x] Doc tests
  * [x] Unit tests
  * [x] Check that provided tolerances are >= 0
  * [x] Remove init_hessian from BFGS and instead take it from `state`.
  * [x] Error when user does not provide init_hessian and init_param
  * [x] Calculate initial cost only when not provided by user
  * [x] Calculate initial gradient only when not provided by user
* [x] DFP
  * [x] Improved documentation
  * [x] Doc tests
  * [x] Unit tests
  * [x] Check that provided tolerance is >= 0
  * [x] Remove init_hessian from DFP and instead take it from `state`.
  * [x] Error when user does not provide init_hessian and init_param
  * [x] Calculate initial cost only when not provided by user
  * [x] Calculate initial gradient only when not provided by user
* [x] L-BFGS
  * [x] Improved documentation
  * [x] Doc tests
  * [x] Unit tests
  * [x] Check that provided tolerances are >= 0
  * [x] Error when user does not provide init_param
  * [x] Calculate initial cost only when not provided by user
  * [x] Calculate initial gradient only when not provided by user
* [x] SR1
  * [x] Improved documentation
  * [x] Doc tests
  * [x] Unit tests
  * [x] Check that tolerances are within allowed bounds
  * [x] Error when user does not provide init_param
  * [x] Calculate initial cost only when not provided by user
  * [x] Calculate initial gradient only when not provided by user
* [x] SR1 Trust region
  * [x] Improved documentation
  * [x] Doc tests
  * [x] Unit tests
  * [x] Check that tolerances are within allowed bounds
  * [x] Error when user does not provide init_param
  * [x] Calculate initial cost only when not provided by user
  * [x] Calculate initial gradient only when not provided by user
