### PR TITLE
Including argmin-math is now only necessary for choosing a backend

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = { version = "0.2" }
 rand = { version = "0.8.3" }
 rand_xoshiro = { version = "0.6.0", features = ["serde1"] }
 thiserror = "1.0"
-argmin-math = { path = "../argmin-math", default-features = false }
+argmin-math = { path = "../argmin-math", default-features = false, features = ["primitives"] }
 # optional
 bincode = { version = "1.3.3", optional = true }
 ctrlc = { version = "3.1.2", optional = true }


### PR DESCRIPTION
Before this commit it was necessary to include `argmin-math`, even if no backend such as `vec`, `ndarray` or `nalgebra` was used. Otherwise it would result in a compilation error. With this change it is only necessary to include `argmin-math` in the `Cargo.toml` if a backend is chosen.