### PR TITLE
Replace assert! macros with macros from approx crate

### DIFF
--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -182,8 +182,8 @@ mod tests {
             p_prev,
             rtr,
         } = cg;
-        assert_relative_eq!(b[0], 1.0f64);
-        assert_relative_eq!(b[1], 2.0f64);
+        assert_relative_eq!(b[0], 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(b[1], 2.0f64, epsilon = f64::EPSILON);
         assert!(r.is_none());
         assert!(p.is_none());
         assert!(p_prev.is_none());
@@ -208,8 +208,8 @@ mod tests {
         let res: Result<_, _> = cg.get_prev_p();
         assert!(res.is_ok());
         let p_prev = res.unwrap();
-        assert_relative_eq!(p_prev[0], 3.0f64);
-        assert_relative_eq!(p_prev[1], 4.0f64);
+        assert_relative_eq!(p_prev[0], 3.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(p_prev[1], 4.0f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -334,12 +334,12 @@ mod tests {
         let (state, kv) = cg.next_iter(&mut problem, state).unwrap();
         assert!(kv.is_some());
 
-        assert_relative_eq!(r, cg.r.as_ref().unwrap()[0]);
-        assert_relative_eq!(p_n, cg.p.as_ref().unwrap()[0]);
-        assert_relative_eq!(p, cg.p_prev.as_ref().unwrap()[0]);
+        assert_relative_eq!(r, cg.r.as_ref().unwrap()[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(p_n, cg.p.as_ref().unwrap()[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(p, cg.p_prev.as_ref().unwrap()[0], epsilon = f64::EPSILON);
         assert_relative_eq!(rtr_n, cg.rtr);
 
-        assert_relative_eq!(norm, state.get_cost());
-        assert_relative_eq!(new_param, state.get_param().unwrap()[0]);
+        assert_relative_eq!(norm, state.get_cost(), epsilon = f64::EPSILON);
+        assert_relative_eq!(new_param, state.get_param().unwrap()[0], epsilon = f64::EPSILON);
     }
 }

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -182,8 +182,8 @@ mod tests {
             p_prev,
             rtr,
         } = cg;
-        assert_eq!(b[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(b[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+        assert_relative_eq!(b[0], 1.0f64);
+        assert_relative_eq!(b[1], 2.0f64);
         assert!(r.is_none());
         assert!(p.is_none());
         assert!(p_prev.is_none());
@@ -208,8 +208,8 @@ mod tests {
         let res: Result<_, _> = cg.get_prev_p();
         assert!(res.is_ok());
         let p_prev = res.unwrap();
-        assert_eq!(p_prev[0].to_ne_bytes(), 3.0f64.to_ne_bytes());
-        assert_eq!(p_prev[1].to_ne_bytes(), 4.0f64.to_ne_bytes());
+        assert_relative_eq!(p_prev[0], 3.0f64);
+        assert_relative_eq!(p_prev[1], 4.0f64);
     }
 
     #[test]

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -305,7 +305,8 @@ mod tests {
         let nlcg = nlcg.restart_orthogonality(0.1);
         assert_relative_eq!(
             *nlcg.restart_orthogonality.as_ref().unwrap(),
-            0.1f64
+            0.1f64,
+            epsilon = f64::EPSILON
         );
     }
 

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -303,9 +303,9 @@ mod tests {
             NonlinearConjugateGradient::new(linesearch, beta_method);
         assert!(nlcg.restart_orthogonality.is_none());
         let nlcg = nlcg.restart_orthogonality(0.1);
-        assert_eq!(
-            nlcg.restart_orthogonality.as_ref().unwrap().to_ne_bytes(),
-            0.1f64.to_ne_bytes()
+        assert_relative_eq!(
+            *nlcg.restart_orthogonality.as_ref().unwrap(),
+            0.1f64
         );
     }
 
@@ -341,30 +341,36 @@ mod tests {
             .unwrap();
         assert!(kv.is_none());
         assert_ne!(state_out, state);
-        assert_eq!(state_out.cost.to_ne_bytes(), 1f64.to_ne_bytes());
-        assert_eq!(
-            state_out.grad.as_ref().unwrap()[0].to_ne_bytes(),
-            3f64.to_ne_bytes()
+        assert_relative_eq!(state_out.cost, 1f64);
+        assert_relative_eq!(
+            state_out.grad.as_ref().unwrap()[0],
+            3f64,
+            epsilon = f64::EPSILON
         );
-        assert_eq!(
-            state_out.grad.as_ref().unwrap()[1].to_ne_bytes(),
-            4f64.to_ne_bytes()
+        assert_relative_eq!(
+            state_out.grad.as_ref().unwrap()[1],
+            4f64,
+            epsilon = f64::EPSILON
         );
-        assert_eq!(
-            state_out.param.as_ref().unwrap()[0].to_ne_bytes(),
-            3f64.to_ne_bytes()
+        assert_relative_eq!(
+            state_out.param.as_ref().unwrap()[0],
+            3f64,
+            epsilon = f64::EPSILON
         );
-        assert_eq!(
-            state_out.param.as_ref().unwrap()[1].to_ne_bytes(),
-            4f64.to_ne_bytes()
+        assert_relative_eq!(
+            state_out.param.as_ref().unwrap()[1],
+            4f64,
+            epsilon = f64::EPSILON
         );
-        assert_eq!(
-            nlcg.p.as_ref().unwrap()[0].to_ne_bytes(),
-            (-3f64).to_ne_bytes()
+        assert_relative_eq!(
+            nlcg.p.as_ref().unwrap()[0],
+            (-3f64),
+            epsilon = f64::EPSILON
         );
-        assert_eq!(
-            nlcg.p.as_ref().unwrap()[1].to_ne_bytes(),
-            (-4f64).to_ne_bytes()
+        assert_relative_eq!(
+            nlcg.p.as_ref().unwrap()[1],
+            (-4f64),
+            epsilon = f64::EPSILON
         );
     }
 

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -226,12 +226,11 @@ mod tests {
 
     use super::*;
     use crate::core::ArgminError;
+    use approx::assert_relative_eq;
     #[cfg(feature = "_ndarrayl")]
     use crate::core::{IterState, State};
     use crate::solver::linesearch::{condition::ArmijoCondition, BacktrackingLineSearch};
     use crate::{assert_error, test_trait_impl};
-    #[cfg(feature = "_ndarrayl")]
-    use approx::assert_relative_eq;
 
     test_trait_impl!(
         gauss_newton_linesearch_method,
@@ -249,7 +248,7 @@ mod tests {
         } = GaussNewtonLS::<_, f64>::new(MyLinesearch {});
 
         assert_eq!(ls, MyLinesearch {});
-        assert_eq!(t.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+        assert_relative_eq!(t, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -260,7 +259,7 @@ mod tests {
         let GaussNewtonLS { tol: t1, .. } =
             GaussNewtonLS::new(linesearch).with_tolerance(tol1).unwrap();
 
-        assert_eq!(t1.to_ne_bytes(), tol1.to_ne_bytes());
+            assert_relative_eq!(t1, tol1, epsilon = f64::EPSILON);
     }
 
     #[test]

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -166,7 +166,6 @@ mod tests {
     #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;
-    #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 
     test_trait_impl!(gauss_newton_method, GaussNewton<f64>);
@@ -175,8 +174,8 @@ mod tests {
     fn test_new() {
         let GaussNewton { tol: t, gamma: g } = GaussNewton::<f64>::new();
 
-        assert_eq!(g.to_ne_bytes(), (1.0f64).to_ne_bytes());
-        assert_eq!(t.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+        assert_relative_eq!(g, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(t, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -185,7 +184,7 @@ mod tests {
 
         let GaussNewton { tol: t, .. } = GaussNewton::new().with_tolerance(tol1).unwrap();
 
-        assert_eq!(t.to_ne_bytes(), tol1.to_ne_bytes());
+        assert_relative_eq!(t, tol1, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -205,7 +204,7 @@ mod tests {
 
         let GaussNewton { gamma: g, .. } = GaussNewton::new().with_gamma(gamma).unwrap();
 
-        assert_eq!(g.to_ne_bytes(), gamma.to_ne_bytes());
+        assert_relative_eq!(g, gamma, epsilon = f64::EPSILON);
     }
 
     #[test]

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -248,17 +248,17 @@ mod tests {
             f2,
         } = GoldenSectionSearch::new(-2.5f64, 3.0f64).unwrap();
 
-        assert_eq!(g1.to_ne_bytes(), G1.to_ne_bytes());
-        assert_eq!(g2.to_ne_bytes(), G2.to_ne_bytes());
-        assert_eq!(min_bound.to_ne_bytes(), (-2.5f64).to_ne_bytes());
-        assert_eq!(max_bound.to_ne_bytes(), 3.0f64.to_ne_bytes());
-        assert_eq!(tolerance.to_ne_bytes(), 0.01f64.to_ne_bytes());
-        assert_eq!(x0.to_ne_bytes(), min_bound.to_ne_bytes());
-        assert_eq!(x1.to_ne_bytes(), 0f64.to_ne_bytes());
-        assert_eq!(x2.to_ne_bytes(), 0f64.to_ne_bytes());
-        assert_eq!(x3.to_ne_bytes(), max_bound.to_ne_bytes());
-        assert_eq!(f1.to_ne_bytes(), 0f64.to_ne_bytes());
-        assert_eq!(f2.to_ne_bytes(), 0f64.to_ne_bytes());
+        assert_relative_eq!(g1, G1, epsilon = f64::EPSILON);
+        assert_relative_eq!(g2, G2, epsilon = f64::EPSILON);
+        assert_relative_eq!(min_bound, -2.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_bound, 3.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tolerance, 0.01f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(x0, min_bound, epsilon = f64::EPSILON);
+        assert_relative_eq!(x1, 0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(x2, 0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(x3, max_bound, epsilon = f64::EPSILON);
+        assert_relative_eq!(f1, 0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(f2, 0f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -293,7 +293,7 @@ mod tests {
             .with_tolerance(0.001)
             .unwrap();
 
-        assert_eq!(tolerance.to_ne_bytes(), 0.001f64.to_ne_bytes());
+        assert_relative_eq!(tolerance, 0.001f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -386,13 +386,13 @@ mod tests {
             assert_relative_eq!(state.cost, f2, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(g1.to_ne_bytes(), G1.to_ne_bytes());
-        assert_eq!(g2.to_ne_bytes(), G2.to_ne_bytes());
-        assert_eq!(min_bound.to_ne_bytes(), (-2.5f64).to_ne_bytes());
-        assert_eq!(max_bound.to_ne_bytes(), 3.0f64.to_ne_bytes());
-        assert_eq!(tolerance.to_ne_bytes(), 0.01f64.to_ne_bytes());
-        assert_eq!(x0.to_ne_bytes(), min_bound.to_ne_bytes());
-        assert_eq!(x3.to_ne_bytes(), max_bound.to_ne_bytes());
+        assert_relative_eq!(g1, G1, epsilon = f64::EPSILON);
+        assert_relative_eq!(g2, G2, epsilon = f64::EPSILON);
+        assert_relative_eq!(min_bound, -2.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_bound, 3.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tolerance, 0.01f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(x0, min_bound, epsilon = f64::EPSILON);
+        assert_relative_eq!(x3, max_bound, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -432,11 +432,11 @@ mod tests {
         assert_relative_eq!(x2, g1 * 2.0f64 + g2 * x3, epsilon = f64::EPSILON);
         assert_relative_eq!(f1, 5.0f64, epsilon = f64::EPSILON);
         assert_relative_eq!(f2, problem.cost(&x2).unwrap(), epsilon = f64::EPSILON);
-        assert_eq!(g1.to_ne_bytes(), G1.to_ne_bytes());
-        assert_eq!(g2.to_ne_bytes(), G2.to_ne_bytes());
-        assert_eq!(min_bound.to_ne_bytes(), (-2.5f64).to_ne_bytes());
-        assert_eq!(max_bound.to_ne_bytes(), 3.0f64.to_ne_bytes());
-        assert_eq!(tolerance.to_ne_bytes(), 0.01f64.to_ne_bytes());
+        assert_relative_eq!(g1, G1, epsilon = f64::EPSILON);
+        assert_relative_eq!(g2, G2, epsilon = f64::EPSILON);
+        assert_relative_eq!(min_bound, -2.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_bound, 3.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tolerance, 0.01f64, epsilon = f64::EPSILON);
         if f1 < f2 {
             assert_relative_eq!(*state.param.as_ref().unwrap(), x1, epsilon = f64::EPSILON);
             assert_relative_eq!(state.cost, f1, epsilon = f64::EPSILON);
@@ -484,11 +484,11 @@ mod tests {
         assert_relative_eq!(x3, 2.0f64, epsilon = f64::EPSILON);
         assert_relative_eq!(f1, problem.cost(&x1).unwrap(), epsilon = f64::EPSILON);
         assert_relative_eq!(f2, 5.0f64, epsilon = f64::EPSILON);
-        assert_eq!(g1.to_ne_bytes(), G1.to_ne_bytes());
-        assert_eq!(g2.to_ne_bytes(), G2.to_ne_bytes());
-        assert_eq!(min_bound.to_ne_bytes(), (-2.5f64).to_ne_bytes());
-        assert_eq!(max_bound.to_ne_bytes(), 3.0f64.to_ne_bytes());
-        assert_eq!(tolerance.to_ne_bytes(), 0.01f64.to_ne_bytes());
+        assert_relative_eq!(g1, G1, epsilon = f64::EPSILON);
+        assert_relative_eq!(g2, G2, epsilon = f64::EPSILON);
+        assert_relative_eq!(min_bound, -2.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_bound, 3.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tolerance, 0.01f64, epsilon = f64::EPSILON);
         if f1 < f2 {
             assert_relative_eq!(*state.param.as_ref().unwrap(), x1, epsilon = f64::EPSILON);
             assert_relative_eq!(state.cost, f1, epsilon = f64::EPSILON);

--- a/argmin/src/solver/landweber/mod.rs
+++ b/argmin/src/solver/landweber/mod.rs
@@ -102,7 +102,7 @@ mod tests {
     fn test_new() {
         let omega_in: f64 = 0.5;
         let Landweber { omega } = Landweber::new(omega_in);
-        assert_eq!(omega.to_ne_bytes(), omega_in.to_ne_bytes());
+        assert_relative_eq!(omega, omega_in, epsilon = f64::EPSILON);
     }
 
     #[test]

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -294,8 +294,8 @@ mod tests {
         assert!(ls.init_cost.is_sign_positive());
         assert_eq!(ls.init_grad, None);
         assert_eq!(ls.search_direction, None);
-        assert_eq!(ls.rho.to_ne_bytes(), 0.9f64.to_ne_bytes());
-        assert_eq!(ls.alpha.to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_relative_eq!(ls.rho, 0.9f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(ls.alpha, 1.0f64, epsilon = f64::EPSILON);
     }
 
     #[test]

--- a/argmin/src/solver/linesearch/condition/armijo.rs
+++ b/argmin/src/solver/linesearch/condition/armijo.rs
@@ -67,6 +67,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::assert_error;
     use crate::core::ArgminError;
@@ -78,7 +80,7 @@ mod tests {
     fn test_armijo_new() {
         let c: f64 = 0.01;
         let ArmijoCondition { c: c_arm } = ArmijoCondition::new(c).unwrap();
-        assert_eq!(c.to_ne_bytes(), c_arm.to_ne_bytes());
+        assert_relative_eq!(c, c_arm, epsilon = f64::EPSILON);
 
         assert_error!(
             ArmijoCondition::new(1.0f64),

--- a/argmin/src/solver/linesearch/condition/goldstein.rs
+++ b/argmin/src/solver/linesearch/condition/goldstein.rs
@@ -70,6 +70,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::assert_error;
     use crate::core::ArgminError;
@@ -81,7 +83,7 @@ mod tests {
     fn test_goldstein_new() {
         let c: f64 = 0.01;
         let GoldsteinCondition { c: c_arm } = GoldsteinCondition::new(c).unwrap();
-        assert_eq!(c.to_ne_bytes(), c_arm.to_ne_bytes());
+        assert_relative_eq!(c, c_arm, epsilon = f64::EPSILON);
 
         assert_error!(
             GoldsteinCondition::new(0.5f64),

--- a/argmin/src/solver/linesearch/condition/strongwolfe.rs
+++ b/argmin/src/solver/linesearch/condition/strongwolfe.rs
@@ -87,6 +87,7 @@ mod tests {
     use crate::assert_error;
     use crate::core::ArgminError;
     use crate::test_trait_impl;
+    use approx::assert_relative_eq;
 
     test_trait_impl!(strongwolfe, StrongWolfeCondition<f64>);
 
@@ -98,8 +99,8 @@ mod tests {
             c1: c1_wolfe,
             c2: c2_wolfe,
         } = StrongWolfeCondition::new(c1, c2).unwrap();
-        assert_eq!(c1.to_ne_bytes(), c1_wolfe.to_ne_bytes());
-        assert_eq!(c2.to_ne_bytes(), c2_wolfe.to_ne_bytes());
+        assert_relative_eq!(c1, c1_wolfe, epsilon = f64::EPSILON);
+        assert_relative_eq!(c2, c2_wolfe, epsilon = f64::EPSILON);
 
         // c1
         assert_error!(

--- a/argmin/src/solver/linesearch/condition/wolfe.rs
+++ b/argmin/src/solver/linesearch/condition/wolfe.rs
@@ -89,6 +89,7 @@ mod tests {
     use crate::assert_error;
     use crate::core::ArgminError;
     use crate::test_trait_impl;
+    use approx::assert_relative_eq;
 
     test_trait_impl!(wolfe, WolfeCondition<f64>);
 
@@ -100,8 +101,8 @@ mod tests {
             c1: c1_wolfe,
             c2: c2_wolfe,
         } = WolfeCondition::new(c1, c2).unwrap();
-        assert_eq!(c1.to_ne_bytes(), c1_wolfe.to_ne_bytes());
-        assert_eq!(c2.to_ne_bytes(), c2_wolfe.to_ne_bytes());
+        assert_relative_eq!(c1, c1_wolfe, epsilon = f64::EPSILON);
+        assert_relative_eq!(c2, c2_wolfe, epsilon = f64::EPSILON);
 
         // c1
         assert_error!(

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -641,6 +641,7 @@ mod tests {
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, Problem, State};
     use crate::test_trait_impl;
+    use approx::assert_relative_eq;
 
     test_trait_impl!(hagerzhang, HagerZhangLineSearch<Vec<f64>, Vec<f64>, f64>);
 
@@ -677,26 +678,26 @@ mod tests {
             finit,
         } = hzls;
 
-        assert_eq!(delta.to_ne_bytes(), 0.1f64.to_ne_bytes());
-        assert_eq!(sigma.to_ne_bytes(), 0.9f64.to_ne_bytes());
-        assert_eq!(epsilon.to_ne_bytes(), 1e-6f64.to_ne_bytes());
+        assert_relative_eq!(delta, 0.1f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(sigma, 0.9f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(epsilon, 1e-6f64, epsilon = f64::EPSILON);
         assert!(epsilon_k.is_nan());
-        assert_eq!(theta.to_ne_bytes(), 0.5f64.to_ne_bytes());
-        assert_eq!(gamma.to_ne_bytes(), 0.66f64.to_ne_bytes());
-        assert_eq!(eta.to_ne_bytes(), 0.01f64.to_ne_bytes());
-        assert_eq!(a_x_init.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(theta, 0.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(gamma, 0.66f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(eta, 0.01f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(a_x_init, f64::EPSILON, epsilon = f64::EPSILON);
         assert!(a_x.is_nan());
         assert!(a_f.is_nan());
         assert!(a_g.is_nan());
-        assert_eq!(b_x_init.to_ne_bytes(), 1e5f64.to_ne_bytes());
+        assert_relative_eq!(b_x_init, 1e5f64, epsilon = f64::EPSILON);
         assert!(b_x.is_nan());
         assert!(b_f.is_nan());
         assert!(b_g.is_nan());
-        assert_eq!(c_x_init.to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_relative_eq!(c_x_init, 1.0f64, epsilon = f64::EPSILON);
         assert!(c_x.is_nan());
         assert!(c_f.is_nan());
         assert!(c_g.is_nan());
-        assert_eq!(best_x.to_ne_bytes(), 0.0f64.to_ne_bytes());
+        assert_relative_eq!(best_x, 0.0f64, epsilon = f64::EPSILON);
         assert!(best_f.is_infinite());
         assert!(best_f.is_sign_positive());
         assert!(best_g.is_nan());
@@ -723,8 +724,8 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.delta.to_ne_bytes(), delta.to_ne_bytes());
-            assert_eq!(hzls.sigma.to_ne_bytes(), sigma.to_ne_bytes());
+            assert_relative_eq!(hzls.delta, delta, epsilon = f64::EPSILON);
+            assert_relative_eq!(hzls.sigma, sigma, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -761,7 +762,7 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.epsilon.to_ne_bytes(), epsilon.to_ne_bytes());
+            assert_relative_eq!(hzls.epsilon, epsilon, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -788,7 +789,7 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.theta.to_ne_bytes(), theta.to_ne_bytes());
+            assert_relative_eq!(hzls.theta, theta, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -815,7 +816,7 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.gamma.to_ne_bytes(), gamma.to_ne_bytes());
+            assert_relative_eq!(hzls.gamma, gamma, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -842,7 +843,7 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.eta.to_ne_bytes(), eta.to_ne_bytes());
+            assert_relative_eq!(hzls.eta, eta);
         }
 
         // incorrect parameters
@@ -876,8 +877,8 @@ mod tests {
             assert!(res.is_ok());
 
             let hzls = res.unwrap();
-            assert_eq!(hzls.a_x_init.to_ne_bytes(), min.to_ne_bytes());
-            assert_eq!(hzls.b_x_init.to_ne_bytes(), max.to_ne_bytes());
+            assert_relative_eq!(hzls.a_x_init, min, epsilon = f64::EPSILON);
+            assert_relative_eq!(hzls.b_x_init, max, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -720,6 +720,8 @@ fn cstep<F: ArgminFloat>(
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, Problem};
     use crate::test_trait_impl;
@@ -759,16 +761,16 @@ mod tests {
         assert!(finit.is_infinite());
         assert!(finit.is_sign_positive());
         assert!(init_grad.is_none());
-        assert_eq!(dginit.to_ne_bytes(), 0.0f64.to_ne_bytes());
-        assert_eq!(dgtest.to_ne_bytes(), 0.0f64.to_ne_bytes());
-        assert_eq!(ftol.to_ne_bytes(), 1e-4f64.to_ne_bytes());
-        assert_eq!(gtol.to_ne_bytes(), 0.9f64.to_ne_bytes());
-        assert_eq!(xtrapf.to_ne_bytes(), 4.0f64.to_ne_bytes());
+        assert_relative_eq!(dginit, 0.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(dgtest, 0.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(ftol, 1e-4f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(gtol, 0.9f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(xtrapf, 4.0f64, epsilon = f64::EPSILON);
         assert!(width.is_nan());
         assert!(width1.is_nan());
-        assert_eq!(xtol.to_ne_bytes(), 1e-10f64.to_ne_bytes());
-        assert_eq!(alpha.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(stpmin.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+        assert_relative_eq!(xtol, 1e-10f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(alpha, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(stpmin, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
         assert!(stpmax.is_infinite());
         assert!(stpmax.is_sign_positive());
         assert_eq!(stp, Step::default());
@@ -787,8 +789,8 @@ mod tests {
         assert!(res.is_ok());
 
         let mtls = res.unwrap();
-        assert_eq!(mtls.ftol.to_ne_bytes(), 0.1f64.to_ne_bytes());
-        assert_eq!(mtls.gtol.to_ne_bytes(), 0.9f64.to_ne_bytes());
+        assert_relative_eq!(mtls.ftol, 0.1f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(mtls.gtol, 0.9f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -840,8 +842,8 @@ mod tests {
         assert!(res.is_ok());
 
         let mtls = res.unwrap();
-        assert_eq!(mtls.stpmin.to_ne_bytes(), 0.1f64.to_ne_bytes());
-        assert_eq!(mtls.stpmax.to_ne_bytes(), 0.9f64.to_ne_bytes());
+        assert_relative_eq!(mtls.stpmin, 0.1f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(mtls.stpmax, 0.9f64, epsilon = f64::EPSILON);
     }
 
     #[test]

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -464,15 +464,15 @@ mod tests {
             sd_tolerance,
         } = nm;
 
-        assert_eq!(alpha.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(gamma.to_ne_bytes(), 2.0f64.to_ne_bytes());
-        assert_eq!(rho.to_ne_bytes(), 0.5f64.to_ne_bytes());
-        assert_eq!(sigma.to_ne_bytes(), 0.5f64.to_ne_bytes());
-        assert_eq!(params[0].0[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(params[1].0[0].to_ne_bytes(), 2.0f64.to_ne_bytes());
+        assert_relative_eq!(alpha, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(gamma, 2.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(rho, 0.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(sigma, 0.5f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(params[0].0[0], 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(params[1].0[0], 2.0f64, epsilon = f64::EPSILON);
         assert_eq!(params[0].1.to_ne_bytes(), f64::NAN.to_ne_bytes());
         assert_eq!(params[1].1.to_ne_bytes(), f64::NAN.to_ne_bytes());
-        assert_eq!(sd_tolerance.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(sd_tolerance, f64::EPSILON, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -485,7 +485,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.sd_tolerance.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.sd_tolerance, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -514,7 +514,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.alpha.to_ne_bytes(), alpha.to_ne_bytes());
+            assert_relative_eq!(nm.alpha, alpha, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -543,7 +543,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.rho.to_ne_bytes(), rho.to_ne_bytes());
+            assert_relative_eq!(nm.rho, rho, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -572,7 +572,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.sigma.to_ne_bytes(), sigma.to_ne_bytes());
+            assert_relative_eq!(nm.sigma, sigma, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -599,8 +599,8 @@ mod tests {
         nm.params.iter_mut().for_each(|(p, c)| *c = p[0]);
         nm.sort_param_vecs();
         for ((p, c), ps) in nm.params.iter().zip(params_sorted.iter()) {
-            assert_eq!(p[0].to_ne_bytes(), ps[0].to_ne_bytes());
-            assert_eq!(c.to_ne_bytes(), ps[0].to_ne_bytes());
+            assert_relative_eq!(p[0], ps[0], epsilon = f64::EPSILON);
+            assert_relative_eq!(*c, ps[0], epsilon = f64::EPSILON);
         }
     }
 
@@ -676,8 +676,8 @@ mod tests {
         nm.shrink(|_| Ok(1.0f64)).unwrap();
 
         for ((p, _), ps) in nm.params.iter().zip(params_shrunk.iter()) {
-            assert_eq!(p[0].to_ne_bytes(), ps[0].to_ne_bytes());
-            assert_eq!(p[1].to_ne_bytes(), ps[1].to_ne_bytes());
+            assert_relative_eq!(p[0], ps[0], epsilon = f64::EPSILON);
+            assert_relative_eq!(p[1], ps[1], epsilon = f64::EPSILON);
         }
     }
 
@@ -698,8 +698,8 @@ mod tests {
 
         for ((p, c), (ps, cs)) in nm.params.iter().zip(params_sorted.iter()) {
             assert_relative_eq!(c, cs, epsilon = f64::EPSILON);
-            assert_eq!(p[0].to_ne_bytes(), ps[0].to_ne_bytes());
-            assert_eq!(p[1].to_ne_bytes(), ps[1].to_ne_bytes());
+            assert_relative_eq!(p[0], ps[0], epsilon = f64::EPSILON);
+            assert_relative_eq!(p[1], ps[1], epsilon = f64::EPSILON);
         }
 
         for i in 0..2 {

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -250,6 +250,8 @@ where
 mod tests {
     #![allow(clippy::let_unit_value)]
 
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError};
     use crate::solver::linesearch::MoreThuenteLineSearch;
@@ -287,8 +289,8 @@ mod tests {
             tol,
         } = ncg;
         assert_eq!(linesearch, ls);
-        assert_eq!(curvature_threshold.to_ne_bytes(), 0.0f64.to_ne_bytes());
-        assert_eq!(tol.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(curvature_threshold, 0.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tol, f64::EPSILON, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -303,8 +305,8 @@ mod tests {
             tol,
         } = ncg;
         assert_eq!(linesearch, ls);
-        assert_eq!(curvature_threshold.to_ne_bytes(), 1e-6f64.to_ne_bytes());
-        assert_eq!(tol.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(curvature_threshold, 1e-6f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tol, f64::EPSILON, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -312,7 +314,7 @@ mod tests {
         let ls = ();
         for tolerance in [f64::EPSILON, 1.0, 10.0, 100.0] {
             let ncg: NewtonCG<_, f64> = NewtonCG::new(ls).with_tolerance(tolerance).unwrap();
-            assert_eq!(ncg.tol.to_ne_bytes(), tolerance.to_ne_bytes());
+            assert_relative_eq!(ncg.tol, tolerance);
         }
 
         for tolerance in [-f64::EPSILON, 0.0, -1.0] {

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -117,27 +117,27 @@ where
 mod tests {
     use super::*;
     use crate::core::ArgminError;
+    use approx::assert_relative_eq;
     #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
     use crate::test_trait_impl;
-    #[cfg(feature = "_ndarrayl")]
-    use approx::assert_relative_eq;
 
     test_trait_impl!(newton_method, Newton<f64>);
 
     #[test]
     fn test_new() {
         let solver: Newton<f64> = Newton::new();
-        assert_eq!(solver.gamma.to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_relative_eq!(solver.gamma, 1.0f64, epsilon = f64::EPSILON);
     }
 
     #[test]
     fn test_default() {
         let solver_new: Newton<f64> = Newton::new();
         let solver_def: Newton<f64> = Newton::default();
-        assert_eq!(
-            solver_new.gamma.to_ne_bytes(),
-            solver_def.gamma.to_ne_bytes()
+        assert_relative_eq!(
+            solver_new.gamma,
+            solver_def.gamma,
+            epsilon = f64::EPSILON
         );
     }
 
@@ -145,7 +145,7 @@ mod tests {
     fn test_with_gamma() {
         for new_gamma in [f64::EPSILON, 0.1, 0.5, 0.9, 1.0] {
             let solver: Newton<f64> = Newton::new().with_gamma(new_gamma).unwrap();
-            assert_eq!(solver.gamma.to_ne_bytes(), new_gamma.to_ne_bytes());
+            assert_relative_eq!(solver.gamma, new_gamma, epsilon = f64::EPSILON);
         }
 
         for new_gamma in [1.0 + f64::EPSILON, 2.0, 0.0, -1.0] {

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -441,10 +441,10 @@ mod tests {
             (0.5f64 + 2.0f64.ln()),
             epsilon = f64::EPSILON
         );
-        assert_eq!(lower_bound[0].to_ne_bytes(), bounds.0[0].to_ne_bytes());
-        assert_eq!(lower_bound[1].to_ne_bytes(), bounds.0[1].to_ne_bytes());
-        assert_eq!(upper_bound[0].to_ne_bytes(), bounds.1[0].to_ne_bytes());
-        assert_eq!(upper_bound[1].to_ne_bytes(), bounds.1[1].to_ne_bytes());
+        assert_relative_eq!(lower_bound[0], bounds.0[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(lower_bound[1], bounds.0[1], epsilon = f64::EPSILON);
+        assert_relative_eq!(upper_bound[0], bounds.1[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(upper_bound[1], bounds.1[1], epsilon = f64::EPSILON);
         assert_eq!(num_particles, 40);
     }
 
@@ -457,9 +457,10 @@ mod tests {
             let res = ParticleSwarm::new((lower_bound.clone(), upper_bound.clone()), 40)
                 .with_inertia_factor(inertia);
             assert!(res.is_ok());
-            assert_eq!(
-                res.unwrap().weight_inertia.to_ne_bytes(),
-                inertia.to_ne_bytes()
+            assert_relative_eq!(
+                res.unwrap().weight_inertia,
+                inertia, 
+                epsilon = f64::EPSILON
             );
         }
 
@@ -486,9 +487,10 @@ mod tests {
             let res = ParticleSwarm::new((lower_bound.clone(), upper_bound.clone()), 40)
                 .with_cognitive_factor(cognitive);
             assert!(res.is_ok());
-            assert_eq!(
-                res.unwrap().weight_cognitive.to_ne_bytes(),
-                cognitive.to_ne_bytes()
+            assert_relative_eq!(
+                res.unwrap().weight_cognitive,
+                cognitive,
+                epsilon = f64::EPSILON
             );
         }
 
@@ -515,9 +517,10 @@ mod tests {
             let res = ParticleSwarm::new((lower_bound.clone(), upper_bound.clone()), 40)
                 .with_social_factor(social);
             assert!(res.is_ok());
-            assert_eq!(
-                res.unwrap().weight_social.to_ne_bytes(),
-                social.to_ne_bytes()
+            assert_relative_eq!(
+                res.unwrap().weight_social,
+                social,
+                epsilon = f64::EPSILON
             );
         }
 
@@ -601,7 +604,7 @@ mod tests {
 
         // at least assure that they are ordered correctly and have the correct cost.
         for (particle, cost) in particles.iter().zip(values.iter()) {
-            assert_eq!(particle.cost.to_ne_bytes(), cost.to_ne_bytes());
+            assert_relative_eq!(particle.cost, cost, epsilon = f64::EPSILON);
         }
     }
 
@@ -623,8 +626,8 @@ mod tests {
 
         assert_eq!(init_position, position);
         assert_eq!(init_position, best_position);
-        assert_eq!(init_cost.to_ne_bytes(), cost.to_ne_bytes());
-        assert_eq!(init_cost.to_ne_bytes(), best_cost.to_ne_bytes());
+        assert_relative_eq!(init_cost, cost, epsilon = f64::EPSILON);
+        assert_relative_eq!(init_cost, best_cost, epsilon = f64::EPSILON);
         assert_eq!(init_velocity, velocity);
     }
 
@@ -726,7 +729,7 @@ mod tests {
                     assert!(*x >= -1.0);
                 }
             }
-            assert_eq!(state.get_cost().to_ne_bytes(), (-3.0f64).to_ne_bytes());
+            assert_relative_eq!(state.get_cost(), -3.0f64, epsilon = f64::EPSILON);
         }
     }
 }

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -311,6 +311,7 @@ mod tests {
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
     use crate::test_trait_impl;
+    use approx::assert_relative_eq;
 
     test_trait_impl!(
         bfgs,
@@ -330,8 +331,8 @@ mod tests {
         } = bfgs;
 
         assert_eq!(linesearch, MyFakeLineSearch {});
-        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
-        assert_eq!(tol_cost.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(tol_grad, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
+        assert_relative_eq!(tol_cost, f64::EPSILON, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -346,7 +347,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_grad, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -373,7 +374,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_cost.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_cost, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -437,13 +438,13 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, p) in s_grad.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_inv_hessian = state_out.take_inv_hessian().unwrap();
@@ -453,10 +454,10 @@ mod tests {
             .flatten()
             .zip(inv_hessian.iter().flatten())
         {
-            assert_eq!(s.to_ne_bytes(), h.to_ne_bytes());
+            assert_relative_eq!(s, h, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -478,7 +479,7 @@ mod tests {
 
         assert!(kv.is_none());
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1234.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -504,7 +505,7 @@ mod tests {
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, g) in s_grad.iter().zip(gradient.iter()) {
-            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+            assert_relative_eq!(s, g, epsilon = f64::EPSILON);
         }
     }
 }

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -254,6 +254,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
@@ -276,7 +278,7 @@ mod tests {
         } = dfp;
 
         assert_eq!(linesearch, MyFakeLineSearch {});
-        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
+        assert_relative_eq!(tol_grad, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -291,7 +293,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_grad, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -355,13 +357,13 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, p) in s_grad.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_inv_hessian = state_out.take_inv_hessian().unwrap();
@@ -371,10 +373,10 @@ mod tests {
             .flatten()
             .zip(inv_hessian.iter().flatten())
         {
-            assert_eq!(s.to_ne_bytes(), h.to_ne_bytes());
+            assert_relative_eq!(s, h, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -396,7 +398,7 @@ mod tests {
 
         assert!(kv.is_none());
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1234.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -422,7 +424,7 @@ mod tests {
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, g) in s_grad.iter().zip(gradient.iter()) {
-            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+            assert_relative_eq!(s, g, epsilon = f64::EPSILON);
         }
     }
 }

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -505,6 +505,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{
         test_utils::{TestProblem, TestSparseProblem},
@@ -536,8 +538,8 @@ mod tests {
         } = lbfgs;
 
         assert_eq!(linesearch, MyFakeLineSearch {});
-        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
-        assert_eq!(tol_cost.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
+        assert_relative_eq!(tol_grad, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
+        assert_relative_eq!(tol_cost, f64::EPSILON, epsilon = f64::EPSILON);
         assert_eq!(m, 3);
         assert!(s.capacity() >= 3);
         assert!(y.capacity() >= 3);
@@ -557,7 +559,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_grad, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -584,7 +586,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_cost.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_cost, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -631,16 +633,16 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, p) in s_grad.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -659,7 +661,7 @@ mod tests {
 
         assert!(kv.is_none());
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1234.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -682,7 +684,7 @@ mod tests {
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, g) in s_grad.iter().zip(gradient.iter()) {
-            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+            assert_relative_eq!(s, g, epsilon = f64::EPSILON);
         }
     }
 

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -304,6 +304,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
@@ -328,9 +330,9 @@ mod tests {
         } = sr1;
 
         assert_eq!(linesearch, MyFakeLineSearch {});
-        assert_eq!(tol_grad.to_ne_bytes(), f64::EPSILON.sqrt().to_ne_bytes());
-        assert_eq!(tol_cost.to_ne_bytes(), f64::EPSILON.to_ne_bytes());
-        assert_eq!(denominator_factor.to_ne_bytes(), 1e-8f64.to_ne_bytes());
+        assert_relative_eq!(tol_grad, f64::EPSILON.sqrt(), epsilon = f64::EPSILON);
+        assert_relative_eq!(tol_cost, f64::EPSILON, epsilon = f64::EPSILON);
+        assert_relative_eq!(denominator_factor, 1e-8f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -345,7 +347,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.denominator_factor.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.denominator_factor, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -372,7 +374,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_grad, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -399,7 +401,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_cost.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_cost, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -463,13 +465,13 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, p) in s_grad.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_inv_hessian = state_out.take_inv_hessian().unwrap();
@@ -479,10 +481,10 @@ mod tests {
             .flatten()
             .zip(inv_hessian.iter().flatten())
         {
-            assert_eq!(s.to_ne_bytes(), h.to_ne_bytes());
+            assert_relative_eq!(s, h, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -504,7 +506,7 @@ mod tests {
 
         assert!(kv.is_none());
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1234.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -530,7 +532,7 @@ mod tests {
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, g) in s_grad.iter().zip(gradient.iter()) {
-            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+            assert_relative_eq!(s, g, epsilon = f64::EPSILON);
         }
     }
 }

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -361,6 +361,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
     use crate::solver::trustregion::CauchyPoint;
@@ -382,11 +384,11 @@ mod tests {
             tol_grad,
         } = sr1;
 
-        assert_eq!(denominator_factor.to_ne_bytes(), 1e-8f64.to_ne_bytes());
+        assert_relative_eq!(denominator_factor, 1e-8f64, epsilon = f64::EPSILON);
         assert_eq!(subproblem, MyFakeSubProblem {});
-        assert_eq!(radius.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(eta.to_ne_bytes(), (0.5f64 * 1e-3f64).to_ne_bytes());
-        assert_eq!(tol_grad.to_ne_bytes(), 1e-3f64.to_ne_bytes());
+        assert_relative_eq!(radius, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(eta, 0.5f64 * 1e-3f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(tol_grad, 1e-3f64, epsilon = f64::EPSILON);
     }
 
     #[test]
@@ -401,7 +403,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.denominator_factor.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.denominator_factor, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -428,7 +430,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.tol_grad.to_ne_bytes(), tol.to_ne_bytes());
+            assert_relative_eq!(nm.tol_grad, tol, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -475,16 +477,16 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, p) in s_grad.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -503,7 +505,7 @@ mod tests {
 
         assert!(kv.is_none());
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1234.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1234.0f64, epsilon = f64::EPSILON)
     }
 
     #[test]
@@ -526,7 +528,7 @@ mod tests {
         let s_grad = state_out.take_gradient().unwrap();
 
         for (s, g) in s_grad.iter().zip(gradient.iter()) {
-            assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+            assert_relative_eq!(s, g, epsilon = f64::EPSILON);
         }
     }
 
@@ -554,7 +556,7 @@ mod tests {
 
         for (s1, g1) in s_hessian.iter().zip(hessian.iter()) {
             for (s, g) in s1.iter().zip(g1.iter()) {
-                assert_eq!(s.to_ne_bytes(), g.to_ne_bytes());
+                assert_relative_eq!(s, g, epsilon = f64::EPSILON);
             }
         }
     }

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -603,7 +603,7 @@ mod tests {
             rng: _rng,
         } = sa;
 
-        assert_eq!(init_temp.to_ne_bytes(), 100.0f64.to_ne_bytes());
+        assert_relative_eq!(init_temp, 100.0f64, epsilon = f64::EPSILON);
         assert_eq!(temp_func, SATempFunc::TemperatureFast);
         assert_eq!(temp_iter, 0);
         assert_eq!(stall_iter_accepted, 0);
@@ -616,7 +616,7 @@ mod tests {
         assert_eq!(reanneal_iter_accepted, 0);
         assert_eq!(reanneal_best, u64::MAX);
         assert_eq!(reanneal_iter_best, 0);
-        assert_eq!(cur_temp.to_ne_bytes(), 100.0f64.to_ne_bytes());
+        assert_relative_eq!(cur_temp, 100.0f64, epsilon = f64::EPSILON);
 
         for temp in [0.0, -1.0, -std::f64::EPSILON, -100.0] {
             let res = SimulatedAnnealing::new(temp);
@@ -653,7 +653,7 @@ mod tests {
             rng,
         } = sa;
 
-        assert_eq!(init_temp.to_ne_bytes(), 100.0f64.to_ne_bytes());
+        assert_relative_eq!(init_temp, 100.0f64, epsilon = f64::EPSILON);
         assert_eq!(temp_func, SATempFunc::TemperatureFast);
         assert_eq!(temp_iter, 0);
         assert_eq!(stall_iter_accepted, 0);
@@ -666,7 +666,7 @@ mod tests {
         assert_eq!(reanneal_iter_accepted, 0);
         assert_eq!(reanneal_best, u64::MAX);
         assert_eq!(reanneal_iter_best, 0);
-        assert_eq!(cur_temp.to_ne_bytes(), 100.0f64.to_ne_bytes());
+        assert_relative_eq!(cur_temp, 100.0f64, epsilon = f64::EPSILON);
         // important part
         assert_eq!(rng, MyRng {});
 
@@ -798,7 +798,7 @@ mod tests {
                 assert_eq!(sa.reanneal_iter_accepted, 0);
                 assert_eq!(sa.reanneal_iter_best, 0);
                 assert_eq!(sa.temp_iter, 0);
-                assert_eq!(sa.cur_temp.to_ne_bytes(), sa.init_temp.to_ne_bytes());
+                assert_relative_eq!(sa.cur_temp, sa.init_temp, epsilon = f64::EPSILON);
             }
         }
     }
@@ -879,9 +879,9 @@ mod tests {
         let s_param = state_out.take_param().unwrap();
 
         for (s, p) in s_param.iter().zip(param.iter()) {
-            assert_eq!(s.to_ne_bytes(), p.to_ne_bytes());
+            assert_relative_eq!(s, p, epsilon = f64::EPSILON);
         }
 
-        assert_eq!(state_out.get_cost().to_ne_bytes(), 1.0f64.to_ne_bytes())
+        assert_relative_eq!(state_out.get_cost(), 1.0f64, epsilon = f64::EPSILON)
     }
 }

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -352,7 +352,7 @@ mod tests {
         } = sh;
 
         assert_eq!(radius.to_ne_bytes(), f64::NAN.to_ne_bytes());
-        assert_eq!(epsilon.to_ne_bytes(), 10e-10f64.to_ne_bytes());
+        assert_relative_eq!(epsilon, 10e-10f64, epsilon = f64::EPSILON);
         assert!(p.is_none());
         assert!(r.is_none());
         assert_eq!(rtr.to_ne_bytes(), f64::NAN.to_ne_bytes());
@@ -365,7 +365,7 @@ mod tests {
     fn test_with_tolerance() {
         for tolerance in [f64::EPSILON, 1e-10, 1e-12, 1e-6, 1.0, 10.0, 100.0] {
             let sh: Steihaug<Vec<f64>, f64> = Steihaug::new().with_epsilon(tolerance).unwrap();
-            assert_eq!(sh.epsilon.to_ne_bytes(), tolerance.to_ne_bytes());
+            assert_relative_eq!(sh.epsilon, tolerance, epsilon = f64::EPSILON);
         }
 
         for tolerance in [-f64::EPSILON, 0.0, -1.0] {
@@ -454,14 +454,14 @@ mod tests {
             max_iters,
         } = sh;
 
-        assert_eq!(radius.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(epsilon.to_ne_bytes(), 10e-10f64.to_ne_bytes());
+        assert_relative_eq!(radius, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(epsilon, 10e-10f64, epsilon = f64::EPSILON);
         assert_relative_eq!(p.as_ref().unwrap()[0], 0.0f64, epsilon = f64::EPSILON);
         assert_relative_eq!(p.as_ref().unwrap()[1], 0.0f64, epsilon = f64::EPSILON);
         assert_relative_eq!(r.as_ref().unwrap()[0], grad[0], epsilon = f64::EPSILON);
         assert_relative_eq!(r.as_ref().unwrap()[1], grad[1], epsilon = f64::EPSILON);
-        assert_eq!(rtr.to_ne_bytes(), 5.0f64.to_ne_bytes());
-        assert_eq!(r_0_norm.to_ne_bytes(), (5.0f64).sqrt().to_ne_bytes());
+        assert_relative_eq!(rtr, 5.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(r_0_norm, (5.0f64).sqrt(), epsilon = f64::EPSILON);
         assert_relative_eq!(d.as_ref().unwrap()[0], -grad[0], epsilon = f64::EPSILON);
         assert_relative_eq!(d.as_ref().unwrap()[1], -grad[1], epsilon = f64::EPSILON);
         assert_eq!(max_iters, u64::MAX);

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -307,6 +307,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_relative_eq;
+
     use super::*;
     use crate::core::test_utils::TestProblem;
     use crate::core::{ArgminError, State};
@@ -329,9 +331,9 @@ mod tests {
             mk0,
         } = tr;
 
-        assert_eq!(radius.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(max_radius.to_ne_bytes(), 100.0f64.to_ne_bytes());
-        assert_eq!(eta.to_ne_bytes(), 0.125f64.to_ne_bytes());
+        assert_relative_eq!(radius, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_radius, 100.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(eta, 0.125f64, epsilon = f64::EPSILON);
         assert_eq!(fxk.to_ne_bytes(), f64::NAN.to_ne_bytes());
         assert_eq!(mk0.to_ne_bytes(), f64::NAN.to_ne_bytes());
     }
@@ -346,7 +348,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.radius.to_ne_bytes(), radius.to_ne_bytes());
+            assert_relative_eq!(nm.radius, radius, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -378,7 +380,7 @@ mod tests {
             assert!(res.is_ok());
 
             let nm = res.unwrap();
-            assert_eq!(nm.eta.to_ne_bytes(), eta.to_ne_bytes());
+            assert_relative_eq!(nm.eta, eta, epsilon = f64::EPSILON);
         }
 
         // incorrect parameters
@@ -424,8 +426,8 @@ mod tests {
 
         let s_param = state_out.take_param().unwrap();
 
-        assert_eq!(s_param[0].to_ne_bytes(), param[0].to_ne_bytes());
-        assert_eq!(s_param[1].to_ne_bytes(), param[1].to_ne_bytes());
+        assert_relative_eq!(s_param[0], param[0], epsilon = f64::EPSILON);
+        assert_relative_eq!(s_param[1], param[1], epsilon = f64::EPSILON);
 
         let TrustRegion {
             radius,
@@ -436,10 +438,10 @@ mod tests {
             mk0,
         } = tr;
 
-        assert_eq!(radius.to_ne_bytes(), 1.0f64.to_ne_bytes());
-        assert_eq!(max_radius.to_ne_bytes(), 100.0f64.to_ne_bytes());
-        assert_eq!(eta.to_ne_bytes(), 0.125f64.to_ne_bytes());
-        assert_eq!(fxk.to_ne_bytes(), 1.0f64.sqrt().to_ne_bytes());
-        assert_eq!(mk0.to_ne_bytes(), 1.0f64.to_ne_bytes());
+        assert_relative_eq!(radius, 1.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(max_radius, 100.0f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(eta, 0.125f64, epsilon = f64::EPSILON);
+        assert_relative_eq!(fxk, 1.0f64.sqrt(), epsilon = f64::EPSILON);
+        assert_relative_eq!(mk0, 1.0f64, epsilon = f64::EPSILON);
     }
 }


### PR DESCRIPTION
(https://github.com/argmin-rs/argmin/issues/278) Replaces all `assert!` macros that directly compare `f64s` in tests. `approx::assert_relative_eq(f64::NAN, f64::NAN)` does not pass, so I skipped those.