### PR TITLE
Implement KeyboardInterrupt termination

### DIFF
--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -267,11 +267,6 @@ where
             state = state.terminate_with(TerminationReason::KeyboardInterrupt);
         }
 
-        // In case it stopped prematurely and `termination_reason` is still `NotTerminated`,
-        // someone must have pulled the handbrake
-        if state.get_iter() < state.get_max_iters() && !state.terminated() {
-            state = state.terminate_with(TerminationReason::Aborted);
-        }
         Ok(OptimizationResult::new(self.problem, self.solver, state))
     }
 

--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -259,7 +259,15 @@ where
             }
         }
 
-        // in case it stopped prematurely and `termination_reason` is still `NotTerminated`,
+        if running.load(Ordering::SeqCst) {
+            // Solver execution has finished
+            running.store(false, Ordering::SeqCst);
+        } else {
+            // Solver execution has been interrupted manually
+            state = state.terminate_with(TerminationReason::KeyboardInterrupt);
+        }
+
+        // In case it stopped prematurely and `termination_reason` is still `NotTerminated`,
         // someone must have pulled the handbrake
         if state.get_iter() < state.get_max_iters() && !state.terminated() {
             state = state.terminate_with(TerminationReason::Aborted);

--- a/argmin/src/core/termination.rs
+++ b/argmin/src/core/termination.rs
@@ -30,6 +30,8 @@ pub enum TerminationReason {
     LineSearchConditionMet,
     /// Reached target tolerance
     TargetToleranceReached,
+    /// Algorithm manually interrupted with Ctrl+C
+    KeyboardInterrupt,
     /// Algorithm aborted
     Aborted,
 }
@@ -50,6 +52,7 @@ impl TerminationReason {
     /// assert!(TerminationReason::BestStallIterExceeded.terminated());
     /// assert!(TerminationReason::LineSearchConditionMet.terminated());
     /// assert!(TerminationReason::TargetToleranceReached.terminated());
+    /// assert!(TerminationReason::KeyboardInterrupt.terminated());
     /// assert!(TerminationReason::Aborted.terminated());
     /// assert!(!TerminationReason::NotTerminated.terminated());
     /// ```
@@ -97,6 +100,10 @@ impl TerminationReason {
     ///     "Target tolerance reached"
     /// );
     /// assert_eq!(
+    ///     TerminationReason::KeyboardInterrupt.text(),
+    ///     "Keyboard interrupt"
+    /// );
+    /// assert_eq!(
     ///     TerminationReason::Aborted.text(),
     ///     "Optimization aborted"
     /// );
@@ -116,6 +123,7 @@ impl TerminationReason {
             TerminationReason::BestStallIterExceeded => "Best stall iterations exceeded",
             TerminationReason::LineSearchConditionMet => "Line search condition met",
             TerminationReason::TargetToleranceReached => "Target tolerance reached",
+            TerminationReason::KeyboardInterrupt => "Keyboard interrupt",
             TerminationReason::Aborted => "Optimization aborted",
         }
     }


### PR DESCRIPTION
Following discussion [here](https://github.com/argmin-rs/argmin/issues/305#issuecomment-1369137557), this PR implements the `KeyboardInterrupt` termination handling.

I've tested that it works properly with my solver.

As a follow-up discussion, I do not need the `finalize` method as initially I introduced it as a way to have a hook just at the end of the loop to check the `NotTerminated` and max iter not reached to detect keyboard interrupt like the existing check at the end of the `run` function.      

Now that `KeyboardInterrupt` is handled I think this last check to set `Aborted` is useless as well, as the state is always terminated, if you're ok I remove it. 