### PR TITLE
Fix calculating pseudo-gradient in OWL-QN

### DIFF
--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -475,7 +475,7 @@ where
         self.s.push_back(xk1.sub(&param));
         let grad = if let Some(l1_coeff) = self.l1_coeff {
             // Stores unregularized gradient and returns L1 gradient.
-            let pseudo_grad = calculate_pseudo_gradient(l1_coeff, &param, &grad);
+            let pseudo_grad = calculate_pseudo_gradient(l1_coeff, &xk1, &grad);
             self.y
                 .push_back(grad.sub(self.l1_prev_unreg_grad.as_ref().unwrap()));
             self.l1_prev_unreg_grad = Some(grad);


### PR DESCRIPTION
The pseudo-gradient of the next step must be calculated using the parameters of the next step, but the current implementation incorrectly uses the current parameters.