### PR TITLE
Update dependencies

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -28,7 +28,7 @@ bincode = { version = "1.3.3", optional = true }
 ctrlc = { version = "3.2.4", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 gnuplot = { version = "0.0.37", optional = true }
-rayon = { version = "1.5.3", optional = true }
+rayon = { version = "1.6.0", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0", optional = true }
 slog = { version = "2.7", optional = true, features = ["dynamic-keys"] }

--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -42,7 +42,7 @@ finitediff = { version = "0.1.4", features = ["ndarray"] }
 argmin_testfunctions = "0.1.1"
 nalgebra = { version = "0.32", features = ["serde-serialize"] }
 ndarray = { version = "0.15", features = ["serde-1"] }
-ndarray-linalg = { version = "0.14", features = ["netlib"] }
+ndarray-linalg = { version = "0.16", features = ["netlib"] }
 argmin-math = { path = "../argmin-math" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 

--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0"
 argmin-math = { path = "../argmin-math", version = "0.3", default-features = false, features = ["primitives"] }
 # optional
 bincode = { version = "1.3.3", optional = true }
-ctrlc = { version = "3.1.2", optional = true }
+ctrlc = { version = "3.2.4", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 gnuplot = { version = "0.0.37", optional = true }
 rayon = { version = "1.5.3", optional = true }

--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -31,10 +31,10 @@ gnuplot = { version = "0.0.37", optional = true }
 rayon = { version = "1.5.3", optional = true }
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0", optional = true }
-slog = { version = "2.4.1", optional = true, features = ["dynamic-keys"] }
-slog-term = { version = "2.8.1", optional = true }
-slog-async = { version = "2.7.0", optional = true }
-slog-json = { version = "2.5.0", optional = true }
+slog = { version = "2.7", optional = true, features = ["dynamic-keys"] }
+slog-term = { version = "2.9", optional = true }
+slog-async = { version = "2.7", optional = true }
+slog-json = { version = "2.6", optional = true }
 
 [dev-dependencies]
 approx = "0.5.0"


### PR DESCRIPTION
Apparently dependabot doesn't work for some reason. Therefore I'm updating manually. 

* [x] ctrlc 3.1.2 -> 3.2.4
* [x] rayon 1.5.3 -> 1.6
* [x] slog 2.4.1 -> 2.7
* [x] slog-term 2.8.1 -> 2.9
* [x] slog-json 2.5.0 -> 2.6
* [x] ndarray-linalg 0.14 -> 0.16