### PR TITLE
Use alias type names in examples

### DIFF
--- a/argmin/examples/backtracking.rs
+++ b/argmin/examples/backtracking.rs
@@ -16,7 +16,7 @@ impl CostFunction for Sphere {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, param: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Error> {
         Ok(sphere(param))
     }
 }
@@ -25,7 +25,7 @@ impl Gradient for Sphere {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, param: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, param: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(sphere_derivative(param))
     }
 }

--- a/argmin/examples/bfgs.rs
+++ b/argmin/examples/bfgs.rs
@@ -30,7 +30,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
     }
 }

--- a/argmin/examples/checkpoint.rs
+++ b/argmin/examples/checkpoint.rs
@@ -18,7 +18,7 @@ impl CostFunction for Rosenbrock {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, p: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, p: &Self::Param) -> Result<Self::Output, Error> {
         Ok(rosenbrock_2d(p, 1.0, 100.0))
     }
 }
@@ -27,7 +27,7 @@ impl Gradient for Rosenbrock {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, p: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(rosenbrock_2d_derivative(p, 1.0, 100.0))
     }
 }

--- a/argmin/examples/conjugategradient.rs
+++ b/argmin/examples/conjugategradient.rs
@@ -15,7 +15,7 @@ impl Operator for MyProblem {
     type Param = Vec<f64>;
     type Output = Vec<f64>;
 
-    fn apply(&self, p: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
         Ok(vec![4.0 * p[0] + 1.0 * p[1], 1.0 * p[0] + 3.0 * p[1]])
     }
 }

--- a/argmin/examples/dfp.rs
+++ b/argmin/examples/dfp.rs
@@ -30,7 +30,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
     }
 }

--- a/argmin/examples/hagerzhang.rs
+++ b/argmin/examples/hagerzhang.rs
@@ -16,7 +16,7 @@ impl CostFunction for Sphere {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, param: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Error> {
         Ok(sphere(param))
     }
 }
@@ -25,7 +25,7 @@ impl Gradient for Sphere {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, param: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, param: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(sphere_derivative(param))
     }
 }

--- a/argmin/examples/landweber.rs
+++ b/argmin/examples/landweber.rs
@@ -16,7 +16,7 @@ impl Gradient for Rosenbrock {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, p: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(rosenbrock_2d_derivative(p, 1.0, 100.0))
     }
 }

--- a/argmin/examples/lbfgs.rs
+++ b/argmin/examples/lbfgs.rs
@@ -30,7 +30,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
     }
 }

--- a/argmin/examples/morethuente.rs
+++ b/argmin/examples/morethuente.rs
@@ -16,7 +16,7 @@ impl CostFunction for Sphere {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, param: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Error> {
         Ok(sphere(param))
     }
 }
@@ -25,7 +25,7 @@ impl Gradient for Sphere {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, param: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, param: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(sphere_derivative(param))
     }
 }

--- a/argmin/examples/newton_cg.rs
+++ b/argmin/examples/newton_cg.rs
@@ -30,7 +30,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(Array1::from(rosenbrock_2d_derivative(
             &p.to_vec(),
             self.a,

--- a/argmin/examples/nonlinear_cg.rs
+++ b/argmin/examples/nonlinear_cg.rs
@@ -17,7 +17,7 @@ impl CostFunction for Rosenbrock {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, p: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, p: &Self::Param) -> Result<Self::Output, Error> {
         Ok(rosenbrock_2d(p, 1.0, 100.0))
     }
 }
@@ -26,7 +26,7 @@ impl Gradient for Rosenbrock {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, p: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(rosenbrock_2d_derivative(p, 1.0, 100.0))
     }
 }

--- a/argmin/examples/simulatedannealing.rs
+++ b/argmin/examples/simulatedannealing.rs
@@ -46,7 +46,7 @@ impl CostFunction for Rosenbrock {
     type Param = Vec<f64>;
     type Output = f64;
 
-    fn cost(&self, param: &Vec<f64>) -> Result<f64, Error> {
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Error> {
         Ok(rosenbrock(param, self.a, self.b))
     }
 }

--- a/argmin/examples/sr1.rs
+++ b/argmin/examples/sr1.rs
@@ -28,7 +28,7 @@ impl Gradient for StyblinskiTang {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| styblinski_tang(&x.to_vec())))
     }
 }

--- a/argmin/examples/sr1_trustregion.rs
+++ b/argmin/examples/sr1_trustregion.rs
@@ -31,7 +31,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
     }
 }

--- a/argmin/examples/steepestdescent.rs
+++ b/argmin/examples/steepestdescent.rs
@@ -32,7 +32,7 @@ impl Gradient for Rosenbrock {
     type Param = Vec<f64>;
     type Gradient = Vec<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(rosenbrock_2d_derivative(p, self.a, self.b))
     }
 }

--- a/argmin/examples/trustregion_nd.rs
+++ b/argmin/examples/trustregion_nd.rs
@@ -30,7 +30,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok(Array1::from(rosenbrock_2d_derivative(
             &p.to_vec(),
             self.a,

--- a/argmin/examples/writers.rs
+++ b/argmin/examples/writers.rs
@@ -31,7 +31,7 @@ impl Gradient for Rosenbrock {
     type Param = Array1<f64>;
     type Gradient = Array1<f64>;
 
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
         Ok((*p).forward_diff(&|x| rosenbrock(&x.to_vec(), self.a, self.b)))
     }
 }


### PR DESCRIPTION
In code examples, both concrete type names and aliases are used for argument and return types of trait implementations.
This fix unifies the type name with aliases for consistency.

Also, return types of some gradient functions are incorrectly specified as `Param`, so this branch corrects them to `Gradient`.