### PR TITLE
Add trait f64 f32 for 1d inverse to ArgminInv

### DIFF
--- a/argmin-math/src/ndarray_m/inv.rs
+++ b/argmin-math/src/ndarray_m/inv.rs
@@ -22,6 +22,14 @@ macro_rules! make_inv {
                 Ok(<Self as Inverse>::inv(&self)?)
             }
         }
+
+        // inverse for scalars (1d solvers)
+        impl ArgminInv<$t> for $t {
+            #[inline]
+            fn inv(&self) -> Result<$t, Error> {
+                Ok(1.0 / self)
+            }
+        }
     };
 }
 
@@ -58,6 +66,16 @@ mod tests {
                             assert!((((res[(i, j)] - target[(i, j)]) as f64).abs()) < 0.000001);
                         }
                     }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_inv_scalar_ $t>]() {
+                    let a = 2.0;
+                    let target = 0.5;
+                    let res = <$t as ArgminInv<$t>>::inv(&a).unwrap();
+                    assert!(((res - target) as f64).abs() < 0.000001);
                 }
             }
         };


### PR DESCRIPTION
I tried to implement the f64/f32 standard inverse for the ArgminInv (modification in the implementation of inv for ndarray).
I also added a test for it.

For unknown compilation reasons on my machine (admittedly weird linux conf), I could not run the test nor use the library locally to check if that works. I will have to look later into it.

I am also not sure if this is what was needed (as a fully newcomer into rust).


**Short Update:** I could run the optimization for scalar function, it seems to work. I am not sure how to get the resulting `get_best_param` or `get_param` in the end, it seems that this function changed in 0.8.