### PR TITLE
Replace `assert!` macros with macros from approx crate

### DIFF
--- a/argmin-math/Cargo.toml
+++ b/argmin-math/Cargo.toml
@@ -45,6 +45,7 @@ cfg-if = "1"
 
 [dev-dependencies]
 paste = "1"
+approx = "0.5.0"
 
 [features]
 default = ["primitives", "vec"]

--- a/argmin-math/src/primitives/add.rs
+++ b/argmin-math/src/primitives/add.rs
@@ -47,6 +47,7 @@ make_add!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -57,7 +58,7 @@ mod tests {
                     let a = 8 as $t;
                     let b = 34 as $t;
                     let res = <$t as ArgminAdd<$t, $t>>::add(&a, &b);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/conj.rs
+++ b/argmin-math/src/primitives/conj.rs
@@ -53,6 +53,7 @@ make_complex_conj!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test_complex {
@@ -63,8 +64,8 @@ mod tests {
                     let a = 8 as $t;
                     let b = 34 as $t;
                     let res = <Complex<$t> as ArgminConj>::conj(&Complex::new(a, b));
-                    assert!(((a as $t - res.re) as f64).abs() < std::f64::EPSILON);
-                    assert!(((-b as $t - res.im) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(a as f64, res.re as f64, epsilon = std::f64::EPSILON);
+                    assert_relative_eq!(-b as f64, res.im as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -77,7 +78,7 @@ mod tests {
                 fn [<test_conj_ $t>]() {
                     let a = 8 as $t;
                     let res = <$t as ArgminConj>::conj(&a);
-                    assert!(((a as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(a as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/div.rs
+++ b/argmin-math/src/primitives/div.rs
@@ -47,6 +47,7 @@ make_div!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -57,7 +58,7 @@ mod tests {
                     let a = 84 as $t;
                     let b = 2 as $t;
                     let res = <$t as ArgminDiv<$t, $t>>::div(&a, &b);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/dot.rs
+++ b/argmin-math/src/primitives/dot.rs
@@ -47,6 +47,7 @@ make_dot_vec!(Complex<usize>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -57,7 +58,7 @@ mod tests {
                     let a = 21 as $t;
                     let b = 2 as $t;
                     let res = a.dot(&b);
-                    assert!((((res - 42 as $t) as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/l1norm.rs
+++ b/argmin-math/src/primitives/l1norm.rs
@@ -80,6 +80,7 @@ make_l1norm_complex_unsigned!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -89,7 +90,7 @@ mod tests {
                 fn [<test_norm_ $t>]() {
                     let a = 8 as $t;
                     let res = <$t as ArgminL1Norm<$t>>::l1_norm(&a);
-                    assert!(((a - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(a as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -102,7 +103,7 @@ mod tests {
                 fn [<test_norm_signed_ $t>]() {
                     let a = -8 as $t;
                     let res = <$t as ArgminL1Norm<$t>>::l1_norm(&a);
-                    assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(8 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -115,7 +116,7 @@ mod tests {
                 fn [<test_norm_complex_signed_ $t>]() {
                     let a = Complex::new(-8 as $t, -4 as $t);
                     let res = <Complex<$t> as ArgminL1Norm<$t>>::l1_norm(&a);
-                    assert!((((8 as $t + 4 as $t) - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!((8 as $t + 4 as $t) as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -128,7 +129,7 @@ mod tests {
                 fn [<test_norm_complex_ $t>]() {
                     let a = Complex::new(8 as $t, 4 as $t);
                     let res = <Complex<$t> as ArgminL1Norm<$t>>::l1_norm(&a);
-                    assert!((((8 as $t + 4 as $t) - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!((8 as $t + 4 as $t) as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/l2norm.rs
+++ b/argmin-math/src/primitives/l2norm.rs
@@ -60,6 +60,7 @@ make_norm_complex!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -69,7 +70,7 @@ mod tests {
                 fn [<test_norm_ $t>]() {
                     let a = 8 as $t;
                     let res = <$t as ArgminL2Norm<$t>>::l2_norm(&a);
-                    assert!(((a - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(a as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -82,7 +83,7 @@ mod tests {
                 fn [<test_norm_signed_ $t>]() {
                     let a = -8 as $t;
                     let res = <$t as ArgminL2Norm<$t>>::l2_norm(&a);
-                    assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(8 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -95,7 +96,7 @@ mod tests {
                 fn [<test_norm_complex_ $t>]() {
                     let a = Complex::new(8 as $t, 4 as $t);
                     let res = <Complex<$t> as ArgminL2Norm<$t>>::l2_norm(&a);
-                    assert!((((a.re.powi(2)+a.im.powi(2)).sqrt() - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!((a.re.powi(2) + a.im.powi(2)).sqrt() as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -108,7 +109,7 @@ mod tests {
                 fn [<test_norm_complex_signed_ $t>]() {
                     let a = Complex::new(-8 as $t, -4 as $t);
                     let res = <Complex<$t> as ArgminL2Norm<$t>>::l2_norm(&a);
-                    assert!((((a.re.powi(2)+a.im.powi(2)).sqrt() - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!((a.re.powi(2)+a.im.powi(2)).sqrt() as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/mul.rs
+++ b/argmin-math/src/primitives/mul.rs
@@ -47,6 +47,7 @@ make_mul!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -57,7 +58,7 @@ mod tests {
                     let a = 2 as $t;
                     let b = 21 as $t;
                     let res = <$t as ArgminMul<$t, $t>>::mul(&a, &b);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/scaledadd.rs
+++ b/argmin-math/src/primitives/scaledadd.rs
@@ -23,6 +23,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -34,7 +35,7 @@ mod tests {
                     let b = 4 as $t;
                     let c = 10 as $t;
                     let res = <$t as ArgminScaledAdd<$t, $t, $t>>::scaled_add(&a, &b, &c);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/scaledsub.rs
+++ b/argmin-math/src/primitives/scaledsub.rs
@@ -23,6 +23,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -34,7 +35,7 @@ mod tests {
                     let b = 2 as $t;
                     let c = 29 as $t;
                     let res = <$t as ArgminScaledSub<$t, $t, $t>>::scaled_sub(&a, &b, &c);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/sub.rs
+++ b/argmin-math/src/primitives/sub.rs
@@ -47,6 +47,7 @@ make_sub!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -57,7 +58,7 @@ mod tests {
                     let a = 50 as $t;
                     let b = 8 as $t;
                     let res = <$t as ArgminSub<$t, $t>>::sub(&a, &b);
-                    assert!(((42 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(42 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/transpose.rs
+++ b/argmin-math/src/primitives/transpose.rs
@@ -47,6 +47,7 @@ make_transpose!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -56,7 +57,7 @@ mod tests {
                 fn [<test_transpose_ $t>]() {
                     let a = 8 as $t;
                     let res = <$t as ArgminTranspose<$t>>::t(a);
-                    assert!(((8 as $t - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(8 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/weighteddot.rs
+++ b/argmin-math/src/primitives/weighteddot.rs
@@ -23,6 +23,7 @@ where
 #[cfg(test)]
 mod tests_vec {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -38,7 +39,7 @@ mod tests_vec {
                         vec![4 as $t, 9 as $t, 2 as $t],
                     ];
                     let res: $t = a.weighted_dot(&w, &b);
-                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(100 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -60,6 +61,7 @@ mod tests_vec {
 #[cfg(test)]
 mod tests_ndarray {
     use super::*;
+    use approx::assert_relative_eq;
     use ndarray::array;
     use paste::item;
 
@@ -76,7 +78,7 @@ mod tests_ndarray {
                         [4 as $t, 9 as $t, 2 as $t],
                     ];
                     let res: $t = a.weighted_dot(&w, &b);
-                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(100 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -98,6 +100,7 @@ mod tests_ndarray {
 #[cfg(test)]
 mod tests_nalgebra {
     use super::*;
+    use approx::assert_relative_eq;
     use nalgebra::{Matrix3, Vector3};
     use paste::item;
 
@@ -114,7 +117,7 @@ mod tests_nalgebra {
                         4 as $t, 9 as $t, 2 as $t,
                     );
                     let res: $t = a.weighted_dot(&w, &b);
-                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(100 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/weighteddot.rs
+++ b/argmin-math/src/primitives/weighteddot.rs
@@ -61,7 +61,6 @@ mod tests_vec {
 #[cfg(test)]
 mod tests_ndarray {
     use super::*;
-    use approx::assert_relative_eq;
     use ndarray::array;
     use paste::item;
 
@@ -78,7 +77,7 @@ mod tests_ndarray {
                         [4 as $t, 9 as $t, 2 as $t],
                     ];
                     let res: $t = a.weighted_dot(&w, &b);
-                    assert_relative_eq!(100 as f64, res as f64, epsilon = std::f64::EPSILON);
+                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
                 }
             }
         };
@@ -100,7 +99,6 @@ mod tests_ndarray {
 #[cfg(test)]
 mod tests_nalgebra {
     use super::*;
-    use approx::assert_relative_eq;
     use nalgebra::{Matrix3, Vector3};
     use paste::item;
 
@@ -117,7 +115,7 @@ mod tests_nalgebra {
                         4 as $t, 9 as $t, 2 as $t,
                     );
                     let res: $t = a.weighted_dot(&w, &b);
-                    assert_relative_eq!(100 as f64, res as f64, epsilon = std::f64::EPSILON);
+                    assert!((((res - 100 as $t) as f64).abs()) < std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/primitives/zero.rs
+++ b/argmin-math/src/primitives/zero.rs
@@ -74,6 +74,7 @@ make_complex_zero!(usize);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -82,7 +83,7 @@ mod tests {
                 #[test]
                 fn [<test_zero_ $t>]() {
                     let a = <$t as ArgminZero>::zero();
-                    assert!(((0 as $t - a) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -90,8 +91,8 @@ mod tests {
                 #[test]
                 fn [<test_zero_complex_ $t>]() {
                     let a = <Complex<$t> as ArgminZero>::zero();
-                    assert!(((0 as $t - a.re) as f64).abs() < std::f64::EPSILON);
-                    assert!(((0 as $t - a.im) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a.re as f64, epsilon = std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a.im as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -99,7 +100,7 @@ mod tests {
                 #[test]
                 fn [<test_zero_like_ $t>]() {
                     let a = (42 as $t).zero_like();
-                    assert!(((0 as $t - a) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -107,8 +108,8 @@ mod tests {
                 #[test]
                 fn [<test_zero_like_complex_ $t>]() {
                     let a = Complex::new(42 as $t, 12 as $t).zero_like();
-                    assert!(((0 as $t - a.re) as f64).abs() < std::f64::EPSILON);
-                    assert!(((0 as $t - a.im) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a.re as f64, epsilon = std::f64::EPSILON);
+                    assert_relative_eq!(0 as f64, a.im as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/vec/add.rs
+++ b/argmin-math/src/vec/add.rs
@@ -180,7 +180,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -201,7 +201,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminAdd<$t, Vec<Vec<$t>>>>::add(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/add.rs
+++ b/argmin-math/src/vec/add.rs
@@ -88,6 +88,7 @@ make_add!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use paste::item;
 
     macro_rules! make_test {
@@ -100,7 +101,7 @@ mod tests {
                     let target = vec![35 as $t, 38 as $t, 42 as $t];
                     let res = <Vec<$t> as ArgminAdd<$t, Vec<$t>>>::add(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON)
                     }
                 }
             }
@@ -113,7 +114,7 @@ mod tests {
                     let target = vec![35 as $t, 38 as $t, 42 as $t];
                     let res = <$t as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&b, &a);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON)
                     }
                 }
             }
@@ -126,7 +127,7 @@ mod tests {
                     let target = vec![42 as $t, 42 as $t, 42 as $t];
                     let res = <Vec<$t> as ArgminAdd<Vec<$t>, Vec<$t>>>::add(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -179,7 +180,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminAdd<Vec<Vec<$t>>, Vec<Vec<$t>>>>::add(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -200,7 +201,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminAdd<$t, Vec<Vec<$t>>>>::add(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/div.rs
+++ b/argmin-math/src/vec/div.rs
@@ -86,6 +86,7 @@ make_div!(Complex<f64>);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -97,7 +98,7 @@ mod tests {
                     let target = vec![1 as $t, 2 as $t, 4 as $t];
                     let res = <Vec<$t> as ArgminDiv<$t, Vec<$t>>>::div(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -114,8 +115,8 @@ mod tests {
                     let target = vec![a[0]/b, a[1]/b, a[2]/b];
                     let res = <Vec<Complex<$t>> as ArgminDiv<Complex<$t>, Vec<Complex<$t>>>>::div(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i].re as f64) - (res[i].re as f64)).abs() < std::f64::EPSILON);
-                        assert!(((target[i].im as f64) - (res[i].im as f64)).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -128,7 +129,7 @@ mod tests {
                     let target = vec![32 as $t, 16 as $t, 8 as $t];
                     let res = <$t as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&b, &a);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -145,8 +146,8 @@ mod tests {
                     let target = vec![b/a[0], b/a[1], b/a[2]];
                     let res = <Complex<$t> as ArgminDiv<Vec<Complex<$t>>, Vec<Complex<$t>>>>::div(&b, &a);
                     for i in 0..3 {
-                        assert!(((target[i].re as f64) - (res[i].re as f64)).abs() < std::f64::EPSILON);
-                        assert!(((target[i].im as f64) - (res[i].im as f64)).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -159,7 +160,7 @@ mod tests {
                     let target = vec![2 as $t, 3 as $t, 2 as $t];
                     let res = <Vec<$t> as ArgminDiv<Vec<$t>, Vec<$t>>>::div(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -180,8 +181,8 @@ mod tests {
                     let target = vec![a[0]/b[0], a[1]/b[1], a[2]/b[2]];
                     let res = <Vec<Complex<$t>> as ArgminDiv<Vec<Complex<$t>>, Vec<Complex<$t>>>>::div(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i].re as f64) - (res[i].re as f64)).abs() < std::f64::EPSILON);
-                        assert!(((target[i].im as f64) - (res[i].im as f64)).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -234,7 +235,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -274,8 +275,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminDiv<Vec<Vec<Complex<$t>>>, Vec<Vec<Complex<$t>>>>>::div(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/div.rs
+++ b/argmin-math/src/vec/div.rs
@@ -235,7 +235,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminDiv<Vec<Vec<$t>>, Vec<Vec<$t>>>>::div(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -275,8 +275,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminDiv<Vec<Vec<Complex<$t>>>, Vec<Vec<Complex<$t>>>>>::div(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
-                        assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/div.rs
+++ b/argmin-math/src/vec/div.rs
@@ -85,8 +85,8 @@ make_div!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/dot.rs
+++ b/argmin-math/src/vec/dot.rs
@@ -297,8 +297,8 @@ mod tests {
                     ];
                     let product = a.dot(&b);
                     for i in 0..2 {
-                            assert_relative_eq!(res[i].re as f64, product[i].re as f64, epsilon = std::f64::EPSILON);
-                            assert_relative_eq!(res[i].im as f64, product[i].im as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(res[i].re as f64, product[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(res[i].im as f64, product[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -521,7 +521,7 @@ mod tests {
                     let product = (2 as $t).dot(&a);
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, product[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/dot.rs
+++ b/argmin-math/src/vec/dot.rs
@@ -122,8 +122,8 @@ make_dot_vec!(Complex<usize>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/dot.rs
+++ b/argmin-math/src/vec/dot.rs
@@ -123,6 +123,7 @@ make_dot_vec!(Complex<usize>);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -132,7 +133,7 @@ mod tests {
                     let a = vec![1 as $t, 2 as $t, 3 as $t];
                     let b = vec![4 as $t, 5 as $t, 6 as $t];
                     let res: $t = a.dot(&b);
-                    assert!((((res - 32 as $t) as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(32 as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -151,8 +152,8 @@ mod tests {
                     ];
                     let res: Complex<$t> = a.dot(&b);
                     let target = a[0]*b[0] + a[1]*b[1] + a[2]*b[2];
-                    assert!((((res - target).re as f64).abs()) < std::f64::EPSILON);
-                    assert!((((res - target).im as f64).abs()) < std::f64::EPSILON);
+                    assert_relative_eq!(res.re as f64, target.re as f64, epsilon = std::f64::EPSILON);
+                    assert_relative_eq!(res.im as f64, target.im as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -164,7 +165,7 @@ mod tests {
                     let product = a.dot(&b);
                     let res = vec![2 as $t, 4 as $t, 6 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -181,8 +182,8 @@ mod tests {
                     let product = a.dot(&b);
                     let res = vec![a[0]*b, a[1]*b, a[2]*b];
                     for i in 0..3 {
-                        assert!(((res[i].re as f64 - product[i].re as f64).abs()) < std::f64::EPSILON);
-                        assert!(((res[i].im as f64 - product[i].im as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i].re as f64, product[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(res[i].im as f64, product[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -195,7 +196,7 @@ mod tests {
                     let product = b.dot(&a);
                     let res = vec![2 as $t, 4 as $t, 6 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -212,8 +213,8 @@ mod tests {
                     let product = b.dot(&a);
                     let res = vec![a[0]*b, a[1]*b, a[2]*b];
                     for i in 0..3 {
-                        assert!(((res[i].re as f64 - product[i].re as f64).abs()) < std::f64::EPSILON);
-                        assert!(((res[i].im as f64 - product[i].im as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i].re as f64, product[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(res[i].im as f64, product[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -231,7 +232,7 @@ mod tests {
                     let product: Vec<Vec<$t>> = a.dot(&b);
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, product[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -255,8 +256,8 @@ mod tests {
                     let product: Vec<Vec<Complex<$t>>> = a.dot(&b);
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((res[i][j].re as f64 - product[i][j].re as f64).abs()) < std::f64::EPSILON);
-                            assert!(((res[i][j].im as f64 - product[i][j].im as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].re as f64, product[i][j].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].im as f64, product[i][j].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -274,7 +275,7 @@ mod tests {
                     let res = vec![14 as $t, 32 as $t, 50 as $t];
                     let product = a.dot(&b);
                     for i in 0..3 {
-                        assert!((((res[i] - product[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -296,8 +297,8 @@ mod tests {
                     ];
                     let product = a.dot(&b);
                     for i in 0..2 {
-                            assert!(((res[i].re as f64 - product[i].re as f64).abs()) < std::f64::EPSILON);
-                            assert!(((res[i].im as f64 - product[i].im as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i].re as f64, product[i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(res[i].im as f64, product[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -353,8 +354,8 @@ mod tests {
                     let product = a.dot(&b);
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((res[i][j].re as f64 - product[i][j].re as f64).abs()) < std::f64::EPSILON);
-                            assert!(((res[i][j].im as f64 - product[i][j].im as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].re as f64, product[i][j].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].im as f64, product[i][j].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -476,7 +477,7 @@ mod tests {
                     let product = a.dot(&(2 as $t));
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert!((((res[i][j] - product[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, product[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -497,8 +498,8 @@ mod tests {
                     let product = a.dot(&b);
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((res[i][j].re as f64 - product[i][j].re as f64).abs()) < std::f64::EPSILON);
-                            assert!(((res[i][j].im as f64 - product[i][j].im as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].re as f64, product[i][j].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].im as f64, product[i][j].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -541,8 +542,8 @@ mod tests {
                     let product = b.dot(&a);
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((res[i][j].re as f64 - product[i][j].re as f64).abs()) < std::f64::EPSILON);
-                            assert!(((res[i][j].im as f64 - product[i][j].im as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].re as f64, product[i][j].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j].im as f64, product[i][j].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/eye.rs
+++ b/argmin-math/src/vec/eye.rs
@@ -51,6 +51,7 @@ make_eye!(usize);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -65,7 +66,7 @@ mod tests {
                     ];
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert!((((res[i][j] - e[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, e[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -87,7 +88,7 @@ mod tests {
                     ];
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert!((((res[i][j] - e[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, e[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/eye.rs
+++ b/argmin-math/src/vec/eye.rs
@@ -50,8 +50,8 @@ make_eye!(usize);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/l1norm.rs
+++ b/argmin-math/src/vec/l1norm.rs
@@ -70,6 +70,7 @@ make_l1norm_complex!(Complex<f64>, f64);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -79,7 +80,7 @@ mod tests {
                     let a = vec![4 as $t, 3 as $t];
                     let res = <Vec<$t> as ArgminL1Norm<$t>>::l1_norm(&a);
                     let target = 7 as $t;
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -89,7 +90,7 @@ mod tests {
                     let a = vec![Complex::new(4 as $t, 2 as $t), Complex::new(3 as $t, 4 as $t)];
                     let res = <Vec<Complex<$t>> as ArgminL1Norm<$t>>::l1_norm(&a);
                     let target = a[0].l1_norm() + a[1].l1_norm();
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -103,7 +104,7 @@ mod tests {
                     let a = vec![-4 as $t, -3 as $t];
                     let res = <Vec<$t> as ArgminL1Norm<$t>>::l1_norm(&a);
                     let target = 7 as $t;
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -113,7 +114,7 @@ mod tests {
                     let a = vec![Complex::new(-4 as $t, -2 as $t), Complex::new(-3 as $t, -4 as $t)];
                     let res = <Vec<Complex<$t>> as ArgminL1Norm<$t>>::l1_norm(&a);
                     let target = a[0].l1_norm() + a[1].l1_norm();
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/vec/l1norm.rs
+++ b/argmin-math/src/vec/l1norm.rs
@@ -69,8 +69,8 @@ make_l1norm_complex!(Complex<f64>, f64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/l2norm.rs
+++ b/argmin-math/src/vec/l2norm.rs
@@ -81,8 +81,8 @@ make_norm_complex!(Complex<f64>, f64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/l2norm.rs
+++ b/argmin-math/src/vec/l2norm.rs
@@ -82,6 +82,7 @@ make_norm_complex!(Complex<f64>, f64);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -91,7 +92,7 @@ mod tests {
                     let a = vec![4 as $t, 3 as $t];
                     let res = <Vec<$t> as ArgminL2Norm<$t>>::l2_norm(&a);
                     let target = 5 as $t;
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -101,7 +102,7 @@ mod tests {
                     let a = vec![Complex::new(4 as $t, 2 as $t), Complex::new(3 as $t, 4 as $t)];
                     let res = <Vec<Complex<$t>> as ArgminL2Norm<$t>>::l2_norm(&a);
                     let target = (a[0].norm_sqr() + a[1].norm_sqr()).sqrt();
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };
@@ -115,7 +116,7 @@ mod tests {
                     let a = vec![-4 as $t, -3 as $t];
                     let res = <Vec<$t> as ArgminL2Norm<$t>>::l2_norm(&a);
                     let target = 5 as $t;
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
 
@@ -125,7 +126,7 @@ mod tests {
                     let a = vec![Complex::new(-4 as $t, -2 as $t), Complex::new(-3 as $t, -4 as $t)];
                     let res = <Vec<Complex<$t>> as ArgminL2Norm<$t>>::l2_norm(&a);
                     let target = (a[0].norm_sqr() + a[1].norm_sqr()).sqrt();
-                    assert!(((target - res) as f64).abs() < std::f64::EPSILON);
+                    assert_relative_eq!(target as f64, res as f64, epsilon = std::f64::EPSILON);
                 }
             }
         };

--- a/argmin-math/src/vec/minmax.rs
+++ b/argmin-math/src/vec/minmax.rs
@@ -71,8 +71,8 @@ make_minmax!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/minmax.rs
+++ b/argmin-math/src/vec/minmax.rs
@@ -115,8 +115,8 @@ mod tests {
                     let res_min = <Vec<Vec<$t>> as ArgminMinMax>::min(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target_max[j][i] as f64, res_max[j][i] as f64, epsilon = std::f64::EPSILON);
-                        assert_relative_eq!(target_min[j][i] as f64, res_min[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target_max[j][i] as f64, res_max[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target_min[j][i] as f64, res_min[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/minmax.rs
+++ b/argmin-math/src/vec/minmax.rs
@@ -72,6 +72,7 @@ make_minmax!(f64);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -85,8 +86,8 @@ mod tests {
                     let res_max = <Vec<$t> as ArgminMinMax>::max(&a, &b);
                     let res_min = <Vec<$t> as ArgminMinMax>::min(&a, &b);
                     for i in 0..3 {
-                        assert!(((target_max[i] - res_max[i]) as f64).abs() < std::f64::EPSILON);
-                        assert!(((target_min[i] - res_min[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target_max[i] as f64, res_max[i] as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target_min[i] as f64, res_min[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -114,8 +115,8 @@ mod tests {
                     let res_min = <Vec<Vec<$t>> as ArgminMinMax>::min(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!(((target_max[j][i] - res_max[j][i]) as f64).abs() < std::f64::EPSILON);
-                        assert!(((target_min[j][i] - res_min[j][i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target_max[j][i] as f64, res_max[j][i] as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target_min[j][i] as f64, res_min[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/mul.rs
+++ b/argmin-math/src/vec/mul.rs
@@ -101,6 +101,7 @@ make_mul!(Complex<f64>);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -112,7 +113,7 @@ mod tests {
                     let target = vec![2 as $t, 8 as $t, 16 as $t];
                     let res = <Vec<$t> as ArgminMul<$t, Vec<$t>>>::mul(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -128,8 +129,8 @@ mod tests {
                     let target = vec![a[0] * b, a[1] * b];
                     let res = <Vec<Complex<$t>> as ArgminMul<Complex<$t>, Vec<Complex<$t>>>>::mul(&a, &b);
                     for i in 0..2 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -142,7 +143,7 @@ mod tests {
                     let target = vec![2 as $t, 8 as $t, 16 as $t];
                     let res = <$t as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&b, &a);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -158,8 +159,8 @@ mod tests {
                     let target = vec![a[0] * b, a[1] * b];
                     let res = <Complex<$t> as ArgminMul<Vec<Complex<$t>>, Vec<Complex<$t>>>>::mul(&b, &a);
                     for i in 0..2 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -172,7 +173,7 @@ mod tests {
                     let target = vec![2 as $t, 12 as $t, 32 as $t];
                     let res = <Vec<$t> as ArgminMul<Vec<$t>, Vec<$t>>>::mul(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -191,8 +192,8 @@ mod tests {
                     let target = vec![a[0]*b[0], a[1]*b[1]];
                     let res = <Vec<Complex<$t>> as ArgminMul<Vec<Complex<$t>>, Vec<Complex<$t>>>>::mul(&a, &b);
                     for i in 0..2 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -245,7 +246,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -272,8 +273,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminMul<Vec<Vec<Complex<$t>>>, Vec<Vec<Complex<$t>>>>>::mul(&a, &b);
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                            assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -361,8 +362,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminMul<Complex<$t>, Vec<Vec<Complex<$t>>>>>::mul(&a, &b);
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                            assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -383,7 +384,7 @@ mod tests {
                     let res = <$t as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -406,8 +407,8 @@ mod tests {
                     let res = <Complex<$t> as ArgminMul<Vec<Vec<Complex<$t>>>, Vec<Vec<Complex<$t>>>>>::mul(&b, &a);
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                            assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/mul.rs
+++ b/argmin-math/src/vec/mul.rs
@@ -246,7 +246,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminMul<Vec<Vec<$t>>, Vec<Vec<$t>>>>::mul(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                        assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -339,7 +339,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminMul<$t, Vec<Vec<$t>>>>::mul(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/mul.rs
+++ b/argmin-math/src/vec/mul.rs
@@ -100,8 +100,8 @@ make_mul!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/scaledadd.rs
+++ b/argmin-math/src/vec/scaledadd.rs
@@ -8,8 +8,8 @@
 #[cfg(test)]
 mod tests {
     use crate::ArgminScaledAdd;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/scaledadd.rs
+++ b/argmin-math/src/vec/scaledadd.rs
@@ -9,6 +9,7 @@
 mod tests {
     use crate::ArgminScaledAdd;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -21,7 +22,7 @@ mod tests {
                     let res = a.scaled_add(&b, &c);
                     let target = vec![9 as $t, 12 as $t, 15 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, target[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -57,7 +58,7 @@ mod tests {
                     let res = a.scaled_add(&b, &c);
                     let target = vec![13 as $t, 12 as $t, 9 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, target[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -117,7 +118,7 @@ mod tests {
                     ];
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, target[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -260,7 +261,7 @@ mod tests {
                     ];
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, target[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/scaledsub.rs
+++ b/argmin-math/src/vec/scaledsub.rs
@@ -8,8 +8,8 @@
 #[cfg(test)]
 mod tests {
     use crate::ArgminScaledSub;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/scaledsub.rs
+++ b/argmin-math/src/vec/scaledsub.rs
@@ -9,6 +9,7 @@
 mod tests {
     use crate::ArgminScaledSub;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -21,7 +22,7 @@ mod tests {
                     let res = a.scaled_sub(&b, &c);
                     let target = vec![2 as $t, 10 as $t, 18 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, target[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -57,7 +58,7 @@ mod tests {
                     let res = a.scaled_sub(&b, &c);
                     let target = vec![3 as $t, 10 as $t, 24 as $t];
                     for i in 0..3 {
-                        assert!((((res[i] - target[i]) as f64).abs()) < std::f64::EPSILON);
+                        assert_relative_eq!(res[i] as f64, target[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -117,7 +118,7 @@ mod tests {
                     ];
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, target[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -260,7 +261,7 @@ mod tests {
                     ];
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!((((res[i][j] - target[i][j]) as f64).abs()) < std::f64::EPSILON);
+                            assert_relative_eq!(res[i][j] as f64, target[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/sub.rs
+++ b/argmin-math/src/vec/sub.rs
@@ -100,8 +100,8 @@ make_sub!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/sub.rs
+++ b/argmin-math/src/vec/sub.rs
@@ -101,6 +101,7 @@ make_sub!(Complex<f64>);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -112,7 +113,7 @@ mod tests {
                     let target = vec![66 as $t, 6 as $t, 42 as $t];
                     let res = <Vec<$t> as ArgminSub<$t, Vec<$t>>>::sub(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -129,8 +130,8 @@ mod tests {
                     let target = vec![a[0] - b, a[1] - b, a[2] - b];
                     let res = <Vec<Complex<$t>> as ArgminSub<Complex<$t>, Vec<Complex<$t>>>>::sub(&a, &b);
                     for i in 0..3 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -143,7 +144,7 @@ mod tests {
                     let target = vec![99 as $t, 96 as $t, 42 as $t];
                     let res = <$t as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&b, &a);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -160,8 +161,8 @@ mod tests {
                     let target = vec![b - a[0], b - a[1], b - a[2]];
                     let res = <Complex<$t> as ArgminSub<Vec<Complex<$t>>, Vec<Complex<$t>>>>::sub(&b, &a);
                     for i in 0..3 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -174,7 +175,7 @@ mod tests {
                     let target = vec![42 as $t, 42 as $t, 42 as $t];
                     let res = <Vec<$t> as ArgminSub<Vec<$t>, Vec<$t>>>::sub(&a, &b);
                     for i in 0..3 {
-                        assert!(((target[i] - res[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -195,8 +196,8 @@ mod tests {
                     let target = vec![a[0] - b[0], a[1] - b[1], a[2] - b[2]];
                     let res = <Vec<Complex<$t>> as ArgminSub<Vec<Complex<$t>>, Vec<Complex<$t>>>>::sub(&a, &b);
                     for i in 0..3 {
-                        assert!((target[i].re as f64 - res[i].re as f64).abs() < std::f64::EPSILON);
-                        assert!((target[i].im as f64 - res[i].im as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(target[i].re as f64, res[i].re as f64, epsilon = std::f64::EPSILON);
+                        assert_relative_eq!(target[i].im as f64, res[i].im as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -249,7 +250,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminSub<Vec<Vec<$t>>, Vec<Vec<$t>>>>::sub(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -276,8 +277,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminSub<Vec<Vec<Complex<$t>>>, Vec<Vec<Complex<$t>>>>>::sub(&a, &b);
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                            assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -298,7 +299,7 @@ mod tests {
                     let res = <Vec<Vec<$t>> as ArgminSub<$t, Vec<Vec<$t>>>>::sub(&a, &b);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert!(((target[j][i] - res[j][i]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i] as f64, res[j][i] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -321,8 +322,8 @@ mod tests {
                     let res = <Vec<Vec<Complex<$t>>> as ArgminSub<Complex<$t>, Vec<Vec<Complex<$t>>>>>::sub(&a, &b);
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!((target[j][i].re as f64 - res[j][i].re as f64).abs() < std::f64::EPSILON);
-                            assert!((target[j][i].im as f64 - res[j][i].im as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].re as f64, res[j][i].re as f64, epsilon = std::f64::EPSILON);
+                            assert_relative_eq!(target[j][i].im as f64, res[j][i].im as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/transpose.rs
+++ b/argmin-math/src/vec/transpose.rs
@@ -58,8 +58,8 @@ make_transpose!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/argmin-math/src/vec/transpose.rs
+++ b/argmin-math/src/vec/transpose.rs
@@ -59,6 +59,7 @@ make_transpose!(Complex<f64>);
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -76,7 +77,7 @@ mod tests {
                     let res = a.t();
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((target[i][j] - res[i][j]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[i][j] as f64, res[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }
@@ -97,7 +98,7 @@ mod tests {
                     let res = a.t();
                     for i in 0..2 {
                         for j in 0..3 {
-                            assert!(((target[i][j] - res[i][j]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(target[i][j] as f64, res[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/zero.rs
+++ b/argmin-math/src/vec/zero.rs
@@ -25,6 +25,7 @@ where
 mod tests {
     use super::*;
     use paste::item;
+    use approx::assert_relative_eq;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -42,7 +43,7 @@ mod tests {
                 fn [<test_zero_like_2_ $t>]() {
                     let a = (vec![42 as $t; 4]).zero_like();
                     for i in 0..4 {
-                        assert!(((0 as $t - a[i]) as f64).abs() < std::f64::EPSILON);
+                        assert_relative_eq!(0 as f64, a[i] as f64, epsilon = std::f64::EPSILON);
                     }
                 }
             }
@@ -62,7 +63,7 @@ mod tests {
                     let a = (vec![vec![42 as $t; 2]; 2]).zero_like();
                     for i in 0..2 {
                         for j in 0..2 {
-                            assert!(((0 as $t - a[i][j]) as f64).abs() < std::f64::EPSILON);
+                            assert_relative_eq!(0 as f64, a[i][j] as f64, epsilon = std::f64::EPSILON);
                         }
                     }
                 }

--- a/argmin-math/src/vec/zero.rs
+++ b/argmin-math/src/vec/zero.rs
@@ -24,8 +24,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
     use approx::assert_relative_eq;
+    use paste::item;
 
     macro_rules! make_test {
         ($t:ty) => {


### PR DESCRIPTION
Follows [(278)](https://github.com/argmin-rs/argmin/issues/278), changes every float equality check that gets run by `cargo test -p argmin-math`.