### PR TITLE
Features `ndarrayl` and `nalgebral` are not to be used by users

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -51,8 +51,8 @@ default = ["slog-logger", "serde1"]
 wasm-bindgen = ["instant/wasm-bindgen", "getrandom/js"]
 slog-logger = ["slog", "slog-term", "slog-async"]
 serde1 = ["serde", "serde_json", "rand/serde1", "bincode", "slog-json"]
-ndarrayl = ["argmin-math/ndarray_latest-serde"]
-nalgebral = ["argmin-math/nalgebra_latest-serde"]
+_ndarrayl = ["argmin-math/ndarray_latest-serde"]
+_nalgebral = ["argmin-math/nalgebra_latest-serde"]
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -99,7 +99,7 @@ required-features = ["argmin-math/ndarray_latest-serde", "slog-logger"]
 
 [[example]]
 name = "gaussnewton_nalgebra"
-required-features = ["nalgebral", "argmin-math/nalgebra_latest-serde", "slog-logger"]
+required-features = ["_nalgebral", "argmin-math/nalgebra_latest-serde", "slog-logger"]
 
 [[example]]
 name = "goldensectionsearch"

--- a/argmin/src/lib.rs
+++ b/argmin/src/lib.rs
@@ -163,10 +163,10 @@
 //!
 //! ## Running the tests and building the examples
 //!
-//! The tests and examples require a set of features to be enabled:
+//! For running all tests and examples, it is recommended to enable all features:
 //!
 //! ```bash
-//! cargo test --features "argmin/ctrlc,argmin-math/ndarray_latest-serde,argmin-math/nalgebra_latest-serde,argmin/ndarrayl"
+//! cargo test --all-features
 //! ```
 //!
 //! # Defining a problem
@@ -644,5 +644,5 @@ pub mod core;
 pub mod solver;
 
 #[cfg(test)]
-#[cfg(feature = "ndarrayl")]
+#[cfg(feature = "_ndarrayl")]
 mod tests;

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -224,11 +224,11 @@ mod tests {
 
     use super::*;
     use crate::core::ArgminError;
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use crate::core::{IterState, State};
     use crate::solver::linesearch::{condition::ArmijoCondition, BacktrackingLineSearch};
     use crate::{assert_error, test_trait_impl};
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(
@@ -283,7 +283,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_line_search_sub_problem() {
         use ndarray::{Array, Array1, Array2};
@@ -331,7 +331,7 @@ mod tests {
         assert_relative_eq!(res[1], 2.0 * 0.5 + 4.0 * 2.0, epsilon = f64::EPSILON);
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_next_iter_param_not_initialized() {
         use ndarray::{Array, Array1, Array2};
@@ -374,7 +374,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_next_iter_regression() {
         use ndarray::{Array, Array1, Array2};

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -161,10 +161,10 @@ where
 mod tests {
     use super::*;
     use crate::core::ArgminError;
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(gauss_newton_method, GaussNewton<f64>);
@@ -233,7 +233,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_next_iter_param_not_initialized() {
         use ndarray::{Array, Array1, Array2};
@@ -270,7 +270,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_solver() {
         use crate::core::State;

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -113,10 +113,10 @@ where
 mod tests {
     use super::*;
     use crate::core::ArgminError;
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(newton_method, Newton<f64>);
@@ -154,7 +154,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_next_iter_param_not_initialized() {
         use crate::core::State;
@@ -192,7 +192,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "ndarrayl")]
+    #[cfg(feature = "_ndarrayl")]
     #[test]
     fn test_solver() {
         use crate::core::State;


### PR DESCRIPTION
Instead, users should choose the math backend via `argmin-math`. These features are unfortunately needed for running tests. In order to make it more clear that those are "internal" they are now prefixed by an underscore: `_ndarrayl` and `_nalgebral`.

Somewhat related to #227.