### PR TITLE
Check if the target cost is reached using the best cost

### DIFF
--- a/argmin/src/core/solver.rs
+++ b/argmin/src/core/solver.rs
@@ -92,7 +92,7 @@ pub trait Solver<O, I: State> {
     ///
     /// 1) algorithm was terminated somewhere else in the Executor
     /// 2) iteration count exceeds maximum number of iterations
-    /// 3) cost is lower than or equal to the target cost
+    /// 3) best cost is lower than or equal to the target cost
     ///
     /// This can be overwritten; however it is not advised. It is recommended to implement other
     /// stopping criteria via ([`terminate`](`Solver::terminate`).
@@ -104,7 +104,7 @@ pub trait Solver<O, I: State> {
         if state.get_iter() >= state.get_max_iters() {
             return TerminationReason::MaxItersReached;
         }
-        if state.get_cost() <= state.get_target_cost() {
+        if state.get_best_cost() <= state.get_target_cost() {
             return TerminationReason::TargetCostReached;
         }
         TerminationReason::NotTerminated

--- a/media/book/src/implementing_solver.md
+++ b/media/book/src/implementing_solver.md
@@ -16,7 +16,7 @@ The `Solver` trait consists of several methods; however, not all of them need to
 * `init(...)`: Run before the the actual iterations and initializes the solver. Does nothing by default.
 * `next_iter(...)`: One iteration of the solver. Will be executed by the `Executor` until a stopping critereon is met.
 * `terminate(...)`: Solver specific stopping criteria. This method is run after every iteration. Note that one can also terminate from within `next_iter` if necessary.
-* `terminate_internal(...)`: By default calls `terminate` and in addition checks if the maximum number of iterations was reached or if the current cost function value is below the target cost function value. Should only be overwritten if absolutely necessary. 
+* `terminate_internal(...)`: By default calls `terminate` and in addition checks if the maximum number of iterations was reached or if the cost function best value is below the target cost value. Should only be overwritten if absolutely necessary. 
 
 Both `init` and `next_iter` have access to the optimization problem (`problem`) as well as the internal state (`state`).
 The methods `terminate` and `terminate_interal` only have access to `state`. 

--- a/media/book/src/implementing_solver.md
+++ b/media/book/src/implementing_solver.md
@@ -16,7 +16,7 @@ The `Solver` trait consists of several methods; however, not all of them need to
 * `init(...)`: Run before the the actual iterations and initializes the solver. Does nothing by default.
 * `next_iter(...)`: One iteration of the solver. Will be executed by the `Executor` until a stopping critereon is met.
 * `terminate(...)`: Solver specific stopping criteria. This method is run after every iteration. Note that one can also terminate from within `next_iter` if necessary.
-* `terminate_internal(...)`: By default calls `terminate` and in addition checks if the maximum number of iterations was reached or if the cost function best value is below the target cost value. Should only be overwritten if absolutely necessary. 
+* `terminate_internal(...)`: By default calls `terminate` and in addition checks if the maximum number of iterations was reached or if the best cost function value is below the target cost value. Should only be overwritten if absolutely necessary. 
 
 Both `init` and `next_iter` have access to the optimization problem (`problem`) as well as the internal state (`state`).
 The methods `terminate` and `terminate_interal` only have access to `state`. 


### PR DESCRIPTION
This PR changes slightly `terminate_internal` to use the best cost to check if the target cost is reached
instead of the current cost.

In the context of constrained optimization, the cost (the value of the cost function at the current
`param` vector) may be lower than the target cost but a constraint at this `param` vector may be violated.
In this case the target cost should not be declared to be reached.
The fix consists in using the best cost which is expected to be updated only if constraints are not violated.
