### PR TITLE
Typed KV store

### DIFF
--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -174,7 +174,7 @@ where
             state.update();
 
             if !self.observers.is_empty() {
-                let mut logs = make_kv!("max_iters" => state.get_max_iters(););
+                let mut logs = kv!("max_iters" => state.get_max_iters(););
 
                 if let Some(kv) = kv {
                     logs = logs.merge(kv);
@@ -234,7 +234,7 @@ where
 
                 if self.timer {
                     let duration = duration.unwrap();
-                    let tmp = make_kv!(
+                    let tmp = kv!(
                         "time" => duration.as_secs() as f64 + f64::from(duration.subsec_nanos()) * 1e-9;
                     );
                     log = log.merge(tmp);

--- a/argmin/src/core/float.rs
+++ b/argmin/src/core/float.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{DeserializeOwnedAlias, SendAlias, SerializeAlias};
+use crate::core::{kv::KVType, DeserializeOwnedAlias, SendAlias, SerializeAlias};
 use num_traits::{Float, FloatConst, FromPrimitive, ToPrimitive};
 use std::fmt::{Debug, Display};
 
@@ -24,6 +24,7 @@ pub trait ArgminFloat:
     + SerializeAlias
     + DeserializeOwnedAlias
     + SendAlias
+    + Into<KVType>
 {
 }
 
@@ -39,5 +40,6 @@ impl<I> ArgminFloat for I where
         + SerializeAlias
         + DeserializeOwnedAlias
         + SendAlias
+        + Into<KVType>
 {
 }

--- a/argmin/src/core/kv.rs
+++ b/argmin/src/core/kv.rs
@@ -10,16 +10,16 @@ use std::fmt::{Debug, Display};
 
 /// Types available for use in [`KV`](KV).
 ///
-/// `Float`, `Int` and `UnsignedInt` are all 64bit. The corresponding 32bit variants must be
+/// `Float`, `Int` and `Uint` are all 64bit. The corresponding 32bit variants must be
 /// be converted to 64 bit. Preferably the `From` impls are used to create a `KVType`:
 ///
 /// ```
 /// # use argmin::core::KVType;
 /// let x: KVType = 1u64.into();
-/// assert_eq!(x, KVType::UnsignedInt(1u64));
+/// assert_eq!(x, KVType::Uint(1u64));
 ///
 /// let x: KVType = 2u32.into();
-/// assert_eq!(x, KVType::UnsignedInt(2u64));
+/// assert_eq!(x, KVType::Uint(2u64));
 ///
 /// let x: KVType = 2i64.into();
 /// assert_eq!(x, KVType::Int(2i64));
@@ -49,11 +49,123 @@ pub enum KVType {
     /// Signed integers
     Int(i64),
     /// Unsigned integers
-    UnsignedInt(u64),
+    Uint(u64),
     /// Boolean values
     Bool(bool),
     /// Strings
     Str(String),
+}
+
+impl KVType {
+    /// Extract float from `KVType`
+    ///
+    /// Returns `Some(<float>)` if `KVType` is of kind `Float` and `None` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Float(1.0).get_float(), Some(1.0));
+    /// assert_eq!(KVType::Int(1).get_float(), None);
+    /// assert_eq!(KVType::Uint(1).get_float(), None);
+    /// assert_eq!(KVType::Bool(true).get_float(), None);
+    /// assert_eq!(KVType::Str("not a float".to_string()).get_float(), None);
+    /// ```
+    pub fn get_float(&self) -> Option<f64> {
+        if let KVType::Float(x) = *self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// Extract int from `KVType`
+    ///
+    /// Returns `Some(<int>)` if `KVType` is of kind `Int` and `None` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Int(1).get_int(), Some(1i64));
+    /// assert_eq!(KVType::Float(1.0).get_int(), None);
+    /// assert_eq!(KVType::Uint(1).get_int(), None);
+    /// assert_eq!(KVType::Bool(true).get_int(), None);
+    /// assert_eq!(KVType::Str("not an int".to_string()).get_int(), None);
+    /// ```
+    pub fn get_int(&self) -> Option<i64> {
+        if let KVType::Int(x) = *self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// Extract unsigned int from `KVType`
+    ///
+    /// Returns `Some(<unsigned int>)` if `KVType` is of kind `Uint` and `None` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Uint(1).get_uint(), Some(1u64));
+    /// assert_eq!(KVType::Int(1).get_uint(), None);
+    /// assert_eq!(KVType::Float(1.0).get_uint(), None);
+    /// assert_eq!(KVType::Bool(true).get_uint(), None);
+    /// assert_eq!(KVType::Str("not an uint".to_string()).get_uint(), None);
+    /// ```
+    pub fn get_uint(&self) -> Option<u64> {
+        if let KVType::Uint(x) = *self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// Extract bool from `KVType`
+    ///
+    /// Returns `Some(<bool>)` if `KVType` is of kind `Bool` and `None` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Bool(true).get_bool(), Some(true));
+    /// assert_eq!(KVType::Float(1.0).get_bool(), None);
+    /// assert_eq!(KVType::Int(1).get_bool(), None);
+    /// assert_eq!(KVType::Uint(1).get_bool(), None);
+    /// assert_eq!(KVType::Str("not a bool".to_string()).get_bool(), None);
+    /// ```
+    pub fn get_bool(&self) -> Option<bool> {
+        if let KVType::Bool(x) = *self {
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    /// Extract String from `KVType`
+    ///
+    /// Returns `Some(<string>)` if `KVType` is of kind `Str` and `None` otherwise.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Str("a string".to_string()).get_string(), Some("a string".to_string()));
+    /// assert_eq!(KVType::Float(1.0).get_string(), None);
+    /// assert_eq!(KVType::Int(1).get_string(), None);
+    /// assert_eq!(KVType::Uint(1).get_string(), None);
+    /// assert_eq!(KVType::Bool(true).get_string(), None);
+    /// ```
+    pub fn get_string(&self) -> Option<String> {
+        if let KVType::Str(x) = self {
+            Some(x.clone())
+        } else {
+            None
+        }
+    }
 }
 
 impl From<f64> for KVType {
@@ -76,7 +188,7 @@ impl From<i64> for KVType {
 
 impl From<u64> for KVType {
     fn from(x: u64) -> KVType {
-        KVType::UnsignedInt(x)
+        KVType::Uint(x)
     }
 }
 
@@ -88,7 +200,7 @@ impl From<i32> for KVType {
 
 impl From<u32> for KVType {
     fn from(x: u32) -> KVType {
-        KVType::UnsignedInt(u64::from(x))
+        KVType::Uint(u64::from(x))
     }
 }
 
@@ -115,7 +227,7 @@ impl Display for KVType {
         match self {
             KVType::Float(x) => write!(f, "{}", x)?,
             KVType::Int(x) => write!(f, "{}", x)?,
-            KVType::UnsignedInt(x) => write!(f, "{}", x)?,
+            KVType::Uint(x) => write!(f, "{}", x)?,
             KVType::Bool(x) => write!(f, "{}", x)?,
             KVType::Str(x) => write!(f, "{}", x)?,
         };

--- a/argmin/src/core/kv.rs
+++ b/argmin/src/core/kv.rs
@@ -240,14 +240,14 @@ impl Display for KVType {
 ///
 /// Keeps pairs of `(&'static str, KVType)` and is used to pass key-value pairs to
 /// [`Observers`](`crate::core::observers`) in each iteration of an optimization algorithm.
-/// Typically constructed using the [`make_kv!`](`crate::make_kv`) macro.
+/// Typically constructed using the [`kv!`](`crate::kv`) macro.
 ///
 /// # Example
 ///
 /// ```
-/// use argmin::make_kv;
+/// use argmin::kv;
 ///
-/// let kv = make_kv!(
+/// let kv = kv!(
 ///     "key1" => "value1";
 ///     "key2" => "value2";
 ///     "key3" => 1234;

--- a/argmin/src/core/kv.rs
+++ b/argmin/src/core/kv.rs
@@ -58,6 +58,28 @@ pub enum KVType {
 }
 
 impl KVType {
+    /// Returns the kind of the `KVType`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use argmin::core::KVType;
+    /// assert_eq!(KVType::Float(1.0).kind(), "Float");
+    /// assert_eq!(KVType::Int(1).kind(), "Int");
+    /// assert_eq!(KVType::Uint(1).kind(), "Uint");
+    /// assert_eq!(KVType::Bool(true).kind(), "Bool");
+    /// assert_eq!(KVType::Str("string".to_string()).kind(), "Str");
+    /// ```
+    pub fn kind(&self) -> &'static str {
+        match self {
+            KVType::Float(_) => "Float",
+            KVType::Int(_) => "Int",
+            KVType::Uint(_) => "Uint",
+            KVType::Bool(_) => "Bool",
+            KVType::Str(_) => "Str",
+        }
+    }
+
     /// Extract float from `KVType`
     ///
     /// Returns `Some(<float>)` if `KVType` is of kind `Float` and `None` otherwise.
@@ -328,6 +350,21 @@ impl KV {
     /// ```
     pub fn get(&self, key: &'static str) -> Option<&KVType> {
         self.kv.get(key)
+    }
+
+    /// Returns all available keys and their `KVType` kind
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{KV, KVType};
+    /// let mut kv1 = KV::new();
+    /// kv1.insert("key1", KVType::Str("value1".to_string()));
+    ///
+    /// assert_eq!(kv1.keys(), vec![("key1", "Str")]);
+    /// ```
+    pub fn keys(&self) -> Vec<(&'static str, &'static str)> {
+        self.kv.iter().map(|(&k, v)| (k, v.kind())).collect()
     }
 
     /// Merge with another `KV`

--- a/argmin/src/core/macros.rs
+++ b/argmin/src/core/macros.rs
@@ -20,17 +20,14 @@
 ///     "key3" => 1234;
 /// );
 /// # assert_eq!(kv.kv.len(), 3);
-/// # assert_eq!(kv.kv[0].0, "key1");
-/// # assert_eq!(format!("{}", kv.kv[0].1), "value1");
-/// # assert_eq!(kv.kv[1].0, "key2");
-/// # assert_eq!(format!("{}", kv.kv[1].1), "value2");
-/// # assert_eq!(kv.kv[2].0, "key3");
-/// # assert_eq!(format!("{}", kv.kv[2].1), "1234");
+/// # assert_eq!(format!("{}", kv.get("key1").unwrap()), "value1");
+/// # assert_eq!(format!("{}", kv.get("key2").unwrap()), "value2");
+/// # assert_eq!(format!("{}", kv.get("key3").unwrap()), "1234");
 /// ```
 #[macro_export]
 macro_rules! make_kv {
     ($($k:expr =>  $v:expr;)*) => {
-        $crate::core::KV { kv: vec![ $(($k, $v.into())),* ] }
+        $crate::core::KV { kv: std::collections::HashMap::from([ $(($k, $v.into())),* ]) }
     };
 }
 

--- a/argmin/src/core/macros.rs
+++ b/argmin/src/core/macros.rs
@@ -30,7 +30,7 @@
 #[macro_export]
 macro_rules! make_kv {
     ($($k:expr =>  $v:expr;)*) => {
-        $crate::core::KV { kv: vec![ $(($k, std::rc::Rc::new($v))),* ] }
+        $crate::core::KV { kv: vec![ $(($k, $v.into())),* ] }
     };
 }
 

--- a/argmin/src/core/macros.rs
+++ b/argmin/src/core/macros.rs
@@ -12,9 +12,9 @@
 /// # Example
 ///
 /// ```
-/// use argmin::make_kv;
+/// use argmin::kv;
 ///
-/// let kv = make_kv!(
+/// let kv = kv!(
 ///     "key1" => "value1";
 ///     "key2" => "value2";
 ///     "key3" => 1234;
@@ -25,7 +25,7 @@
 /// # assert_eq!(format!("{}", kv.get("key3").unwrap()), "1234");
 /// ```
 #[macro_export]
-macro_rules! make_kv {
+macro_rules! kv {
     ($($k:expr =>  $v:expr;)*) => {
         $crate::core::KV { kv: std::collections::HashMap::from([ $(($k, $v.into())),* ]) }
     };

--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -47,7 +47,7 @@ pub use anyhow::Error;
 pub use errors::ArgminError;
 pub use executor::Executor;
 pub use float::ArgminFloat;
-pub use kv::KV;
+pub use kv::{KVType, KV};
 pub use parallelization::{SendAlias, SyncAlias};
 pub use problem::{CostFunction, Gradient, Hessian, Jacobian, LinearProgram, Operator, Problem};
 pub use result::OptimizationResult;

--- a/argmin/src/core/observers/mod.rs
+++ b/argmin/src/core/observers/mod.rs
@@ -388,7 +388,7 @@ mod tests {
             .push(test_obs_3, ObserverMode::Every(3))
             .push(test_obs_4, ObserverMode::NewBest);
 
-        obs.observe_init("test_solver", &make_kv!()).unwrap();
+        obs.observe_init("test_solver", &kv!()).unwrap();
 
         // all `init_called` should be 1, all `iter_called` 0
         for s in storages.iter() {
@@ -399,7 +399,7 @@ mod tests {
         }
 
         let mut state: TState = IterState::new();
-        obs.observe_iter(&state, &make_kv!()).unwrap();
+        obs.observe_iter(&state, &kv!()).unwrap();
 
         assert_eq!(storages[0].lock().unwrap().init_called, 1);
         assert_eq!(storages[0].lock().unwrap().iter_called, 0);
@@ -411,7 +411,7 @@ mod tests {
         assert_eq!(storages[3].lock().unwrap().iter_called, 1);
 
         state.increment_iter();
-        obs.observe_iter(&state, &make_kv!()).unwrap();
+        obs.observe_iter(&state, &kv!()).unwrap();
 
         assert_eq!(storages[0].lock().unwrap().init_called, 1);
         assert_eq!(storages[0].lock().unwrap().iter_called, 0);
@@ -424,7 +424,7 @@ mod tests {
 
         state.increment_iter();
         state.increment_iter();
-        obs.observe_iter(&state, &make_kv!()).unwrap();
+        obs.observe_iter(&state, &kv!()).unwrap();
 
         assert_eq!(storages[0].lock().unwrap().init_called, 1);
         assert_eq!(storages[0].lock().unwrap().iter_called, 0);
@@ -438,7 +438,7 @@ mod tests {
         state.increment_iter();
         // "new best found"
         state.last_best_iter = state.iter;
-        obs.observe_iter(&state, &make_kv!()).unwrap();
+        obs.observe_iter(&state, &kv!()).unwrap();
 
         assert_eq!(storages[0].lock().unwrap().init_called, 1);
         assert_eq!(storages[0].lock().unwrap().iter_called, 0);

--- a/argmin/src/core/observers/slog_logger.rs
+++ b/argmin/src/core/observers/slog_logger.rs
@@ -146,8 +146,8 @@ impl SlogLogger {
 
 impl slog::KV for KV {
     fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
-        for idx in self.kv.iter().rev() {
-            serializer.emit_str(Key::from(idx.0), &idx.1.to_string())?;
+        for idx in self.kv.iter() {
+            serializer.emit_str(Key::from(*idx.0), &idx.1.to_string())?;
         }
         Ok(())
     }

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -158,7 +158,7 @@ where
 
         Ok((
             state.param(new_param).cost(norm),
-            Some(make_kv!("alpha" => alpha; "beta" => beta;)),
+            Some(kv!("alpha" => alpha; "beta" => beta;)),
         ))
     }
 }

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -452,11 +452,9 @@ mod tests {
         assert!(kv.is_none());
         let (mut state, kv) = nlcg.next_iter(&mut problem, state).unwrap();
         state.update();
-        let kv2 = make_kv!("beta" => 0; "restart_iter" => false; "restart_orthogonality" => false;);
-        for ((k1, v1), (k2, v2)) in kv.unwrap().kv.iter().zip(kv2.kv.iter()) {
-            assert_eq!(k1, k2);
-            assert_eq!(format!("{}", v1), format!("{}", v2));
-        }
+        let kv2 =
+            make_kv!("beta" => 0.0; "restart_iter" => false; "restart_orthogonality" => false;);
+        assert_eq!(kv.unwrap(), kv2);
         assert_relative_eq!(
             state.param.as_ref().unwrap()[0],
             1.0f64,

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -224,7 +224,7 @@ where
 
         Ok((
             state.param(xk1).cost(cost).gradient(new_grad),
-            Some(make_kv!("beta" => self.beta;
+            Some(kv!("beta" => self.beta;
              "restart_iter" => restart_iter;
              "restart_orthogonality" => restart_orthogonality;
             )),
@@ -452,8 +452,7 @@ mod tests {
         assert!(kv.is_none());
         let (mut state, kv) = nlcg.next_iter(&mut problem, state).unwrap();
         state.update();
-        let kv2 =
-            make_kv!("beta" => 0.0; "restart_iter" => false; "restart_orthogonality" => false;);
+        let kv2 = kv!("beta" => 0.0; "restart_iter" => false; "restart_orthogonality" => false;);
         assert_eq!(kv.unwrap(), kv2);
         assert_relative_eq!(
             state.param.as_ref().unwrap()[0],

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -727,7 +727,10 @@ mod tests {
 
         let (state, kv) = nm.next_iter(&mut problem, state).unwrap();
 
-        assert_eq!(format!("{}", kv.unwrap().kv[0].1), "Reflection");
+        assert_eq!(
+            format!("{}", kv.unwrap().get("action").unwrap()),
+            "Reflection"
+        );
 
         let param = state.get_param().unwrap();
 
@@ -767,7 +770,10 @@ mod tests {
 
         let (state, kv) = nm.next_iter(&mut problem, state).unwrap();
 
-        assert_eq!(format!("{}", kv.unwrap().kv[0].1), "Expansion");
+        assert_eq!(
+            format!("{}", kv.unwrap().get("action").unwrap()),
+            "Expansion"
+        );
 
         let param = state.get_param().unwrap();
 
@@ -800,7 +806,10 @@ mod tests {
 
         let (state, kv) = nm.next_iter(&mut problem, state).unwrap();
 
-        assert_eq!(format!("{}", kv.unwrap().kv[0].1), "ContractionOutside");
+        assert_eq!(
+            format!("{}", kv.unwrap().get("action").unwrap()),
+            "ContractionOutside"
+        );
 
         let param = state.get_param().unwrap();
 
@@ -833,7 +842,10 @@ mod tests {
 
         let (state, kv) = nm.next_iter(&mut problem, state).unwrap();
 
-        assert_eq!(format!("{}", kv.unwrap().kv[0].1), "ContractionInside");
+        assert_eq!(
+            format!("{}", kv.unwrap().get("action").unwrap()),
+            "ContractionInside"
+        );
 
         let param = state.get_param().unwrap();
 

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -409,7 +409,7 @@ where
 
         Ok((
             state.param(self.params[0].0.clone()).cost(self.params[0].1),
-            Some(make_kv!("action" => action;)),
+            Some(make_kv!("action" => format!("{}", action);)),
         ))
     }
 

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -409,7 +409,7 @@ where
 
         Ok((
             state.param(self.params[0].0.clone()).cost(self.params[0].1),
-            Some(make_kv!("action" => format!("{}", action);)),
+            Some(kv!("action" => format!("{}", action);)),
         ))
     }
 

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -487,7 +487,7 @@ where
 
         Ok((
             state.param(xk1).cost(next_cost).gradient(grad),
-            Some(make_kv!("gamma" => gamma;)),
+            Some(kv!("gamma" => gamma;)),
         ))
     }
 

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -286,7 +286,7 @@ where
                 .cost(next_cost)
                 .gradient(grad)
                 .inv_hessian(inv_hessian),
-            Some(make_kv!["denominator" => b; "hessian_update" => hessian_update;]),
+            Some(kv!["denominator" => b; "hessian_update" => hessian_update;]),
         ))
     }
 

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -343,7 +343,7 @@ where
 
         Ok((
             state.param(xk1).cost(fk1).gradient(dfk1).hessian(hessian),
-            Some(make_kv!["ared" => ared;
+            Some(kv!["ared" => ared;
                          "pred" => pred;
                          "ap" => ap;
                          "radius" => self.radius;

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -870,15 +870,16 @@ mod tests {
             "reanneal_best" => reanneal_best;
         );
 
-        kv.unwrap()
-            .kv
-            .iter()
-            .zip(kv_expected.kv.iter())
-            .map(|(kv1, kv2)| {
-                assert_eq!(kv1.0, kv2.0);
-                assert_eq!(format!("{}", kv1.1), format!("{}", kv2.1));
-            })
-            .count();
+        assert_eq!(kv.unwrap(), kv_expected);
+        // kv.unwrap()
+        //     .kv
+        //     .iter()
+        //     .zip(kv_expected.kv.iter())
+        //     .map(|(kv1, kv2)| {
+        //         assert_eq!(kv1.0, kv2.0);
+        //         assert_eq!(format!("{}", kv1.1), format!("{}", kv2.1));
+        //     })
+        //     .count();
 
         let s_param = state_out.take_param().unwrap();
 

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -470,7 +470,7 @@ where
 
         Ok((
             state.param(param).cost(cost),
-            Some(make_kv!(
+            Some(kv!(
                 "initial_temperature" => self.init_temp;
                 "stall_iter_accepted_limit" => self.stall_iter_accepted_limit;
                 "stall_iter_best_limit" => self.stall_iter_best_limit;
@@ -541,7 +541,7 @@ where
             } else {
                 state.param(prev_param).cost(prev_cost)
             },
-            Some(make_kv!(
+            Some(kv!(
                 "t" => self.cur_temp;
                 "new_be" => new_best_found;
                 "acc" => accepted;
@@ -861,7 +861,7 @@ mod tests {
         let problem = TestProblem::new();
         let (mut state_out, kv) = sa.init(&mut Problem::new(problem), state).unwrap();
 
-        let kv_expected = make_kv!(
+        let kv_expected = kv!(
             "initial_temperature" => 100.0f64;
             "stall_iter_accepted_limit" => stall_iter_accepted_limit;
             "stall_iter_best_limit" => stall_iter_best_limit;
@@ -871,15 +871,6 @@ mod tests {
         );
 
         assert_eq!(kv.unwrap(), kv_expected);
-        // kv.unwrap()
-        //     .kv
-        //     .iter()
-        //     .zip(kv_expected.kv.iter())
-        //     .map(|(kv1, kv2)| {
-        //         assert_eq!(kv1.0, kv2.0);
-        //         assert_eq!(format!("{}", kv1.1), format!("{}", kv2.1));
-        //     })
-        //     .count();
 
         let s_param = state_out.take_param().unwrap();
 

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -296,7 +296,7 @@ where
                     .gradient(grad)
                     .hessian(hessian)
             },
-            Some(make_kv!("radius" => cur_radius;)),
+            Some(kv!("radius" => cur_radius;)),
         ))
     }
 


### PR DESCRIPTION
This allows one to implement more powerful observers because the observed values are now directly available instead of just as a type which can be `Display`ed.

Internally `KV` is now a `HashMap` instead of a `Vec`. Furthermore a `get` method was added to be able to retrieve a value by key. 

The macro `make_kv!` was renamed to `kv!`.

A `keys` method was added to `KV` which returns the contained keys and their `KVType` kind.