### PR TITLE
Fix π(x; y) in OWL-QN

### DIFF
--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -425,9 +425,12 @@ where
         let d = if let Some(l1_coeff) = self.l1_coeff {
             line_problem.with_l1_constraint(l1_coeff, &param, &prev_grad);
             let zeros = r.zero_like();
-            P::max(&r.mul(&prev_grad).signum(), &zeros)
-                .mul(&r)
-                .mul(&float!(-1.0))
+            P::max(
+                &r.mul(&prev_grad).sub(&F::min_positive_value()).signum(),
+                &zeros,
+            )
+            .mul(&r)
+            .mul(&float!(-1.0))
         } else {
             r.mul(&float!(-1.0))
         };


### PR DESCRIPTION
According to Algorithm 1 in the OWL-QN paper, the $k$-th line search direction $p^k$ is calculated as follows:
$p^k \leftarrow \pi(d^k; v^k)$,
where $\pi_i(x_i; y_i)$ returns $x_i$ if $\sigma(x_i) = \sigma(y_i)$ and $0$ otherwise, $d^k = \boldsymbol{H_k} v^k$, and $v^k$ is a pseudo-gradient.

The current implementation calculates $p^k$ by filtering $d^k$ using the sign of the multiplication of $d^k$ and $v^k$.
However, this implementation returns a wrong result if $v^k_i = 0$ because $0$ has a sign in Rust.
For example, $\pi_i(-1.0; -0)$ must be $0$, but the current implementation returns $-1.0$.

This PR solves this problem by subtracting the minimum positive value from the multiplication of $d^k$ and $v^k$.