### PR TITLE
New TerminationReason definition

### DIFF
--- a/argmin/src/core/solver.rs
+++ b/argmin/src/core/solver.rs
@@ -99,7 +99,7 @@ pub trait Solver<O, I: State> {
     fn terminate_internal(&mut self, state: &I) -> TerminationStatus {
         let solver_status = self.terminate(state);
         if solver_status.terminated() {
-            return solver_status.clone();
+            return solver_status;
         }
         if state.get_iter() >= state.get_max_iters() {
             return TerminationStatus::Terminated(TerminationReason::MaxItersReached);

--- a/argmin/src/core/solver.rs
+++ b/argmin/src/core/solver.rs
@@ -99,7 +99,7 @@ pub trait Solver<O, I: State> {
     fn terminate_internal(&mut self, state: &I) -> TerminationStatus {
         let solver_status = self.terminate(state);
         if solver_status.terminated() {
-            return solver_status;
+            return solver_status.clone();
         }
         if state.get_iter() >= state.get_max_iters() {
             return TerminationStatus::Terminated(TerminationReason::MaxItersReached);

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -1168,10 +1168,10 @@ where
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationStatus};
     /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
     /// let termination_status = state.get_termination_status();
-    /// # assert_eq!(termination_status, TerminationStatus::NotTerminated);
+    /// # assert_eq!(*termination_status, TerminationStatus::NotTerminated);
     /// ```
-    fn get_termination_status(&self) -> TerminationStatus {
-        self.termination_status
+    fn get_termination_status(&self) -> &TerminationStatus {
+        &self.termination_status
     }
 
     /// Returns the termination reason if terminated, otherwise None.
@@ -1184,8 +1184,8 @@ where
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```
-    fn get_termination_reason(&self) -> Option<TerminationReason> {
-        match self.termination_status {
+    fn get_termination_reason(&self) -> Option<&TerminationReason> {
+        match &self.termination_status {
             TerminationStatus::Terminated(reason) => Some(reason),
             TerminationStatus::NotTerminated => None,
         }

--- a/argmin/src/core/state/linearprogramstate.rs
+++ b/argmin/src/core/state/linearprogramstate.rs
@@ -445,10 +445,10 @@ where
     /// # use argmin::core::{LinearProgramState, State, ArgminFloat, TerminationStatus};
     /// # let mut state: LinearProgramState<Vec<f64>, f64> = LinearProgramState::new();
     /// let termination_status = state.get_termination_status();
-    /// # assert_eq!(termination_status, TerminationStatus::NotTerminated);
+    /// # assert_eq!(*termination_status, TerminationStatus::NotTerminated);
     /// ```
-    fn get_termination_status(&self) -> TerminationStatus {
-        self.termination_status
+    fn get_termination_status(&self) -> &TerminationStatus {
+        &self.termination_status
     }
 
     /// Returns the termination reason if terminated, otherwise None.
@@ -461,8 +461,8 @@ where
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```
-    fn get_termination_reason(&self) -> Option<TerminationReason> {
-        match self.termination_status {
+    fn get_termination_reason(&self) -> Option<&TerminationReason> {
+        match &self.termination_status {
             TerminationStatus::Terminated(reason) => Some(reason),
             TerminationStatus::NotTerminated => None,
         }

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -108,10 +108,10 @@ pub trait State {
     fn terminate_with(self, termination_reason: TerminationReason) -> Self;
 
     /// Returns termination status.
-    fn get_termination_status(&self) -> TerminationStatus;
+    fn get_termination_status(&self) -> &TerminationStatus;
 
     /// Returns the termination reason if terminated, otherwise None.
-    fn get_termination_reason(&self) -> Option<TerminationReason>;
+    fn get_termination_reason(&self) -> Option<&TerminationReason>;
 
     /// Return whether the algorithm has terminated or not
     fn terminated(&self) -> bool {

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -724,10 +724,10 @@ where
     /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationStatus};
     /// # let mut state: PopulationState<Vec<f64>, f64> = PopulationState::new();
     /// let termination_status = state.get_termination_status();
-    /// # assert_eq!(termination_status, TerminationStatus::NotTerminated);
+    /// # assert_eq!(*termination_status, TerminationStatus::NotTerminated);
     /// ```
-    fn get_termination_status(&self) -> TerminationStatus {
-        self.termination_status
+    fn get_termination_status(&self) -> &TerminationStatus {
+        &self.termination_status
     }
 
     /// Returns the termination reason if terminated, otherwise None.
@@ -740,8 +740,8 @@ where
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```
-    fn get_termination_reason(&self) -> Option<TerminationReason> {
-        match self.termination_status {
+    fn get_termination_reason(&self) -> Option<&TerminationReason> {
+        match &self.termination_status {
             TerminationStatus::Terminated(reason) => Some(reason),
             TerminationStatus::NotTerminated => None,
         }

--- a/argmin/src/solver/brent/brentopt.rs
+++ b/argmin/src/solver/brent/brentopt.rs
@@ -133,7 +133,7 @@ where
         if (self.x - m).abs() <= two * tol - (self.b - self.a) / two {
             return Ok((
                 state
-                    .terminate_with(TerminationReason::TargetPrecisionReached)
+                    .terminate_with(TerminationReason::SolverConverged)
                     .param(self.x)
                     .cost(self.fx),
                 None,
@@ -235,7 +235,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             res.state().termination_status,
-            TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         );
         assert_relative_eq!(
             res.state().param.unwrap(),

--- a/argmin/src/solver/brent/brentroot.rs
+++ b/argmin/src/solver/brent/brentroot.rs
@@ -125,7 +125,7 @@ where
         if mid.abs() <= eff_tol || self.fb == float!(0.0) {
             return Ok((
                 state
-                    .terminate_with(TerminationReason::TargetPrecisionReached)
+                    .terminate_with(TerminationReason::SolverConverged)
                     .param(self.b)
                     .cost(self.fb.abs()),
                 None,

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -168,7 +168,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, J, (), F>) -> TerminationStatus {
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol {
-            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -153,7 +153,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, (), J, (), F>) -> TerminationStatus {
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol {
-            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -205,7 +205,7 @@ where
 
     fn terminate(&mut self, _state: &IterState<F, (), (), (), F>) -> TerminationStatus {
         if self.tolerance * (self.x1.abs() + self.x2.abs()) >= (self.x3 - self.x0).abs() {
-            return TerminationStatus::Terminated(TerminationReason::TargetToleranceReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -242,7 +242,7 @@ where
             self.search_direction.as_ref().unwrap(),
             self.alpha,
         ) {
-            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         } else {
             TerminationStatus::NotTerminated
         }
@@ -595,7 +595,7 @@ mod tests {
                 &mut ls,
                 &IterState::<Vec<f64>, Vec<f64>, (), (), f64>::new().param(init_param)
             ),
-            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         );
 
         ls.init_cost = 0.0f64;
@@ -655,7 +655,7 @@ mod tests {
         assert_eq!(func_counts["gradient_count"], 1);
         assert_eq!(
             data.termination_status,
-            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         );
 
         assert!(data.get_gradient().is_none());
@@ -704,7 +704,7 @@ mod tests {
         assert_eq!(func_counts["gradient_count"], 1);
         assert_eq!(
             data.termination_status,
-            TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         );
         assert!(data.get_gradient().is_none());
     }

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -624,13 +624,13 @@ where
         if self.best_f - self.finit <= self.delta * self.best_x * self.dginit
             && self.best_g >= self.sigma * self.dginit
         {
-            return TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         if (float!(2.0) * self.delta - float!(1.0)) * self.dginit >= self.best_g
             && self.best_g >= self.sigma * self.dginit
             && self.best_f <= self.finit + self.epsilon_k
         {
-            return TerminationStatus::Terminated(TerminationReason::LineSearchConditionMet);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -443,7 +443,7 @@ where
                     .param(cur_param)
                     .cost(cur_cost)
                     .gradient(cur_grad)
-                    .terminate_with(TerminationReason::LineSearchConditionMet),
+                    .terminate_with(TerminationReason::SolverConverged),
                 None,
             ));
         }

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -424,7 +424,7 @@ where
                 .sum::<F>())
         .sqrt();
         if s < self.sd_tolerance {
-            return TerminationStatus::Terminated(TerminationReason::TargetToleranceReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -211,7 +211,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if (state.get_cost() - state.get_prev_cost()).abs() < self.tol {
-            TerminationStatus::Terminated(TerminationReason::TargetToleranceReached)
+            TerminationStatus::Terminated(TerminationReason::SolverConverged)
         } else {
             TerminationStatus::NotTerminated
         }

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -296,10 +296,10 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         if (state.get_prev_cost() - state.cost).abs() < self.tol_cost {
-            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -246,7 +246,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -494,10 +494,10 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol_cost {
-            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -293,10 +293,10 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         if (state.get_prev_cost() - state.cost).abs() < self.tol_cost {
-            return TerminationStatus::Terminated(TerminationReason::NoChangeInCost);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -353,7 +353,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, G, (), B, F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -559,10 +559,14 @@ where
 
     fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
         if self.stall_iter_accepted > self.stall_iter_accepted_limit {
-            return TerminationStatus::Terminated(TerminationReason::AcceptedStallIterExceeded);
+            return TerminationStatus::Terminated(TerminationReason::SolverExit(
+                "AcceptedStallIterExceeded".to_string(),
+            ));
         }
         if self.stall_iter_best > self.stall_iter_best_limit {
-            return TerminationStatus::Terminated(TerminationReason::BestStallIterExceeded);
+            return TerminationStatus::Terminated(TerminationReason::SolverExit(
+                "BestStallIterExceeded".to_string(),
+            ));
         }
         TerminationStatus::NotTerminated
     }

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -254,7 +254,7 @@ where
             return Ok((
                 state
                     .param(p.add(&d.mul(&tau)))
-                    .terminate_with(TerminationReason::TargetPrecisionReached),
+                    .terminate_with(TerminationReason::SolverConverged),
                 None,
             ));
         }
@@ -268,7 +268,7 @@ where
             return Ok((
                 state
                     .param(p.add(&d.mul(&tau)))
-                    .terminate_with(TerminationReason::TargetPrecisionReached),
+                    .terminate_with(TerminationReason::SolverConverged),
                 None,
             ));
         }
@@ -280,7 +280,7 @@ where
             return Ok((
                 state
                     .param(p_n)
-                    .terminate_with(TerminationReason::TargetPrecisionReached),
+                    .terminate_with(TerminationReason::SolverConverged),
                 None,
             ));
         }
@@ -300,7 +300,7 @@ where
 
     fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationStatus {
         if self.r_0_norm < self.epsilon {
-            return TerminationStatus::Terminated(TerminationReason::TargetPrecisionReached);
+            return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }
         if state.get_iter() >= self.max_iters {
             return TerminationStatus::Terminated(TerminationReason::MaxItersReached);


### PR DESCRIPTION
This PR implements a new version of `TerminationReason` enum as discussed  [here](https://github.com/argmin-rs/argmin/issues/305#issuecomment-1382015565).

It introduces the variant `SolverExit(String)` which allows to define custom stopping reason and `SolverConverged` which is intended to gather all successful exit reasons under the same umbrella. 

Some unwanted implementation consequences: 
* `TerminationReason` is not `Copy` anymore (`TerminationStatus` as well)
* We "loose" information when several successful exits are possible for a solver
