### PR TITLE
ignore website files for Languages graph in Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.py linguist-detectable=false
+*.scss linguist-detectable=false
+*.js linguist-detectable=false
+*.html linguist-detectable=false


### PR DESCRIPTION
After adding the website, Github thinks that a large portion of the code is SCSS, HTML and JS files. These changes ignore that.