### PR TITLE
Add TerminationStatus

### DIFF
--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -54,4 +54,4 @@ pub use result::OptimizationResult;
 pub use serialization::{DeserializeOwnedAlias, SerializeAlias};
 pub use solver::Solver;
 pub use state::{IterState, LinearProgramState, PopulationState, State};
-pub use termination::TerminationReason;
+pub use termination::{TerminationReason, TerminationStatus};

--- a/argmin/src/core/result.rs
+++ b/argmin/src/core/result.rs
@@ -140,7 +140,7 @@ where
         writeln!(
             f,
             "    termination:   {}",
-            self.state.get_termination_reason()
+            self.state.get_termination_status()
         )?;
         if let Some(time) = self.state.get_time() {
             writeln!(f, "    time:          {time:?}")?;

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -1037,7 +1037,7 @@ where
         self.best_param.as_ref()
     }
 
-    /// Sets the termination status (default: [`TerminationStatus::NotTerminated`])
+    /// Sets the termination status to [`Terminated`](`TerminationStatus::Terminated`) with the given reason
     ///
     /// # Example
     ///

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -1160,7 +1160,7 @@ where
         self.max_iters
     }
 
-    /// Returns the termination reason.
+    /// Returns the termination status.
     ///
     /// # Example
     ///
@@ -1172,6 +1172,23 @@ where
     /// ```
     fn get_termination_status(&self) -> TerminationStatus {
         self.termination_status
+    }
+
+    /// Returns the termination reason if terminated, otherwise None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
+    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let termination_reason = state.get_termination_reason();
+    /// # assert_eq!(termination_reason, None);
+    /// ```
+    fn get_termination_reason(&self) -> Option<TerminationReason> {
+        match self.termination_status {
+            TerminationStatus::Terminated(reason) => Some(reason),
+            TerminationStatus::NotTerminated => None,
+        }
     }
 
     /// Returns the time elapsed since the start of the optimization.

--- a/argmin/src/core/state/linearprogramstate.rs
+++ b/argmin/src/core/state/linearprogramstate.rs
@@ -314,7 +314,7 @@ where
         self.best_param.as_ref()
     }
 
-    /// Sets the termination reason (default: [`TerminationReason::NotTerminated`])
+    /// Sets the termination status to [`Terminated`](`TerminationStatus::Terminated`) with the given reason
     ///
     /// # Example
     ///

--- a/argmin/src/core/state/linearprogramstate.rs
+++ b/argmin/src/core/state/linearprogramstate.rs
@@ -451,6 +451,23 @@ where
         self.termination_status
     }
 
+    /// Returns the termination reason if terminated, otherwise None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
+    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let termination_reason = state.get_termination_reason();
+    /// # assert_eq!(termination_reason, None);
+    /// ```
+    fn get_termination_reason(&self) -> Option<TerminationReason> {
+        match self.termination_status {
+            TerminationStatus::Terminated(reason) => Some(reason),
+            TerminationStatus::NotTerminated => None,
+        }
+    }
+
     /// Returns the time elapsed since the start of the optimization.
     ///
     /// # Example

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -103,7 +103,7 @@ pub trait State {
     /// far.
     fn is_best(&self) -> bool;
 
-    /// Set termination status to terminated with given reason
+    /// Sets the termination status to [`Terminated`](`TerminationStatus::Terminated`) with the given reason
     #[must_use]
     fn terminate_with(self, termination_reason: TerminationReason) -> Self;
 

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -13,7 +13,7 @@ pub use iterstate::IterState;
 pub use linearprogramstate::LinearProgramState;
 pub use populationstate::PopulationState;
 
-use crate::core::{ArgminFloat, Problem, TerminationReason};
+use crate::core::{ArgminFloat, Problem, TerminationReason, TerminationStatus};
 use std::collections::HashMap;
 
 /// Minimal interface which struct used for managing state in solvers have to implement.
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 /// * the current number of iterations
 /// * how often each function of the problem has been called
 /// * the time required since the beginning of the optimization until the current point in time
-/// * the reason why it terminated ([`TerminationReason`])
+/// * the status of optimization execution ([`TerminationStatus`])
 ///
 /// Since the state in general changes for each iteration, "current" refers to the current
 /// iteration.
@@ -103,15 +103,18 @@ pub trait State {
     /// far.
     fn is_best(&self) -> bool;
 
-    /// Set termination reason
+    /// Set termination status to terminated with given reason
     #[must_use]
     fn terminate_with(self, termination_reason: TerminationReason) -> Self;
 
     /// Returns termination reason. Returns [`TerminationReason::NotTerminated`] if not terminated.
-    fn get_termination_reason(&self) -> TerminationReason;
+    fn get_termination_status(&self) -> TerminationStatus;
 
     /// Return whether the algorithm has terminated or not
     fn terminated(&self) -> bool {
-        self.get_termination_reason().terminated()
+        matches!(
+            self.get_termination_status(),
+            TerminationStatus::Terminated(_)
+        )
     }
 }

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -107,8 +107,11 @@ pub trait State {
     #[must_use]
     fn terminate_with(self, termination_reason: TerminationReason) -> Self;
 
-    /// Returns termination reason. Returns [`TerminationReason::NotTerminated`] if not terminated.
+    /// Returns termination status.
     fn get_termination_status(&self) -> TerminationStatus;
+
+    /// Returns the termination reason if terminated, otherwise None.
+    fn get_termination_reason(&self) -> Option<TerminationReason>;
 
     /// Return whether the algorithm has terminated or not
     fn terminated(&self) -> bool {

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -593,7 +593,7 @@ where
         self.best_individual.as_ref()
     }
 
-    /// Sets the termination status to terminated with the given reason
+    /// Sets the termination status to [`Terminated`](`TerminationStatus::Terminated`) with the given reason
     ///
     /// # Example
     ///

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -730,6 +730,23 @@ where
         self.termination_status
     }
 
+    /// Returns the termination reason if terminated, otherwise None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
+    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let termination_reason = state.get_termination_reason();
+    /// # assert_eq!(termination_reason, None);
+    /// ```
+    fn get_termination_reason(&self) -> Option<TerminationReason> {
+        match self.termination_status {
+            TerminationStatus::Terminated(reason) => Some(reason),
+            TerminationStatus::NotTerminated => None,
+        }
+    }
+
     /// Returns the time elapsed since the start of the optimization.
     ///
     /// # Example

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::core::{ArgminFloat, Problem, State, TerminationReason};
+use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationStatus};
 use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 /// * maximum number of iterations that will be executed
 /// * problem function evaluation counts
 /// * elapsed time
-/// * termination reason (set to [`TerminationReason::NotTerminated`] if not terminated yet)
+/// * termination status
 #[derive(Clone, Default, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct PopulationState<P, F> {
@@ -61,8 +61,8 @@ pub struct PopulationState<P, F> {
     pub counts: HashMap<String, u64>,
     /// Time required so far
     pub time: Option<instant::Duration>,
-    /// Reason of termination
-    pub termination_reason: TerminationReason,
+    /// Status of optimization execution
+    pub termination_status: TerminationStatus,
 }
 
 impl<P, F> PopulationState<P, F>
@@ -449,7 +449,7 @@ where
     /// ```
     /// # extern crate instant;
     /// # use instant;
-    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationReason};
+    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationStatus};
     /// let state: PopulationState<Vec<f64>, f64> = PopulationState::new();
     /// # assert!(state.individual.is_none());
     /// # assert!(state.prev_individual.is_none());
@@ -466,7 +466,7 @@ where
     /// # assert_eq!(state.max_iters, std::u64::MAX);
     /// # assert_eq!(state.counts.len(), 0);
     /// # assert_eq!(state.time.unwrap(), instant::Duration::new(0, 0));
-    /// # assert_eq!(state.termination_reason, TerminationReason::NotTerminated);
+    /// # assert_eq!(state.termination_status, TerminationStatus::NotTerminated);
     /// ```
     fn new() -> Self {
         PopulationState {
@@ -485,7 +485,7 @@ where
             max_iters: std::u64::MAX,
             counts: HashMap::new(),
             time: Some(instant::Duration::new(0, 0)),
-            termination_reason: TerminationReason::NotTerminated,
+            termination_status: TerminationStatus::NotTerminated,
         }
     }
 
@@ -593,19 +593,19 @@ where
         self.best_individual.as_ref()
     }
 
-    /// Sets the termination reason (default: [`TerminationReason::NotTerminated`])
+    /// Sets the termination status to terminated with the given reason
     ///
     /// # Example
     ///
     /// ```
-    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationReason};
+    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationReason, TerminationStatus};
     /// # let mut state: PopulationState<Vec<f64>, f64> = PopulationState::new();
-    /// # assert_eq!(state.termination_reason, TerminationReason::NotTerminated);
+    /// # assert_eq!(state.termination_status, TerminationStatus::NotTerminated);
     /// let state = state.terminate_with(TerminationReason::MaxItersReached);
-    /// # assert_eq!(state.termination_reason, TerminationReason::MaxItersReached);
+    /// # assert_eq!(state.termination_status, TerminationStatus::Terminated(TerminationReason::MaxItersReached));
     /// ```
     fn terminate_with(mut self, reason: TerminationReason) -> Self {
-        self.termination_reason = reason;
+        self.termination_status = TerminationStatus::Terminated(reason);
         self
     }
 
@@ -721,13 +721,13 @@ where
     /// # Example
     ///
     /// ```
-    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationReason};
+    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationStatus};
     /// # let mut state: PopulationState<Vec<f64>, f64> = PopulationState::new();
-    /// let termination_reason = state.get_termination_reason();
-    /// # assert_eq!(termination_reason, TerminationReason::NotTerminated);
+    /// let termination_status = state.get_termination_status();
+    /// # assert_eq!(termination_status, TerminationStatus::NotTerminated);
     /// ```
-    fn get_termination_reason(&self) -> TerminationReason {
-        self.termination_reason
+    fn get_termination_status(&self) -> TerminationStatus {
+        self.termination_status
     }
 
     /// Returns the time elapsed since the start of the optimization.

--- a/argmin/src/solver/brent/brentopt.rs
+++ b/argmin/src/solver/brent/brentopt.rs
@@ -209,7 +209,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::Executor;
+    use crate::core::{Executor, TerminationStatus};
     use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
@@ -234,8 +234,8 @@ mod tests {
             .run()
             .unwrap();
         assert_eq!(
-            res.state().termination_reason,
-            TerminationReason::TargetPrecisionReached
+            res.state().termination_status,
+            TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached)
         );
         assert_relative_eq!(
             res.state().param.unwrap(),

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -8,7 +8,7 @@
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     Jacobian, LineSearch, Operator, OptimizationResult, Problem, SerializeAlias, Solver,
-    TerminationReason, KV,
+    TerminationReason, TerminationStatus, KV,
 };
 use argmin_math::{ArgminDot, ArgminInv, ArgminL2Norm, ArgminMul, ArgminTranspose};
 #[cfg(feature = "serde1")]
@@ -166,11 +166,11 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, J, (), F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, J, (), F>) -> TerminationStatus {
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol {
-            return TerminationReason::NoChangeInCost;
+            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, Error, IterState, Jacobian, Operator, Problem, Solver, State, TerminationReason,
-    KV,
+    TerminationStatus, KV,
 };
 use argmin_math::{ArgminDot, ArgminInv, ArgminL2Norm, ArgminMul, ArgminSub, ArgminTranspose};
 #[cfg(feature = "serde1")]
@@ -151,11 +151,11 @@ where
         Ok((state.param(new_param).cost(residuals.l2_norm()), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, (), J, (), F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, (), J, (), F>) -> TerminationStatus {
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol {
-            return TerminationReason::NoChangeInCost;
+            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -17,7 +17,8 @@
 //! <https://en.wikipedia.org/wiki/Golden-section_search>
 
 use crate::core::{
-    ArgminFloat, CostFunction, Error, IterState, Problem, Solver, TerminationReason, KV,
+    ArgminFloat, CostFunction, Error, IterState, Problem, Solver, TerminationReason,
+    TerminationStatus, KV,
 };
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -202,11 +203,11 @@ where
         }
     }
 
-    fn terminate(&mut self, _state: &IterState<F, (), (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, _state: &IterState<F, (), (), (), F>) -> TerminationStatus {
         if self.tolerance * (self.x1.abs() + self.x2.abs()) >= (self.x3 - self.x0).abs() {
-            return TerminationReason::TargetToleranceReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetToleranceReached);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
-    Solver, State, TerminationReason, KV,
+    Solver, State, TerminationReason, TerminationStatus, KV,
 };
 use crate::solver::linesearch::condition::*;
 use argmin_math::ArgminScaledAdd;
@@ -233,7 +233,7 @@ where
         Ok((state, None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationStatus {
         if self.condition.evaluate_condition(
             state.cost,
             state.get_gradient(),
@@ -242,9 +242,9 @@ where
             self.search_direction.as_ref().unwrap(),
             self.alpha,
         ) {
-            TerminationReason::LineSearchConditionMet
+            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
         } else {
-            TerminationReason::NotTerminated
+            TerminationStatus::NotTerminated
         }
     }
 }
@@ -595,7 +595,7 @@ mod tests {
                 &mut ls,
                 &IterState::<Vec<f64>, Vec<f64>, (), (), f64>::new().param(init_param)
             ),
-            TerminationReason::LineSearchConditionMet
+            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
         );
 
         ls.init_cost = 0.0f64;
@@ -609,7 +609,7 @@ mod tests {
                 &mut ls,
                 &IterState::<Vec<f64>, Vec<f64>, (), (), f64>::new().param(init_param)
             ),
-            TerminationReason::NotTerminated
+            TerminationStatus::NotTerminated
         );
     }
 
@@ -654,8 +654,8 @@ mod tests {
         assert_eq!(func_counts["cost_count"], 2);
         assert_eq!(func_counts["gradient_count"], 1);
         assert_eq!(
-            data.termination_reason,
-            TerminationReason::LineSearchConditionMet
+            data.termination_status,
+            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
         );
 
         assert!(data.get_gradient().is_none());
@@ -703,8 +703,8 @@ mod tests {
         assert_eq!(func_counts["cost_count"], 3);
         assert_eq!(func_counts["gradient_count"], 1);
         assert_eq!(
-            data.termination_reason,
-            TerminationReason::LineSearchConditionMet
+            data.termination_status,
+            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
         );
         assert!(data.get_gradient().is_none());
     }

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
-    Solver, TerminationReason, KV,
+    Solver, TerminationReason, TerminationStatus, KV,
 };
 use argmin_math::{ArgminDot, ArgminScaledAdd};
 #[cfg(feature = "serde1")]
@@ -620,19 +620,19 @@ where
         Ok((state.param(new_param).cost(self.best_f), None))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, G, (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, _state: &IterState<P, G, (), (), F>) -> TerminationStatus {
         if self.best_f - self.finit <= self.delta * self.best_x * self.dginit
             && self.best_g >= self.sigma * self.dginit
         {
-            return TerminationReason::LineSearchConditionMet;
+            return TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet);
         }
         if (float!(2.0) * self.delta - float!(1.0)) * self.dginit >= self.best_g
             && self.best_g >= self.sigma * self.dginit
             && self.best_f <= self.finit + self.epsilon_k
         {
-            return TerminationReason::LineSearchConditionMet;
+            return TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
-    TerminationReason, KV,
+    TerminationReason, TerminationStatus, KV,
 };
 use argmin_math::{ArgminAdd, ArgminMul, ArgminSub};
 #[cfg(feature = "serde1")]
@@ -413,7 +413,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
         let n = float!(self.params.len() as f64);
         let c0: F = self.params.iter().map(|(_, c)| *c).sum::<F>() / n;
         let s: F = (float!(1.0) / (n - float!(1.0))
@@ -424,9 +424,9 @@ where
                 .sum::<F>())
         .sqrt();
         if s < self.sd_tolerance {
-            return TerminationReason::TargetToleranceReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetToleranceReached);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -7,7 +7,8 @@
 
 use crate::core::{
     ArgminFloat, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian, IterState, LineSearch,
-    Operator, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason, KV,
+    Operator, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason,
+    TerminationStatus, KV,
 };
 use crate::solver::conjugategradient::ConjugateGradient;
 use argmin_math::{
@@ -208,11 +209,11 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if (state.get_cost() - state.get_prev_cost()).abs() < self.tol {
-            TerminationReason::TargetToleranceReached
+            TerminationStatus::Terminated(TerminationReason::TargetToleranceReached)
         } else {
-            TerminationReason::NotTerminated
+            TerminationStatus::NotTerminated
         }
     }
 }

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -7,7 +7,8 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
-    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
+    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    TerminationStatus, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminEye, ArgminL2Norm, ArgminMul, ArgminSub, ArgminTranspose,
@@ -293,14 +294,14 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
         if (state.get_prev_cost() - state.cost).abs() < self.tol_cost {
-            return TerminationReason::NoChangeInCost;
+            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -7,7 +7,8 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
-    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
+    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    TerminationStatus, KV,
 };
 use argmin_math::{ArgminAdd, ArgminDot, ArgminL2Norm, ArgminMul, ArgminSub};
 #[cfg(feature = "serde1")]
@@ -243,11 +244,11 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -7,7 +7,8 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
-    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason, KV,
+    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason,
+    TerminationStatus, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminL1Norm, ArgminL2Norm, ArgminMinMax, ArgminMul, ArgminSignum,
@@ -491,14 +492,14 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol_cost {
-            return TerminationReason::NoChangeInCost;
+            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -7,7 +7,8 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
-    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason, KV,
+    LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    TerminationStatus, KV,
 };
 use argmin_math::{ArgminAdd, ArgminDot, ArgminL2Norm, ArgminMul, ArgminSub};
 #[cfg(feature = "serde1")]
@@ -290,14 +291,14 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
         if (state.get_prev_cost() - state.cost).abs() < self.tol_cost {
-            return TerminationReason::NoChangeInCost;
+            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -8,7 +8,7 @@
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian,
     IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
-    TrustRegionRadius, KV,
+    TerminationStatus, TrustRegionRadius, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminL2Norm, ArgminMul, ArgminSub, ArgminWeightedDot, ArgminZeroLike,
@@ -351,11 +351,11 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), B, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), B, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
-    TerminationReason, KV,
+    TerminationReason, TerminationStatus, KV,
 };
 use rand::prelude::*;
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -557,14 +557,14 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationReason {
+    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
         if self.stall_iter_accepted > self.stall_iter_accepted_limit {
-            return TerminationReason::AcceptedStallIterExceeded;
+            return TerminationStatus::Terminated(TerminationReason::AcceptedStallIterExceeded);
         }
         if self.stall_iter_best > self.stall_iter_best_limit {
-            return TerminationReason::BestStallIterExceeded;
+            return TerminationStatus::Terminated(TerminationReason::BestStallIterExceeded);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, State, TerminationReason,
-    TrustRegionRadius, KV,
+    TerminationStatus, TrustRegionRadius, KV,
 };
 use argmin_math::{ArgminL2Norm, ArgminMul, ArgminWeightedDot};
 #[cfg(feature = "serde1")]
@@ -97,12 +97,12 @@ where
         Ok((state.param(new_param), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         // Not an iterative algorithm
         if state.get_iter() >= 1 {
-            TerminationReason::MaxItersReached
+            TerminationStatus::Terminated(TerminationReason::MaxItersReached)
         } else {
-            TerminationReason::NotTerminated
+            TerminationStatus::NotTerminated
         }
     }
 }

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, State, TerminationReason,
-    TrustRegionRadius, KV,
+    TerminationStatus, TrustRegionRadius, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminInv, ArgminL2Norm, ArgminMul, ArgminSub, ArgminWeightedDot,
@@ -136,11 +136,11 @@ where
         Ok((state.param(pstar).gradient(g).hessian(h), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationStatus {
         if state.get_iter() >= 1 {
-            TerminationReason::MaxItersReached
+            TerminationStatus::Terminated(TerminationReason::MaxItersReached)
         } else {
-            TerminationReason::NotTerminated
+            TerminationStatus::NotTerminated
         }
     }
 }

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, Error, IterState, Problem, SerializeAlias, Solver, State, TerminationReason,
-    TrustRegionRadius, KV,
+    TerminationStatus, TrustRegionRadius, KV,
 };
 use argmin_math::{
     ArgminAdd, ArgminDot, ArgminL2Norm, ArgminMul, ArgminWeightedDot, ArgminZeroLike,
@@ -298,14 +298,14 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationReason {
+    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationStatus {
         if self.r_0_norm < self.epsilon {
-            return TerminationReason::TargetPrecisionReached;
+            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
         }
         if state.get_iter() >= self.max_iters {
-            return TerminationReason::MaxItersReached;
+            return TerminationStatus::Terminated(TerminationReason::MaxItersReached);
         }
-        TerminationReason::NotTerminated
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -7,7 +7,7 @@
 
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian,
-    IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
+    IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationStatus,
     TrustRegionRadius, KV,
 };
 use crate::solver::trustregion::reduction_ratio;
@@ -300,8 +300,8 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, G, (), H, F>) -> TerminationReason {
-        TerminationReason::NotTerminated
+    fn terminate(&mut self, _state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+        TerminationStatus::NotTerminated
     }
 }
 

--- a/media/book/src/running_solver.md
+++ b/media/book/src/running_solver.md
@@ -99,7 +99,10 @@ let best = res.state().get_best_param().unwrap();
 // Cost function value associated with best parameter vector
 let best_cost = res.state().get_best_cost();
 
-// Reason why the optimizer terminated
+// Check the execution status
+let termination_status = res.state().get_termination_status();
+
+// Optionally, check why the optimizer terminated (if status is terminated) 
 let termination_reason = res.state().get_termination_reason();
 
 // Time needed for optimization


### PR DESCRIPTION
Following the discussion [here](https://github.com/argmin-rs/argmin/issues/305#issuecomment-1369137557), this PR implements `TerminationStatus`.

API changes:
* Added `TerminationStatus`
* Removed `NotTerminated` variant from `TerminationReason`
* Added in `State` trait: `get_termination_status()`
* Changed in `State` trait: `get_termination_reason()` returns an `Option<TerminationReason>`