### PR TITLE
Keep track of residuals in `IterState`, adapted `GaussNewton` accordingly

### DIFF
--- a/argmin/src/core/checkpointing/file.rs
+++ b/argmin/src/core/checkpointing/file.rs
@@ -181,11 +181,12 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn test_save() {
         let solver = TestSolver::new();
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new().param(vec![1.0f64, 0.0]);
+        let state: IterState<Vec<f64>, (), (), (), (), f64> =
+            IterState::new().param(vec![1.0f64, 0.0]);
         let check = FileCheckpoint::new("checkpoints", "solver", CheckpointingFrequency::Always);
         check.save_cond(&solver, &state, 20).unwrap();
 
-        let _loaded: Option<(TestSolver, IterState<Vec<f64>, (), (), (), f64>)> =
+        let _loaded: Option<(TestSolver, IterState<Vec<f64>, (), (), (), (), f64>)> =
             check.load().unwrap();
     }
 }

--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -408,8 +408,9 @@ mod tests {
         let problem = TestProblem::new();
         let solver = TestSolver::new();
 
-        let mut executor = Executor::new(problem, solver)
-            .configure(|config: IterState<Vec<f64>, (), (), (), f64>| config.param(vec![0.0, 0.0]));
+        let mut executor = Executor::new(problem, solver).configure(
+            |config: IterState<Vec<f64>, (), (), (), (), f64>| config.param(vec![0.0, 0.0]),
+        );
 
         // 1) Parameter vector changes, but not cost (continues to be `Inf`)
         let new_param = vec![1.0, 1.0];
@@ -492,8 +493,9 @@ mod tests {
 
         // 4) `-Inf` is better than `Inf`
         let solver = TestSolver {};
-        let mut executor = Executor::new(problem, solver)
-            .configure(|config: IterState<Vec<f64>, (), (), (), f64>| config.param(vec![0.0, 0.0]));
+        let mut executor = Executor::new(problem, solver).configure(
+            |config: IterState<Vec<f64>, (), (), (), (), f64>| config.param(vec![0.0, 0.0]),
+        );
 
         let new_param = vec![1.0, 1.0];
         let new_cost = std::f64::NEG_INFINITY;
@@ -584,7 +586,7 @@ mod tests {
         }
 
         // Implement Solver for OptimizationAlgorithm
-        impl<O, P, F> Solver<O, IterState<P, (), (), (), F>> for OptimizationAlgorithm
+        impl<O, P, F> Solver<O, IterState<P, (), (), (), (), F>> for OptimizationAlgorithm
         where
             O: CostFunction<Param = P, Output = F>,
             P: Clone,
@@ -596,8 +598,8 @@ mod tests {
             fn init(
                 &mut self,
                 _problem: &mut Problem<O>,
-                state: IterState<P, (), (), (), F>,
-            ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+                state: IterState<P, (), (), (), (), F>,
+            ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
                 self.internal_state = 1;
                 Ok((state, None))
             }
@@ -606,21 +608,21 @@ mod tests {
             fn next_iter(
                 &mut self,
                 _problem: &mut Problem<O>,
-                state: IterState<P, (), (), (), F>,
-            ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+                state: IterState<P, (), (), (), (), F>,
+            ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
                 self.internal_state += 1;
                 Ok((state, None))
             }
 
             // Avoid terminating early because param does not change
-            fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
+            fn terminate(&mut self, _state: &IterState<P, (), (), (), (), F>) -> TerminationStatus {
                 TerminationStatus::NotTerminated
             }
 
             // Avoid terminating early because param does not change
             fn terminate_internal(
                 &mut self,
-                state: &IterState<P, (), (), (), F>,
+                state: &IterState<P, (), (), (), (), F>,
             ) -> TerminationStatus {
                 if state.get_iter() >= state.get_max_iters() {
                     TerminationStatus::Terminated(TerminationReason::MaxItersReached)

--- a/argmin/src/core/observers/mod.rs
+++ b/argmin/src/core/observers/mod.rs
@@ -198,7 +198,7 @@ impl<I> Observers<I> {
     /// use argmin::core::observers::Observers;
     /// use argmin::core::IterState;
     ///
-    /// let observers: Observers<IterState<Vec<f64>, (), (), (), f64>> = Observers::new();
+    /// let observers: Observers<IterState<Vec<f64>, (), (), (), (), f64>> = Observers::new();
     /// # assert!(observers.is_empty());
     /// ```
     pub fn new() -> Self {
@@ -214,7 +214,7 @@ impl<I> Observers<I> {
     /// use argmin_observer_slog::SlogLogger;
     /// use argmin::core::IterState;
     ///
-    /// let mut observers: Observers<IterState<Vec<f64>, (), (), (), f64>> = Observers::new();
+    /// let mut observers: Observers<IterState<Vec<f64>, (), (), (), (), f64>> = Observers::new();
     ///
     /// let logger = SlogLogger::term();
     /// observers.push(logger, ObserverMode::Always);
@@ -237,7 +237,7 @@ impl<I> Observers<I> {
     /// use argmin::core::observers::Observers;
     /// use argmin::core::IterState;
     ///
-    /// let observers: Observers<IterState<Vec<f64>, (), (), (), f64>> = Observers::new();
+    /// let observers: Observers<IterState<Vec<f64>, (), (), (), (), f64>> = Observers::new();
     /// assert!(observers.is_empty());
     /// ```
     pub fn is_empty(&self) -> bool {
@@ -375,7 +375,7 @@ mod tests {
 
         let storages = [test_stor_1, test_stor_2, test_stor_3, test_stor_4];
 
-        type TState = IterState<Vec<f64>, (), (), (), f64>;
+        type TState = IterState<Vec<f64>, (), (), (), (), f64>;
 
         let mut obs: Observers<TState> = Observers::new();
         obs.push(test_obs_1, ObserverMode::Never)

--- a/argmin/src/core/result.rs
+++ b/argmin/src/core/result.rs
@@ -39,7 +39,7 @@ impl<O, S, I> OptimizationResult<O, S, I> {
     /// # struct SomeSolver {}
     /// #
     /// let rosenbrock = Rosenbrock::new();
-    /// let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let solver = SomeSolver {};
     ///
     /// let result = OptimizationResult::new(Problem::new(rosenbrock), solver, state);
@@ -65,7 +65,7 @@ impl<O, S, I> OptimizationResult<O, S, I> {
     /// # struct Rosenbrock {}
     /// # let solver = ();
     /// #
-    /// # let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// #
     /// # let result = OptimizationResult::new(Problem::new(Rosenbrock {}), solver, state);
     /// #
@@ -85,7 +85,7 @@ impl<O, S, I> OptimizationResult<O, S, I> {
     /// # struct Rosenbrock {}
     /// # let solver = ();
     /// #
-    /// # let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// #
     /// # let result = OptimizationResult::new(Problem::new(Rosenbrock {}), solver, state);
     /// #
@@ -105,11 +105,11 @@ impl<O, S, I> OptimizationResult<O, S, I> {
     /// # struct Rosenbrock {}
     /// # let solver = ();
     /// #
-    /// # let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// #
     /// # let result = OptimizationResult::new(Problem::new(Rosenbrock {}), solver, state);
     /// #
-    /// let state: &IterState<Vec<f64>, (), (), (), f64> = result.state();
+    /// let state: &IterState<Vec<f64>, (), (), (), (), f64> = result.state();
     /// ```
     pub fn state(&self) -> &I {
         &self.state
@@ -199,7 +199,7 @@ mod tests {
 
     send_sync_test!(
         optimizationresult,
-        OptimizationResult<TestProblem, TestSolver, IterState<(), (), (), (), f64>>
+        OptimizationResult<TestProblem, TestSolver, IterState<(), (), (), (), (), f64>>
     );
 
     // TODO: More tests, in particular the checking that the output is as intended.

--- a/argmin/src/core/solver.rs
+++ b/argmin/src/core/solver.rs
@@ -30,7 +30,7 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 /// #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 /// struct OptimizationAlgorithm {}
 ///
-/// impl<O, P, G, J, H, F> Solver<O, IterState<P, G, J, H, F>> for OptimizationAlgorithm
+/// impl<O, P, G, J, H, R, F> Solver<O, IterState<P, G, J, H, R, F>> for OptimizationAlgorithm
 /// where
 ///     O: CostFunction<Param = P, Output = F>,
 ///     P: Clone,
@@ -41,8 +41,8 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 ///     fn init(
 ///         &mut self,
 ///         problem: &mut Problem<O>,
-///         state: IterState<P, G, J, H, F>,
-///     ) -> Result<(IterState<P, G, J, H, F>, Option<KV>), Error> {
+///         state: IterState<P, G, J, H, R, F>,
+///     ) -> Result<(IterState<P, G, J, H, R, F>, Option<KV>), Error> {
 ///         // Initialize algorithm, update `state`.
 ///         // Implementing this method is optional.
 ///         Ok((state, None))
@@ -51,14 +51,14 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 ///     fn next_iter(
 ///         &mut self,
 ///         problem: &mut Problem<O>,
-///         state: IterState<P, G, J, H, F>,
-///     ) -> Result<(IterState<P, G, J, H, F>, Option<KV>), Error> {
+///         state: IterState<P, G, J, H, R, F>,
+///     ) -> Result<(IterState<P, G, J, H, R, F>, Option<KV>), Error> {
 ///         // Compute single iteration of algorithm, update `state`.
 ///         // Implementing this method is required.
 ///         Ok((state, None))
 ///     }
 ///     
-///     fn terminate(&mut self, state: &IterState<P, G, J, H, F>) -> TerminationStatus {
+///     fn terminate(&mut self, state: &IterState<P, G, J, H, R, F>) -> TerminationStatus {
 ///         // Check if stopping criteria are met.
 ///         // Implementing this method is optional.
 ///         TerminationStatus::NotTerminated

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -72,6 +72,8 @@ pub struct IterState<P, G, J, H, R, F> {
     pub prev_jacobian: Option<J>,
     /// Value of residuals from recent call to apply
     pub residuals: Option<R>,
+    /// Value of residuals from previous call to apply
+    pub prev_residuals: Option<R>,
     /// Current iteration
     pub iter: u64,
     /// Iteration number of last best cost
@@ -98,7 +100,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # let param_old = vec![1.0f64, 2.0f64];
     /// # let state = state.param(param_old);
     /// # assert!(state.prev_param.is_none());
@@ -124,7 +126,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<(), Vec<f64>, (), (), f64, ()> = IterState::new();
+    /// # let state: IterState<(), Vec<f64>, (), (), (), f64> = IterState::new();
     /// # let grad_old = vec![1.0f64, 2.0f64];
     /// # let state = state.gradient(grad_old);
     /// # assert!(state.prev_grad.is_none());
@@ -150,7 +152,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<(), (), (), Vec<f64>, f64, ()> = IterState::new();
+    /// # let state: IterState<(), (), (), Vec<f64>, (), f64> = IterState::new();
     /// # let hessian_old = vec![1.0f64, 2.0f64];
     /// # let state = state.hessian(hessian_old);
     /// # assert!(state.prev_hessian.is_none());
@@ -176,7 +178,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<(), (), (), Vec<f64>, f64, ()>> = IterState::new();
+    /// # let state: IterState<(), (), (), Vec<f64>, (), f64> = IterState::new();
     /// # let inv_hessian_old = vec![1.0f64, 2.0f64];
     /// # let state = state.inv_hessian(inv_hessian_old);
     /// # assert!(state.prev_inv_hessian.is_none());
@@ -202,7 +204,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<(), (), Vec<f64>, (), f64, ()> = IterState::new();
+    /// # let state: IterState<(), (), Vec<f64>, (), (), f64> = IterState::new();
     /// # let jacobian_old = vec![1.0f64, 2.0f64];
     /// # let state = state.jacobian(jacobian_old);
     /// # assert!(state.prev_jacobian.is_none());
@@ -229,7 +231,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State};
-    /// # let state: IterState<(), (), Vec<f64>, (), f64, ()> = IterState::new();
+    /// # let state: IterState<(), (), Vec<f64>, (), (), f64> = IterState::new();
     /// # let cost_old = 1.0f64;
     /// # let state = state.cost(cost_old);
     /// # assert_eq!(state.prev_cost.to_ne_bytes(), f64::INFINITY.to_ne_bytes());
@@ -255,7 +257,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.target_cost.to_ne_bytes(), f64::NEG_INFINITY.to_ne_bytes());
     /// let state = state.target_cost(0.0);
     /// # assert_eq!(state.target_cost.to_ne_bytes(), 0.0f64.to_ne_bytes());
@@ -272,7 +274,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.max_iters, std::u64::MAX);
     /// let state = state.max_iters(1000);
     /// # assert_eq!(state.max_iters, 1000);
@@ -283,13 +285,39 @@ where
         self
     }
 
+    /// Set residuals. This shifts the stored residuals to the previous residuals.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State};
+    /// # let state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
+    /// # let residuals_old = vec![1.0f64, 2.0f64];
+    /// # let state = state.residuals(residuals_old);
+    /// # assert!(state.prev_residuals.is_none());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// # let residuals = vec![0.0f64, 3.0f64];
+    /// let state = state.residuals(residuals);
+    /// # assert_eq!(state.prev_residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(state.prev_residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 0.0f64.to_ne_bytes());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[1].to_ne_bytes(), 3.0f64.to_ne_bytes());
+    /// ```
+    #[must_use]
+    pub fn residuals(mut self, residuals: R) -> Self {
+        std::mem::swap(&mut self.prev_residuals, &mut self.residuals);
+        self.residuals = Some(residuals);
+        self
+    }
+
     /// Returns the current cost function value
     ///
     /// # Example
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # let state = state.cost(2.0);
     /// let cost = state.get_cost();
     /// # assert_eq!(cost.to_ne_bytes(), 2.0f64.to_ne_bytes());
@@ -304,7 +332,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.prev_cost = 2.0;
     /// let prev_cost = state.get_prev_cost();
     /// # assert_eq!(prev_cost.to_ne_bytes(), 2.0f64.to_ne_bytes());
@@ -319,7 +347,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.best_cost = 2.0;
     /// let best_cost = state.get_best_cost();
     /// # assert_eq!(best_cost.to_ne_bytes(), 2.0f64.to_ne_bytes());
@@ -334,7 +362,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.prev_best_cost = 2.0;
     /// let prev_best_cost = state.get_prev_best_cost();
     /// # assert_eq!(prev_best_cost.to_ne_bytes(), 2.0f64.to_ne_bytes());
@@ -349,7 +377,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.target_cost.to_ne_bytes(), std::f64::NEG_INFINITY.to_ne_bytes());
     /// # state.target_cost = 0.0;
     /// let target_cost = state.get_target_cost();
@@ -365,7 +393,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.take_param().is_none());
     /// # let mut state = state.param(vec![1.0, 2.0]);
     /// # assert_eq!(state.param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -386,7 +414,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.prev_param.is_none());
     /// # state.prev_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.prev_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -405,7 +433,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.take_prev_param().is_none());
     /// # state.prev_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.prev_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -426,7 +454,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.prev_best_param.is_none());
     /// # state.prev_best_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.prev_best_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -445,7 +473,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.take_best_param().is_none());
     /// # state.best_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.best_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -466,7 +494,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.take_prev_best_param().is_none());
     /// # state.prev_best_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.prev_best_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -487,7 +515,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), Vec<f64>, (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), Vec<f64>, (), (), (), f64> = IterState::new();
     /// # assert!(state.grad.is_none());
     /// # assert!(state.get_gradient().is_none());
     /// # state.grad = Some(vec![1.0, 2.0]);
@@ -507,7 +535,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), Vec<f64>, (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), Vec<f64>, (), (), (), f64> = IterState::new();
     /// # assert!(state.take_gradient().is_none());
     /// # state.grad = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.grad.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -528,7 +556,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), Vec<f64>, (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), Vec<f64>, (), (), (), f64> = IterState::new();
     /// # assert!(state.prev_grad.is_none());
     /// # assert!(state.get_prev_gradient().is_none());
     /// # state.prev_grad = Some(vec![1.0, 2.0]);
@@ -548,7 +576,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), Vec<f64>, (), (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), Vec<f64>, (), (), (), f64> = IterState::new();
     /// # assert!(state.take_prev_gradient().is_none());
     /// # state.prev_grad = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.prev_grad.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -569,7 +597,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.hessian.is_none());
     /// # assert!(state.get_hessian().is_none());
     /// # state.hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -593,7 +621,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.hessian.is_none());
     /// # assert!(state.take_hessian().is_none());
     /// # state.hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -619,7 +647,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.prev_hessian.is_none());
     /// # assert!(state.get_prev_hessian().is_none());
     /// # state.prev_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -643,7 +671,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.prev_hessian.is_none());
     /// # assert!(state.take_prev_hessian().is_none());
     /// # state.prev_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -669,7 +697,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.inv_hessian.is_none());
     /// # assert!(state.get_inv_hessian().is_none());
     /// # state.inv_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -693,7 +721,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.inv_hessian.is_none());
     /// # assert!(state.take_inv_hessian().is_none());
     /// # state.inv_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -719,7 +747,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.prev_inv_hessian.is_none());
     /// # assert!(state.get_prev_inv_hessian().is_none());
     /// # state.prev_inv_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -743,7 +771,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), (), Vec<Vec<f64>>, (), f64> = IterState::new();
     /// # assert!(state.prev_inv_hessian.is_none());
     /// # assert!(state.take_prev_inv_hessian().is_none());
     /// # state.prev_inv_hessian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -769,7 +797,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), (), f64> = IterState::new();
     /// # assert!(state.jacobian.is_none());
     /// # assert!(state.get_jacobian().is_none());
     /// # state.jacobian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -793,7 +821,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), (), f64> = IterState::new();
     /// # assert!(state.jacobian.is_none());
     /// # assert!(state.take_jacobian().is_none());
     /// # state.jacobian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -819,7 +847,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), (), f64> = IterState::new();
     /// # assert!(state.prev_jacobian.is_none());
     /// # assert!(state.get_prev_jacobian().is_none());
     /// # state.prev_jacobian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -843,7 +871,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), f64, ()> = IterState::new();
+    /// # let mut state: IterState<(), (), Vec<Vec<f64>>, (), (), f64> = IterState::new();
     /// # assert!(state.prev_jacobian.is_none());
     /// # assert!(state.take_prev_jacobian().is_none());
     /// # state.prev_jacobian = Some(vec![vec![1.0, 2.0], vec![3.0, 4.0]]);
@@ -863,13 +891,13 @@ where
         self.prev_jacobian.take()
     }
 
-    /// Returns a reference to previous parameter vector
+    /// Returns a reference to the residuals
     ///
     /// # Example
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), (), f64, Vec<f64>> = IterState::new();
+    /// # let mut state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
     /// # assert!(state.residuals.is_none());
     /// # state.residuals = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -882,13 +910,13 @@ where
         self.residuals.as_ref()
     }
 
-    /// Moves the previous parameter vector out and replaces it internally with `None`
+    /// Moves the residuals out and replaces it internally with `None`
     ///
     /// # Example
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<(), (), (), (), f64, Vec<f64>> = IterState::new();
+    /// # let mut state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
     /// # assert!(state.take_residuals().is_none());
     /// # state.residuals = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -901,6 +929,46 @@ where
     /// ```
     pub fn take_residuals(&mut self) -> Option<R> {
         self.residuals.take()
+    }
+
+    /// Returns a reference to the previous residuals
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State, ArgminFloat};
+    /// # let mut state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
+    /// # assert!(state.residuals.is_none());
+    /// # state.residuals = Some(vec![1.0, 2.0]);
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// let residuals = state.get_residuals();  // Option<&R>
+    /// # assert_eq!(residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// ```
+    pub fn get_prev_residuals(&self) -> Option<&R> {
+        self.prev_residuals.as_ref()
+    }
+
+    /// Moves the previous residuals out and replaces it internally with `None`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use argmin::core::{IterState, State, ArgminFloat};
+    /// # let mut state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
+    /// # assert!(state.take_residuals().is_none());
+    /// # state.residuals = Some(vec![1.0, 2.0]);
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(state.residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// let residuals = state.take_residuals();  // Option<R>
+    /// # assert!(state.take_residuals().is_none());
+    /// # assert!(state.residuals.is_none());
+    /// # assert_eq!(residuals.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
+    /// # assert_eq!(residuals.as_ref().unwrap()[1].to_ne_bytes(), 2.0f64.to_ne_bytes());
+    /// ```
+    pub fn take_prev_residuals(&mut self) -> Option<R> {
+        self.prev_residuals.take()
     }
 }
 
@@ -922,7 +990,7 @@ where
     /// # extern crate instant;
     /// # use instant;
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationStatus};
-    /// let state: IterState<Vec<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<Vec<f64>>, f64> = IterState::new();
+    /// let state: IterState<Vec<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<Vec<f64>>, Vec<f64>, f64> = IterState::new();
     /// # assert!(state.param.is_none());
     /// # assert!(state.prev_param.is_none());
     /// # assert!(state.best_param.is_none());
@@ -967,6 +1035,7 @@ where
             jacobian: None,
             prev_jacobian: None,
             residuals: None,
+            prev_residuals: None,
             iter: 0,
             last_best_iter: 0,
             max_iters: std::u64::MAX,
@@ -983,7 +1052,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     ///
     /// // Simulating a new, better parameter vector
     /// state.best_param = Some(vec![1.0f64]);
@@ -1005,7 +1074,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     ///
     /// // Simulating a new, better parameter vector
     /// state.best_param = Some(vec![1.0f64]);
@@ -1048,7 +1117,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.param.is_none());
     /// # state.param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -1067,7 +1136,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert!(state.best_param.is_none());
     /// # state.best_param = Some(vec![1.0, 2.0]);
     /// # assert_eq!(state.best_param.as_ref().unwrap()[0].to_ne_bytes(), 1.0f64.to_ne_bytes());
@@ -1086,7 +1155,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason, TerminationStatus};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.termination_status, TerminationStatus::NotTerminated);
     /// let state = state.terminate_with(TerminationReason::MaxItersReached);
     /// # assert_eq!(state.termination_status, TerminationStatus::Terminated(TerminationReason::MaxItersReached));
@@ -1104,7 +1173,7 @@ where
     /// # extern crate instant;
     /// # use instant;
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let state = state.time(Some(instant::Duration::new(0, 12)));
     /// # assert_eq!(state.time.unwrap(), instant::Duration::new(0, 12));
     /// ```
@@ -1119,7 +1188,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.cost = 12.0;
     /// let cost = state.get_cost();
     /// # assert_eq!(cost.to_ne_bytes(), 12.0f64.to_ne_bytes());
@@ -1134,7 +1203,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.best_cost = 12.0;
     /// let best_cost = state.get_best_cost();
     /// # assert_eq!(best_cost.to_ne_bytes(), 12.0f64.to_ne_bytes());
@@ -1149,7 +1218,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.target_cost = 12.0;
     /// let target_cost = state.get_target_cost();
     /// # assert_eq!(target_cost.to_ne_bytes(), 12.0f64.to_ne_bytes());
@@ -1164,7 +1233,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.iter = 12;
     /// let iter = state.get_iter();
     /// # assert_eq!(iter, 12);
@@ -1179,7 +1248,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.last_best_iter = 12;
     /// let last_best_iter = state.get_last_best_iter();
     /// # assert_eq!(last_best_iter, 12);
@@ -1194,7 +1263,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.max_iters = 12;
     /// let max_iters = state.get_max_iters();
     /// # assert_eq!(max_iters, 12);
@@ -1209,7 +1278,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationStatus};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let termination_status = state.get_termination_status();
     /// # assert_eq!(*termination_status, TerminationStatus::NotTerminated);
     /// ```
@@ -1223,7 +1292,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```
@@ -1242,7 +1311,7 @@ where
     /// # extern crate instant;
     /// # use instant;
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let time = state.get_time();
     /// # assert_eq!(time.unwrap(), instant::Duration::new(0, 0));
     /// ```
@@ -1256,7 +1325,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.iter, 0);
     /// state.increment_iter();
     /// # assert_eq!(state.iter, 1);
@@ -1270,7 +1339,7 @@ where
     /// ```
     /// # use std::collections::HashMap;
     /// # use argmin::core::{Problem, IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.counts, HashMap::new());
     /// # state.counts.insert("test2".to_string(), 10u64);
     /// #
@@ -1300,7 +1369,7 @@ where
     /// ```
     /// # use std::collections::HashMap;
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # assert_eq!(state.counts, HashMap::new());
     /// # state.counts.insert("test2".to_string(), 10u64);
     /// let counts = state.get_func_counts();
@@ -1319,7 +1388,7 @@ where
     ///
     /// ```
     /// # use argmin::core::{IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// # state.last_best_iter = 12;
     /// # state.iter = 12;
     /// let is_best = state.is_best();
@@ -1342,9 +1411,10 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn test_iterstate() {
         let param = vec![1.0f64, 2.0];
+        let residuals = vec![1.0f64, 2.0];
         let cost: f64 = 42.0;
 
-        let mut state: IterState<Vec<f64>, Vec<f64>, Vec<f64>, Vec<Vec<f64>>, f64> =
+        let mut state: IterState<Vec<f64>, Vec<f64>, Vec<f64>, Vec<Vec<f64>>, Vec<f64>, f64> =
             IterState::new();
 
         assert!(state.get_param().is_none());
@@ -1382,9 +1452,13 @@ mod tests {
         assert!(state.get_prev_inv_hessian().is_none());
         assert!(state.get_jacobian().is_none());
         assert!(state.get_prev_jacobian().is_none());
+        assert!(state.get_residuals().is_none());
+        assert!(state.get_prev_residuals().is_none());
         assert_eq!(state.get_iter(), 0);
 
         assert!(state.is_best());
+
+        state = state.residuals(param.clone());
 
         assert_eq!(state.get_max_iters(), std::u64::MAX);
         let func_counts = state.get_func_counts().clone();
@@ -1411,6 +1485,13 @@ mod tests {
 
         assert_eq!(*state.get_param().unwrap(), new_param);
         assert_eq!(*state.get_prev_param().unwrap(), param);
+
+        let new_residuals = vec![2.0, 1.0];
+
+        state = state.residuals(new_residuals.clone());
+
+        assert_eq!(*state.get_residuals().unwrap(), new_residuals);
+        assert_eq!(*state.get_prev_residuals().unwrap(), residuals);
 
         let new_cost: f64 = 21.0;
 
@@ -1516,6 +1597,8 @@ mod tests {
         assert_eq!(state.take_prev_inv_hessian().unwrap(), inv_hessian);
         assert_eq!(state.take_jacobian().unwrap(), new_jacobian);
         assert_eq!(state.take_prev_jacobian().unwrap(), jacobian);
+        assert_eq!(*state.get_residuals().unwrap(), new_residuals);
+        assert_eq!(*state.get_prev_residuals().unwrap(), residuals);
         let func_counts = state.get_func_counts().clone();
         assert!(!func_counts.contains_key("cost_count"));
         assert!(!func_counts.contains_key("operator_count"));

--- a/argmin/src/core/state/linearprogramstate.rs
+++ b/argmin/src/core/state/linearprogramstate.rs
@@ -456,8 +456,8 @@ where
     /// # Example
     ///
     /// ```
-    /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # use argmin::core::{LinearProgramState, State, ArgminFloat, TerminationReason};
+    /// # let mut state: LinearProgramState<Vec<f64>, f64> = LinearProgramState::new();
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -735,8 +735,8 @@ where
     /// # Example
     ///
     /// ```
-    /// # use argmin::core::{IterState, State, ArgminFloat, TerminationReason};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+    /// # use argmin::core::{PopulationState, State, ArgminFloat, TerminationReason};
+    /// # let mut state: PopulationState<Vec<f64>, f64> = PopulationState::new();
     /// let termination_reason = state.get_termination_reason();
     /// # assert_eq!(termination_reason, None);
     /// ```

--- a/argmin/src/core/test_utils.rs
+++ b/argmin/src/core/test_utils.rs
@@ -326,14 +326,14 @@ impl TestSolver {
     }
 }
 
-impl<O> Solver<O, IterState<Vec<f64>, (), (), (), f64>> for TestSolver {
+impl<O> Solver<O, IterState<Vec<f64>, (), (), (), (), f64>> for TestSolver {
     const NAME: &'static str = "TestSolver";
 
     fn next_iter(
         &mut self,
         _problem: &mut Problem<O>,
-        state: IterState<Vec<f64>, (), (), (), f64>,
-    ) -> Result<(IterState<Vec<f64>, (), (), (), f64>, Option<KV>), Error> {
+        state: IterState<Vec<f64>, (), (), (), (), f64>,
+    ) -> Result<(IterState<Vec<f64>, (), (), (), (), f64>, Option<KV>), Error> {
         Ok((state, None))
     }
 }

--- a/argmin/src/lib.rs
+++ b/argmin/src/lib.rs
@@ -112,6 +112,8 @@
 // Explicitly disallow EQ comparison of floats. (This clippy lint is denied by default; however,
 // this is just to make sure that it will always stay this way.)
 #![deny(clippy::float_cmp)]
+// Some types just are complex
+#![allow(clippy::type_complexity)]
 
 #[macro_use]
 pub mod core;

--- a/argmin/src/solver/brent/brentopt.rs
+++ b/argmin/src/solver/brent/brentopt.rs
@@ -97,7 +97,7 @@ impl<F: ArgminFloat> BrentOpt<F> {
     }
 }
 
-impl<O, F> Solver<O, IterState<F, (), (), (), F>> for BrentOpt<F>
+impl<O, F> Solver<O, IterState<F, (), (), (), (), F>> for BrentOpt<F>
 where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
@@ -108,8 +108,8 @@ where
         &mut self,
         problem: &mut Problem<O>,
         // BrentOpt maintains its own state
-        state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         let u = self.a + self.c * (self.b - self.a);
         self.v = u;
         self.w = u;
@@ -125,8 +125,8 @@ where
         &mut self,
         problem: &mut Problem<O>,
         // BrentOpt maintains its own state
-        state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         let two = float!(2f64);
         let tol = self.eps * self.x.abs() + self.t;
         let m = (self.a + self.b) / two;

--- a/argmin/src/solver/brent/brentroot.rs
+++ b/argmin/src/solver/brent/brentroot.rs
@@ -75,7 +75,7 @@ impl<F: ArgminFloat> BrentRoot<F> {
     }
 }
 
-impl<O, F> Solver<O, IterState<F, (), (), (), F>> for BrentRoot<F>
+impl<O, F> Solver<O, IterState<F, (), (), (), (), F>> for BrentRoot<F>
 where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
@@ -86,8 +86,8 @@ where
         &mut self,
         problem: &mut Problem<O>,
         // BrentRoot maintains its own state
-        state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         self.fa = problem.cost(&self.a)?;
         self.fb = problem.cost(&self.b)?;
         if self.fa * self.fb > float!(0.0) {
@@ -101,8 +101,8 @@ where
         &mut self,
         problem: &mut Problem<O>,
         // BrentRoot maintains its own state
-        state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         if (self.fb > float!(0.0) && self.fc > float!(0.0))
             || self.fb < float!(0.0) && self.fc < float!(0.0)
         {

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -229,7 +229,8 @@ mod tests {
     #[test]
     fn test_init() {
         let mut cg: ConjugateGradient<_, f64> = ConjugateGradient::new(vec![1.0f64, 2.0]);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new().param(vec![3.0, 4.0]);
+        let state: IterState<Vec<f64>, (), (), (), (), f64> =
+            IterState::new().param(vec![3.0, 4.0]);
         let (state_out, kv) = cg
             .init(&mut Problem::new(TestProblem::new()), state.clone())
             .unwrap();

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -89,7 +89,7 @@ where
     }
 }
 
-impl<P, O, F> Solver<O, IterState<P, (), (), (), F>> for ConjugateGradient<P, F>
+impl<P, O, F> Solver<O, IterState<P, (), (), (), (), F>> for ConjugateGradient<P, F>
 where
     O: Operator<Param = P, Output = P>,
     P: Clone
@@ -106,8 +106,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         let init_param = state.get_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -127,8 +127,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         let p = self.p.take().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`ConjugateGradient`: Field `p` not set"

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -118,7 +118,7 @@ where
     }
 }
 
-impl<O, P, G, L, B, F> Solver<O, IterState<P, G, (), (), F>>
+impl<O, P, G, L, B, F> Solver<O, IterState<P, G, (), (), (), F>>
     for NonlinearConjugateGradient<P, L, B, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
@@ -129,7 +129,7 @@ where
         + ArgminMul<F, P>
         + ArgminDot<G, F>
         + ArgminL2Norm<F>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     B: NLCGBetaUpdate<G, P, F>,
     F: ArgminFloat,
 {
@@ -138,8 +138,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let param = state.get_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -156,8 +156,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let p = self.p.as_ref().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`NonlinearConjugateGradient`: Field `p` not set"

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -334,7 +334,7 @@ mod tests {
         let beta_method = PolakRibiere::new();
         let mut nlcg: NonlinearConjugateGradient<Vec<f64>, _, _, f64> =
             NonlinearConjugateGradient::new(linesearch, beta_method);
-        let state: IterState<Vec<f64>, Vec<f64>, (), (), f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), (), (), f64> =
             IterState::new().param(vec![3.0, 4.0]);
         let (state_out, kv) = nlcg
             .init(&mut Problem::new(TestProblem::new()), state.clone())

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -109,7 +109,7 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
     }
 }
 
-impl<O, F, P, J, U> Solver<O, IterState<P, (), J, (), F>> for GaussNewton<F>
+impl<O, F, P, J, U, R> Solver<O, IterState<P, (), J, (), R, F>> for GaussNewton<F>
 where
     O: Operator<Param = P, Output = U> + Jacobian<Param = P, Jacobian = J>,
     P: Clone + ArgminSub<P, P> + ArgminMul<F, P>,
@@ -127,8 +127,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, (), J, (), F>,
-    ) -> Result<(IterState<P, (), J, (), F>, Option<KV>), Error> {
+        state: IterState<P, (), J, (), R, F>,
+    ) -> Result<(IterState<P, (), J, (), R, F>, Option<KV>), Error> {
         let param = state.get_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -151,7 +151,7 @@ where
         Ok((state.param(new_param).cost(residuals.l2_norm()), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, (), J, (), F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, (), J, (), R, F>) -> TerminationStatus {
         if (state.get_prev_cost() - state.get_cost()).abs() < self.tol {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -109,16 +109,16 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
     }
 }
 
-impl<O, F, P, J, U, R> Solver<O, IterState<P, (), J, (), R, F>> for GaussNewton<F>
+impl<O, P, J, R, F> Solver<O, IterState<P, (), J, (), R, F>> for GaussNewton<F>
 where
-    O: Operator<Param = P, Output = U> + Jacobian<Param = P, Jacobian = J>,
+    O: Operator<Param = P, Output = R> + Jacobian<Param = P, Jacobian = J>,
     P: Clone + ArgminSub<P, P> + ArgminMul<F, P>,
-    U: ArgminL2Norm<F>,
+    R: ArgminL2Norm<F>,
     J: Clone
         + ArgminTranspose<J>
         + ArgminInv<J>
         + ArgminDot<J, J>
-        + ArgminDot<U, P>
+        + ArgminDot<R, P>
         + ArgminDot<P, P>,
     F: ArgminFloat,
 {
@@ -148,7 +148,9 @@ where
 
         let new_param = param.sub(&p.mul(&self.gamma));
 
-        Ok((state.param(new_param).cost(residuals.l2_norm()), None))
+        let cost = residuals.l2_norm();
+
+        Ok((state.param(new_param).residuals(residuals).cost(cost), None))
     }
 
     fn terminate(&mut self, state: &IterState<P, (), J, (), R, F>) -> TerminationStatus {

--- a/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/argmin/src/solver/goldensectionsearch/mod.rs
@@ -134,7 +134,7 @@ where
     }
 }
 
-impl<O, F> Solver<O, IterState<F, (), (), (), F>> for GoldenSectionSearch<F>
+impl<O, F> Solver<O, IterState<F, (), (), (), (), F>> for GoldenSectionSearch<F>
 where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
@@ -144,8 +144,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        mut state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         let init_estimate = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -181,8 +181,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<F, (), (), (), F>,
-    ) -> Result<(IterState<F, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<F, (), (), (), (), F>,
+    ) -> Result<(IterState<F, (), (), (), (), F>, Option<KV>), Error> {
         if self.f2 < self.f1 {
             self.x0 = self.x1;
             self.x1 = self.x2;
@@ -203,7 +203,7 @@ where
         }
     }
 
-    fn terminate(&mut self, _state: &IterState<F, (), (), (), F>) -> TerminationStatus {
+    fn terminate(&mut self, _state: &IterState<F, (), (), (), (), F>) -> TerminationStatus {
         if self.tolerance * (self.x1.abs() + self.x2.abs()) >= (self.x3 - self.x0).abs() {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -55,7 +55,7 @@ where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone + SerializeAlias + DeserializeOwnedAlias,
     G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, G>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
+    L: Clone + LineSearch<G, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Steepest Descent";

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -50,12 +50,12 @@ impl<L> SteepestDescent<L> {
     }
 }
 
-impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), F>> for SteepestDescent<L>
+impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), (), F>> for SteepestDescent<L>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone + SerializeAlias + DeserializeOwnedAlias,
     G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, G>,
-    L: Clone + LineSearch<G, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Steepest Descent";
@@ -63,8 +63,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let param_new = state
             .get_param()
             .ok_or_else(argmin_error_closure!(

--- a/argmin/src/solver/landweber/mod.rs
+++ b/argmin/src/solver/landweber/mod.rs
@@ -63,7 +63,7 @@ impl<F> Landweber<F> {
     }
 }
 
-impl<O, F, P, G> Solver<O, IterState<P, G, (), (), F>> for Landweber<F>
+impl<O, F, P, G> Solver<O, IterState<P, G, (), (), (), F>> for Landweber<F>
 where
     O: Gradient<Param = P, Gradient = G>,
     P: Clone + ArgminScaledSub<G, F, P>,
@@ -74,8 +74,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -130,7 +130,7 @@ impl<P, G, L, F> BacktrackingLineSearch<P, G, L, F>
 where
     P: ArgminScaledAdd<G, F, P>,
     L: LineSearchCondition<G, G, F>,
-    IterState<P, G, (), (), F>: State<Float = F>,
+    IterState<P, G, (), (), (), F>: State<Float = F>,
     F: ArgminFloat,
 {
     /// Perform a single backtracking step
@@ -591,10 +591,10 @@ mod tests {
         assert_eq!(
             <BacktrackingLineSearch<Vec<f64>, Vec<f64>, ArmijoCondition<f64>, f64> as Solver<
                 TestProblem,
-                IterState<Vec<f64>, Vec<f64>, (), (), f64>,
+                IterState<Vec<f64>, Vec<f64>, (), (), (), f64>,
             >>::terminate(
                 &mut ls,
-                &IterState::<Vec<f64>, Vec<f64>, (), (), f64>::new().param(init_param)
+                &IterState::<Vec<f64>, Vec<f64>, (), (), (), f64>::new().param(init_param)
             ),
             TerminationStatus::Terminated(TerminationReason::SolverConverged)
         );
@@ -605,10 +605,10 @@ mod tests {
         assert_eq!(
             <BacktrackingLineSearch<Vec<f64>, Vec<f64>, ArmijoCondition<f64>, f64> as Solver<
                 TestProblem,
-                IterState<Vec<f64>, Vec<f64>, (), (), f64>,
+                IterState<Vec<f64>, Vec<f64>, (), (), (), f64>,
             >>::terminate(
                 &mut ls,
-                &IterState::<Vec<f64>, Vec<f64>, (), (), f64>::new().param(init_param)
+                &IterState::<Vec<f64>, Vec<f64>, (), (), (), f64>::new().param(init_param)
             ),
             TerminationStatus::NotTerminated
         );

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -495,7 +495,7 @@ impl<P, G, F> LineSearch<G, F> for HagerZhangLineSearch<P, G, F> {
     }
 }
 
-impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for HagerZhangLineSearch<P, G, F>
+impl<P, G, O, F> Solver<O, IterState<P, G, (), (), (), F>> for HagerZhangLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<G, F, P>,
@@ -507,8 +507,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         check_param!(
             self.search_direction,
             concat!(
@@ -572,8 +572,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         // L1
         let aa = (self.a_x, self.a_f, self.a_g);
         let bb = (self.b_x, self.b_f, self.b_g);
@@ -622,7 +622,7 @@ where
         Ok((state.param(new_param).cost(self.best_f), None))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, G, (), (), F>) -> TerminationStatus {
+    fn terminate(&mut self, _state: &IterState<P, G, (), (), (), F>) -> TerminationStatus {
         if self.best_f - self.finit <= self.delta * self.best_x * self.dginit
             && self.best_g >= self.sigma * self.dginit
         {

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -296,7 +296,7 @@ where
     }
 }
 
-impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for MoreThuenteLineSearch<P, G, F>
+impl<P, G, O, F> Solver<O, IterState<P, G, (), (), (), F>> for MoreThuenteLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<G, F, P>,
@@ -308,8 +308,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         check_param!(
             self.search_direction,
             concat!(
@@ -372,8 +372,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         // set the minimum and maximum steps to correspond to the present interval of uncertainty
         let mut info = 0;
         let (stmin, stmax) = if self.brackt {

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -690,7 +690,7 @@ mod tests {
             (vec![-0.5, 2.0], 0.5f64.powi(2) + 2.0f64.powi(2)),
         ];
         let mut nm: NelderMead<_, f64> = NelderMead::new(params);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let problem = MwProblem {};
         let (state_out, kv) = nm.init(&mut Problem::new(problem), state).unwrap();
 
@@ -721,7 +721,7 @@ mod tests {
     fn test_next_iter_reflection() {
         let params: Vec<Vec<f64>> = vec![vec![-1.0, 0.0], vec![-0.1, 0.65], vec![-0.1, -0.95]];
         let mut nm: NelderMead<_, f64> = NelderMead::new(params);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let mut problem = Problem::new(MwProblem {});
         let (state, _) = nm.init(&mut problem, state).unwrap();
 
@@ -764,7 +764,7 @@ mod tests {
             vec![-1.0, -1.0 - f64::EPSILON],
         ];
         let mut nm: NelderMead<_, f64> = NelderMead::new(params);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let mut problem = Problem::new(MwProblem {});
         let (state, _) = nm.init(&mut problem, state).unwrap();
 
@@ -800,7 +800,7 @@ mod tests {
     fn test_next_iter_contraction_outside() {
         let params: Vec<Vec<f64>> = vec![vec![-1.1, 0.0], vec![-0.1, 1.0], vec![-0.1, -0.5]];
         let mut nm: NelderMead<_, f64> = NelderMead::new(params);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let mut problem = Problem::new(MwProblem {});
         let (state, _) = nm.init(&mut problem, state).unwrap();
 
@@ -836,7 +836,7 @@ mod tests {
     fn test_next_iter_contraction_inside() {
         let params: Vec<Vec<f64>> = vec![vec![-1.0, 0.0], vec![0.0, 1.0], vec![0.0, -0.5]];
         let mut nm: NelderMead<_, f64> = NelderMead::new(params);
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let mut problem = Problem::new(MwProblem {});
         let (state, _) = nm.init(&mut problem, state).unwrap();
 

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -316,7 +316,7 @@ impl fmt::Display for Action {
     }
 }
 
-impl<O, P, F> Solver<O, IterState<P, (), (), (), F>> for NelderMead<P, F>
+impl<O, P, F> Solver<O, IterState<P, (), (), (), (), F>> for NelderMead<P, F>
 where
     O: CostFunction<Param = P, Output = F>,
     P: Clone + SerializeAlias + ArgminSub<P, P> + ArgminAdd<P, P> + ArgminMul<F, P>,
@@ -327,8 +327,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         self.params
             .iter_mut()
             .for_each(|(p, c)| *c = problem.cost(p).unwrap());
@@ -344,8 +344,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         let num_param_vecs = self.params.len();
 
         let x0 = self.calculate_centroid();
@@ -413,7 +413,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
+    fn terminate(&mut self, _state: &IterState<P, (), (), (), (), F>) -> TerminationStatus {
         let n = float!(self.params.len() as f64);
         let c0: F = self.params.iter().map(|(_, c)| *c).sum::<F>() / n;
         let s: F = (float!(1.0) / (n - float!(1.0))

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<O, L, P, G, H, R, F> Solver<O, IterState<P, G, (), H, R, F>> for NewtonCG<L, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, (), F>> for NewtonCG<L, F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone
@@ -120,17 +120,16 @@ where
         + ArgminZeroLike,
     G: SerializeAlias + DeserializeOwnedAlias + ArgminL2Norm<F> + ArgminMul<F, P>,
     H: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminDot<P, P>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), R, F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat + ArgminL2Norm<F>,
-    R: Clone + SerializeAlias + DeserializeOwnedAlias,
 {
     const NAME: &'static str = "Newton-CG";
 
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, R, F>,
-    ) -> Result<(IterState<P, G, (), H, R, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -211,7 +210,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, R, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         if (state.get_cost() - state.get_prev_cost()).abs() < self.tol {
             TerminationStatus::Terminated(TerminationReason::SolverConverged)
         } else {

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for NewtonCG<L, F>
+impl<O, L, P, G, H, R, F> Solver<O, IterState<P, G, (), H, R, F>> for NewtonCG<L, F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone
@@ -120,16 +120,17 @@ where
         + ArgminZeroLike,
     G: SerializeAlias + DeserializeOwnedAlias + ArgminL2Norm<F> + ArgminMul<F, P>,
     H: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminDot<P, P>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), R, F>>,
     F: ArgminFloat + ArgminL2Norm<F>,
+    R: Clone + SerializeAlias + DeserializeOwnedAlias,
 {
     const NAME: &'static str = "Newton-CG";
 
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, R, F>,
+    ) -> Result<(IterState<P, G, (), H, R, F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -153,7 +154,8 @@ where
         let mut x = param.zero_like();
         let mut cg = ConjugateGradient::new(grad.mul(&(float!(-1.0))));
 
-        let (mut cg_state, _) = cg.init(&mut cg_problem, IterState::new().param(x_p.clone()))?;
+        let (mut cg_state, _): (IterState<_, _, _, _, _, _>, _) =
+            cg.init(&mut cg_problem, IterState::new().param(x_p.clone()))?;
 
         let grad_norm_factor = float!(0.5).min(grad.l2_norm().sqrt()) * grad.l2_norm();
 
@@ -209,7 +211,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, R, F>) -> TerminationStatus {
         if (state.get_cost() - state.get_prev_cost()).abs() < self.tol {
             TerminationStatus::Terminated(TerminationReason::SolverConverged)
         } else {

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<O, P, G, H, R, F> Solver<O, IterState<P, G, (), H, R, F>> for Newton<F>
+impl<O, P, G, H, F> Solver<O, IterState<P, G, (), H, (), F>> for Newton<F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone + ArgminScaledSub<P, F, P>,
@@ -97,8 +97,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, R, F>,
-    ) -> Result<(IterState<P, G, (), H, R, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<O, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for Newton<F>
+impl<O, P, G, H, R, F> Solver<O, IterState<P, G, (), H, R, F>> for Newton<F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone + ArgminScaledSub<P, F, P>,
@@ -97,8 +97,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, R, F>,
+    ) -> Result<(IterState<P, G, (), H, R, F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -398,7 +398,7 @@ mod tests {
         let mut bfgs: BFGS<_, f64> = BFGS::new(linesearch);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = bfgs.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -411,7 +411,7 @@ mod tests {
         );
 
         // Forgot initial inverse Hessian guess
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let res = bfgs.init(&mut Problem::new(problem), state);
@@ -426,7 +426,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param.clone())
             .inv_hessian(inv_hessian.clone());
         let problem = TestProblem::new();
@@ -468,7 +468,7 @@ mod tests {
 
         let mut bfgs: BFGS<_, f64> = BFGS::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .cost(1234.0);
@@ -491,7 +491,7 @@ mod tests {
 
         let mut bfgs: BFGS<_, f64> = BFGS::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .gradient(gradient.clone());

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -131,7 +131,7 @@ where
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for BFGS<L, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, (), F>> for BFGS<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -156,7 +156,7 @@ where
         + ArgminMul<F, H>
         + ArgminTranspose<H>
         + ArgminEye,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "BFGS";
@@ -164,8 +164,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -207,8 +207,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`BFGS`: Parameter vector in state not set."
@@ -294,7 +294,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for DFP<L, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, (), F>> for DFP<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -119,7 +119,7 @@ where
         + ArgminDot<G, P>
         + ArgminAdd<H, H>
         + ArgminMul<F, H>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "DFP";
@@ -127,8 +127,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -170,8 +170,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`DFP`: Parameter vector in state not set."
@@ -244,7 +244,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -316,7 +316,7 @@ mod tests {
         let mut dfp: DFP<_, f64> = DFP::new(linesearch);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = dfp.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -329,7 +329,7 @@ mod tests {
         );
 
         // Forgot initial inverse Hessian guess
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let res = dfp.init(&mut Problem::new(problem), state);
@@ -344,7 +344,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param.clone())
             .inv_hessian(inv_hessian.clone());
         let problem = TestProblem::new();
@@ -386,7 +386,7 @@ mod tests {
 
         let mut dfp: DFP<_, f64> = DFP::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .cost(1234.0);
@@ -409,7 +409,7 @@ mod tests {
 
         let mut dfp: DFP<_, f64> = DFP::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .gradient(gradient.clone());

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -302,7 +302,7 @@ where
     }
 }
 
-impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), F>> for LBFGS<L, P, G, F>
+impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), (), F>> for LBFGS<L, P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -335,7 +335,9 @@ where
         + ArgminMul<F, P>
         + ArgminZeroLike
         + ArgminMinMax,
-    L: Clone + LineSearch<P, F> + Solver<LineSearchProblem<O, P, G, F>, IterState<P, G, (), (), F>>,
+    L: Clone
+        + LineSearch<P, F>
+        + Solver<LineSearchProblem<O, P, G, F>, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "L-BFGS";
@@ -343,8 +345,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -375,8 +377,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`L-BFGS`: Parameter vector in state not set."
@@ -493,7 +495,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), (), F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), (), (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/argmin/src/solver/quasinewton/lbfgs.rs
@@ -611,7 +611,7 @@ mod tests {
         let mut lbfgs: LBFGS<_, Vec<f64>, Vec<f64>, f64> = LBFGS::new(linesearch, 3);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), (), (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = lbfgs.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -624,7 +624,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), (), f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), (), (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let (mut state_out, kv) = lbfgs.init(&mut Problem::new(problem), state).unwrap();
@@ -654,7 +654,7 @@ mod tests {
 
         let mut lbfgs: LBFGS<_, Vec<f64>, Vec<f64>, f64> = LBFGS::new(linesearch, 3);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), (), f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), (), (), f64> =
             IterState::new().param(param).cost(1234.0);
 
         let problem = TestProblem::new();
@@ -674,7 +674,7 @@ mod tests {
 
         let mut lbfgs: LBFGS<_, Vec<f64>, Vec<f64>, f64> = LBFGS::new(linesearch, 3);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), (), f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), (), (), f64> =
             IterState::new().param(param).gradient(gradient.clone());
 
         let problem = TestProblem::new();

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -424,7 +424,7 @@ mod tests {
         let mut sr1: SR1<_, f64> = SR1::new(linesearch);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = sr1.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -437,7 +437,7 @@ mod tests {
         );
 
         // Forgot initial inverse Hessian guess
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let res = sr1.init(&mut Problem::new(problem), state);
@@ -452,7 +452,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param.clone())
             .inv_hessian(inv_hessian.clone());
         let problem = TestProblem::new();
@@ -494,7 +494,7 @@ mod tests {
 
         let mut sr1: SR1<_, f64> = SR1::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .cost(1234.0);
@@ -517,7 +517,7 @@ mod tests {
 
         let mut sr1: SR1<_, f64> = SR1::new(linesearch);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .inv_hessian(inv_hessian)
             .gradient(gradient.clone());

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -145,7 +145,7 @@ where
     }
 }
 
-impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for SR1<L, F>
+impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, (), F>> for SR1<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
@@ -169,7 +169,7 @@ where
         + ArgminDot<P, P>
         + ArgminAdd<H, H>
         + ArgminMul<F, H>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "SR1";
@@ -177,8 +177,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -219,8 +219,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`SR1`: Parameter vector in state not set."
@@ -291,7 +291,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -452,7 +452,7 @@ mod tests {
         let mut sr1: SR1TrustRegion<_, f64> = SR1TrustRegion::new(subproblem);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = sr1.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -465,7 +465,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let (mut state_out, kv) = sr1.init(&mut Problem::new(problem), state).unwrap();
@@ -495,7 +495,7 @@ mod tests {
 
         let mut sr1: SR1TrustRegion<_, f64> = SR1TrustRegion::new(subproblem);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param).cost(1234.0);
 
         let problem = TestProblem::new();
@@ -515,7 +515,7 @@ mod tests {
 
         let mut sr1: SR1TrustRegion<_, f64> = SR1TrustRegion::new(subproblem);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param).gradient(gradient.clone());
 
         let problem = TestProblem::new();
@@ -540,7 +540,7 @@ mod tests {
 
         let mut sr1: SR1TrustRegion<_, f64> = SR1TrustRegion::new(subproblem);
 
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new()
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new()
             .param(param)
             .gradient(gradient)
             .hessian(hessian.clone());

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-impl<O, R, P, G, B, F> Solver<O, IterState<P, G, (), B, F>> for SR1TrustRegion<R, F>
+impl<O, R, P, G, B, F> Solver<O, IterState<P, G, (), B, (), F>> for SR1TrustRegion<R, F>
 where
     O: CostFunction<Param = P, Output = F>
         + Gradient<Param = P, Gradient = G>
@@ -206,7 +206,7 @@ where
         + ArgminDot<P, P>
         + ArgminAdd<B, B>
         + ArgminMul<F, B>,
-    R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), B, F>>,
+    R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), B, (), F>>,
     F: ArgminFloat + ArgminL2Norm<F>,
 {
     const NAME: &'static str = "SR1 trust region";
@@ -214,8 +214,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), B, F>,
-    ) -> Result<(IterState<P, G, (), B, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), B, (), F>,
+    ) -> Result<(IterState<P, G, (), B, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -254,8 +254,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), B, F>,
-    ) -> Result<(IterState<P, G, (), B, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), B, (), F>,
+    ) -> Result<(IterState<P, G, (), B, (), F>, Option<KV>), Error> {
         let xk = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`SR1TrustRegion`: Parameter vector in state not set."
@@ -351,7 +351,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), B, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), B, (), F>) -> TerminationStatus {
         if state.get_gradient().unwrap().l2_norm() < self.tol_grad {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -843,7 +843,7 @@ mod tests {
             .with_reannealing_best(reanneal_best);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new();
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = sa.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -856,7 +856,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, (), (), (), f64> = IterState::new().param(param.clone());
+        let state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let (mut state_out, kv) = sa.init(&mut Problem::new(problem), state).unwrap();
 

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -435,7 +435,7 @@ where
     }
 }
 
-impl<O, P, F, R> Solver<O, IterState<P, (), (), (), F>> for SimulatedAnnealing<F, R>
+impl<O, P, F, R> Solver<O, IterState<P, (), (), (), (), F>> for SimulatedAnnealing<F, R>
 where
     O: CostFunction<Param = P, Output = F> + Anneal<Param = P, Output = P, Float = F>,
     P: Clone,
@@ -446,8 +446,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -480,8 +480,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, (), (), (), F>,
-    ) -> Result<(IterState<P, (), (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, (), (), (), (), F>,
+    ) -> Result<(IterState<P, (), (), (), (), F>, Option<KV>), Error> {
         // Careful: The order in here is *very* important, even if it may not seem so. Everything
         // is linked to the iteration number, and getting things mixed up may lead to unexpected
         // behavior.
@@ -552,7 +552,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, (), (), (), F>) -> TerminationStatus {
+    fn terminate(&mut self, _state: &IterState<P, (), (), (), (), F>) -> TerminationStatus {
         if self.stall_iter_accepted > self.stall_iter_accepted_limit {
             return TerminationStatus::Terminated(TerminationReason::SolverExit(
                 "AcceptedStallIterExceeded".to_string(),

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<O, F, P, G, H> Solver<O, IterState<P, G, (), H, F>> for CauchyPoint<F>
+impl<O, F, P, G, H> Solver<O, IterState<P, G, (), H, (), F>> for CauchyPoint<F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone + ArgminMul<F, P> + ArgminWeightedDot<P, F, H>,
@@ -63,8 +63,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -97,7 +97,7 @@ where
         Ok((state.param(new_param), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         // Not an iterative algorithm
         if state.get_iter() >= 1 {
             TerminationStatus::Terminated(TerminationReason::MaxItersReached)

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -153,7 +153,7 @@ mod tests {
         cp.set_radius(1.0);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = cp.next_iter(&mut Problem::new(problem), state);
         assert_error!(
@@ -166,7 +166,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param);
         let problem = TestProblem::new();
         let (mut state_out, kv) = cp.next_iter(&mut Problem::new(problem), state).unwrap();

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -53,7 +53,7 @@ where
     }
 }
 
-impl<O, F, P, H> Solver<O, IterState<P, P, (), H, F>> for Dogleg<F>
+impl<O, F, P, H> Solver<O, IterState<P, P, (), H, (), F>> for Dogleg<F>
 where
     O: Gradient<Param = P, Gradient = P> + Hessian<Param = P, Hessian = H>,
     P: Clone
@@ -70,8 +70,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, P, (), H, F>,
-    ) -> Result<(IterState<P, P, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, P, (), H, (), F>,
+    ) -> Result<(IterState<P, P, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -136,7 +136,7 @@ where
         Ok((state.param(pstar).gradient(g).hessian(h), None))
     }
 
-    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, P, (), H, (), F>) -> TerminationStatus {
         if state.get_iter() >= 1 {
             TerminationStatus::Terminated(TerminationReason::MaxItersReached)
         } else {

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -212,7 +212,7 @@ mod tests {
         dl.set_radius(1.0);
 
         // Forgot to initialize the parameter vector
-        let state: IterState<Array1<f64>, Array1<f64>, (), Array2<f64>, f64> = IterState::new();
+        let state: IterState<Array1<f64>, Array1<f64>, (), Array2<f64>, (), f64> = IterState::new();
         let problem = TestProblem {};
         let res = dl.next_iter(&mut Problem::new(problem), state);
         assert_error!(
@@ -225,7 +225,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Array1<f64>, Array1<f64>, (), Array2<f64>, f64> =
+        let state: IterState<Array1<f64>, Array1<f64>, (), Array2<f64>, (), f64> =
             IterState::new().param(param);
         let problem = TestProblem {};
         let (mut state_out, kv) = dl.next_iter(&mut Problem::new(problem), state).unwrap();

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -404,7 +404,7 @@ mod tests {
         sh.set_radius(1.0);
 
         // Forgot to initialize gradient
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = sh.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -417,7 +417,7 @@ mod tests {
         );
 
         // Forgot to initialize Hessian
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().gradient(grad.clone());
         let problem = TestProblem::new();
         let res = sh.init(&mut Problem::new(problem), state);
@@ -431,7 +431,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().gradient(grad.clone()).hessian(hessian);
         let problem = TestProblem::new();
         let (mut state_out, kv) = sh.init(&mut Problem::new(problem), state).unwrap();

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -178,7 +178,7 @@ where
     }
 }
 
-impl<P, O, F, H> Solver<O, IterState<P, P, (), H, F>> for Steihaug<P, F>
+impl<P, O, F, H> Solver<O, IterState<P, P, (), H, (), F>> for Steihaug<P, F>
 where
     P: Clone
         + SerializeAlias
@@ -195,8 +195,8 @@ where
     fn init(
         &mut self,
         _problem: &mut Problem<O>,
-        state: IterState<P, P, (), H, F>,
-    ) -> Result<(IterState<P, P, (), H, F>, Option<KV>), Error> {
+        state: IterState<P, P, (), H, (), F>,
+    ) -> Result<(IterState<P, P, (), H, (), F>, Option<KV>), Error> {
         let r = state
             .get_gradient()
             .ok_or_else(argmin_error_closure!(
@@ -232,8 +232,8 @@ where
     fn next_iter(
         &mut self,
         _problem: &mut Problem<O>,
-        mut state: IterState<P, P, (), H, F>,
-    ) -> Result<(IterState<P, P, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, P, (), H, (), F>,
+    ) -> Result<(IterState<P, P, (), H, (), F>, Option<KV>), Error> {
         let grad = state.take_gradient().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`Steihaug`: Gradient in state not set."
@@ -298,7 +298,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, state: &IterState<P, P, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, state: &IterState<P, P, (), H, (), F>) -> TerminationStatus {
         if self.r_0_norm < self.epsilon {
             return TerminationStatus::Terminated(TerminationReason::SolverConverged);
         }

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<O, R, F, P, G, H> Solver<O, IterState<P, G, (), H, F>> for TrustRegion<R, F>
+impl<O, R, F, P, G, H> Solver<O, IterState<P, G, (), H, (), F>> for TrustRegion<R, F>
 where
     O: CostFunction<Param = P, Output = F>
         + Gradient<Param = P, Gradient = G>
@@ -172,7 +172,7 @@ where
         + ArgminAdd<P, P>,
     G: Clone + SerializeAlias + DeserializeOwnedAlias,
     H: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminDot<P, P>,
-    R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), H, F>>,
+    R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), H, (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Trust region";
@@ -180,8 +180,8 @@ where
     fn init(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             NotInitialized,
             concat!(
@@ -221,8 +221,8 @@ where
     fn next_iter(
         &mut self,
         problem: &mut Problem<O>,
-        mut state: IterState<P, G, (), H, F>,
-    ) -> Result<(IterState<P, G, (), H, F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), H, (), F>,
+    ) -> Result<(IterState<P, G, (), H, (), F>, Option<KV>), Error> {
         let param = state.take_param().ok_or_else(argmin_error_closure!(
             PotentialBug,
             "`TrustRegion`: Parameter vector in state not set."
@@ -300,7 +300,7 @@ where
         ))
     }
 
-    fn terminate(&mut self, _state: &IterState<P, G, (), H, F>) -> TerminationStatus {
+    fn terminate(&mut self, _state: &IterState<P, G, (), H, (), F>) -> TerminationStatus {
         TerminationStatus::NotTerminated
     }
 }

--- a/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/argmin/src/solver/trustregion/trustregion_method.rs
@@ -402,7 +402,7 @@ mod tests {
         let mut tr: TrustRegion<_, f64> = TrustRegion::new(cp);
 
         // Forgot to initialize parameter vector
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> = IterState::new();
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> = IterState::new();
         let problem = TestProblem::new();
         let res = tr.init(&mut Problem::new(problem), state);
         assert_error!(
@@ -415,7 +415,7 @@ mod tests {
         );
 
         // All good.
-        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, f64> =
+        let state: IterState<Vec<f64>, Vec<f64>, (), Vec<Vec<f64>>, (), f64> =
             IterState::new().param(param.clone());
         let problem = TestProblem::new();
         let (mut state_out, kv) = tr.init(&mut Problem::new(problem), state).unwrap();

--- a/media/book/src/implementing_solver.md
+++ b/media/book/src/implementing_solver.md
@@ -85,7 +85,7 @@ impl<F> Landweber<F> {
     }
 }
 
-impl<O, F, P, G> Solver<O, IterState<P, G, (), (), F>> for Landweber<F>
+impl<O, F, P, G> Solver<O, IterState<P, G, (), (), (), F>> for Landweber<F>
 where
     // The Landweber solver requires `O` to implement `Gradient`. 
     // `P` and `G` indicate the types of the parameter vector and gradient,
@@ -111,8 +111,8 @@ where
         // vector, gradient, Hessian and cost function value of the current,
         // previous and best iteration as well as current iteration number, and
         // many more.
-        mut state: IterState<P, G, (), (), F>,
-    ) -> Result<(IterState<P, G, (), (), F>, Option<KV>), Error> {
+        mut state: IterState<P, G, (), (), (), F>,
+    ) -> Result<(IterState<P, G, (), (), (), F>, Option<KV>), Error> {
         // First we obtain the current parameter vector from the `state` struct (`x_k`).
         // Landweber requires an initial parameter vector. Return an error if this was 
         // not provided by the user.


### PR DESCRIPTION
I took a stab at updating the definition of IterState to support a fix for #342.   Library builds.  Tests likely don't build.  I currently don't have the ability to build the tests.
