### PR TITLE
SlogLogger emit data config

### DIFF
--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -572,6 +572,8 @@ mod tests {
     #[test]
     #[cfg(feature = "serde1")]
     fn test_checkpointing_solver_initialization() {
+        use std::fmt::Debug;
+
         use crate::core::checkpointing::{CheckpointingFrequency, FileCheckpoint};
         use crate::core::test_utils::TestProblem;
         use crate::core::{ArgminFloat, CostFunction};
@@ -588,7 +590,7 @@ mod tests {
         impl<O, P, F> Solver<O, IterState<P, (), (), (), F>> for OptimizationAlgorithm
         where
             O: CostFunction<Param = P, Output = F>,
-            P: Clone,
+            P: Clone + Debug,
             F: ArgminFloat,
         {
             const NAME: &'static str = "OptimizationAlgorithm";

--- a/argmin/src/core/mod.rs
+++ b/argmin/src/core/mod.rs
@@ -53,5 +53,5 @@ pub use problem::{CostFunction, Gradient, Hessian, Jacobian, LinearProgram, Oper
 pub use result::OptimizationResult;
 pub use serialization::{DeserializeOwnedAlias, SerializeAlias};
 pub use solver::Solver;
-pub use state::{IterState, LinearProgramState, PopulationState, State};
+pub use state::{IterState, LinearProgramState, PopulationState, State, StateData};
 pub use termination::{TerminationReason, TerminationStatus};

--- a/argmin/src/core/observers/slog_logger.rs
+++ b/argmin/src/core/observers/slog_logger.rs
@@ -13,6 +13,7 @@
 //! See [`SlogLogger`] for details regarding usage.
 
 use crate::core::observers::Observe;
+use crate::core::state::StateData;
 use crate::core::{Error, State, KV};
 use slog;
 use slog::{info, o, Drain, Key, Record, Serializer};
@@ -31,9 +32,38 @@ use std::sync::Mutex;
 pub struct SlogLogger {
     /// the logger
     logger: slog::Logger,
+    /// Data to log. It is logged in order. Duplicates are not checked.
+    log_data: Vec<StateData>,
 }
 
 impl SlogLogger {
+    /// Specify the data to log. Data is logged in the order that it is specified
+    /// in the input `log_data` and duplicates are not removed.
+    ///
+    /// The available data is any value obtained via the methods defined in the
+    /// [`State`] trait.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use argmin::core::observers::SlogLogger;
+    /// use argmin::core::StateData;
+    ///
+    /// // Default is to log function counts, best cost, cost, and iter. Modify
+    /// // it to also log the current parameters.
+    /// let mut log_data = Vec::new();
+    /// log_data.push(StateData::FunctionCounts);
+    /// log_data.push(StateData::BestCost);
+    /// log_data.push(StateData::Cost);
+    /// log_data.push(StateData::Iter);
+    /// log_data.push(StateData::Param);
+    /// let terminal_logger = SlogLogger::term().data(log_data);
+    /// ```
+    pub fn data(&mut self, log_data: Vec<StateData>) -> &mut Self {
+        self.log_data = log_data;
+        self
+    }
+
     /// Log to the terminal.
     ///
     /// Will block execution when buffer is full.
@@ -75,8 +105,15 @@ impl SlogLogger {
             .overflow_strategy(overflow_strategy)
             .build()
             .fuse();
+        let log_data = vec![
+            StateData::FunctionCounts,
+            StateData::BestCost,
+            StateData::Cost,
+            StateData::Iter,
+        ];
         SlogLogger {
             logger: slog::Logger::root(drain, o!()),
+            log_data,
         }
     }
 
@@ -138,8 +175,15 @@ impl SlogLogger {
             .overflow_strategy(overflow_strategy)
             .build()
             .fuse();
+        let log_data = vec![
+            StateData::FunctionCounts,
+            StateData::BestCost,
+            StateData::Cost,
+            StateData::Iter,
+        ];
         Ok(SlogLogger {
             logger: slog::Logger::root(drain, o!()),
+            log_data,
         })
     }
 }
@@ -153,18 +197,67 @@ impl slog::KV for KV {
     }
 }
 
-struct LogState<I>(I);
+struct LogState<'a, I>(I, &'a [StateData]);
 
-impl<I> slog::KV for LogState<&'_ I>
+impl<'a, I> slog::KV for LogState<'a, &I>
 where
     I: State,
 {
     fn serialize(&self, _record: &Record, serializer: &mut dyn Serializer) -> slog::Result {
+        let state = self.0;
+        for data in self.1 {
+            let key = Key::from(data.to_string());
+            match data {
+                StateData::BestCost => {
+                    serializer.emit_str(key, &state.get_best_cost().to_string())?;
+                }
+                StateData::BestParam => {
+                    let param = state
+                        .get_best_param()
+                        .map_or("None".to_string(), |p| format!("{:?}", p));
+                    serializer.emit_str(key, &param)?;
+                }
+                StateData::Cost => {
+                    serializer.emit_str(key, &self.0.get_cost().to_string())?;
+                }
+                StateData::FunctionCounts => {
+                    for (k, &v) in state.get_func_counts().iter() {
+                        serializer.emit_u64(Key::from(k.clone()), v)?;
+                    }
+                }
+                StateData::IsBest => serializer.emit_bool(key, state.is_best())?,
+                StateData::Iter => serializer.emit_u64(key, state.get_iter())?,
+                StateData::LastBestIter => serializer.emit_u64(key, state.get_last_best_iter())?,
+                StateData::MaxIters => serializer.emit_u64(key, state.get_max_iters())?,
+                StateData::Param => {
+                    let param = state
+                        .get_param()
+                        .map_or("None".to_string(), |p| format!("{:?}", p));
+                    serializer.emit_str(Key::from(key), &param)?;
+                }
+                StateData::TargetCost => {
+                    serializer.emit_str(key, &state.get_target_cost().to_string())?
+                }
+                StateData::TerminationReason => serializer.emit_str(
+                    key,
+                    state.get_termination_reason().map_or("None", |r| r.text()),
+                )?,
+                StateData::TerminationStatus => {
+                    serializer.emit_str(key, &state.get_termination_status().to_string())?
+                }
+                StateData::Time => serializer.emit_str(
+                    key,
+                    &state
+                        .get_time()
+                        .map_or("None".to_string(), |t| format!("{:?}", t)),
+                )?,
+            }
+        }
         for (k, &v) in self.0.get_func_counts().iter() {
             serializer.emit_u64(Key::from(k.clone()), v)?;
         }
         serializer.emit_str(Key::from("best_cost"), &self.0.get_best_cost().to_string())?;
-        serializer.emit_str(Key::from("cost"), &self.0.get_cost().to_string())?;
+
         serializer.emit_u64(Key::from("iter"), self.0.get_iter())?;
         Ok(())
     }
@@ -182,7 +275,7 @@ where
 
     /// Logs information about the progress of the optimization after every iteration.
     fn observe_iter(&mut self, state: &I, kv: &KV) -> Result<(), Error> {
-        info!(self.logger, ""; LogState(state), kv);
+        info!(self.logger, ""; LogState(state, &self.log_data), kv);
         Ok(())
     }
 }

--- a/argmin/src/core/observers/slog_logger.rs
+++ b/argmin/src/core/observers/slog_logger.rs
@@ -233,7 +233,7 @@ where
                     let param = state
                         .get_param()
                         .map_or("None".to_string(), |p| format!("{:?}", p));
-                    serializer.emit_str(Key::from(key), &param)?;
+                    serializer.emit_str(key, &param)?;
                 }
                 StateData::TargetCost => {
                     serializer.emit_str(key, &state.get_target_cost().to_string())?

--- a/argmin/src/core/observers/slog_logger.rs
+++ b/argmin/src/core/observers/slog_logger.rs
@@ -253,12 +253,6 @@ where
                 )?,
             }
         }
-        for (k, &v) in self.0.get_func_counts().iter() {
-            serializer.emit_u64(Key::from(k.clone()), v)?;
-        }
-        serializer.emit_str(Key::from("best_cost"), &self.0.get_best_cost().to_string())?;
-
-        serializer.emit_u64(Key::from("iter"), self.0.get_iter())?;
         Ok(())
     }
 }

--- a/argmin/src/core/solver.rs
+++ b/argmin/src/core/solver.rs
@@ -20,6 +20,7 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 /// # Example
 ///
 /// ```
+/// use std::fmt::Debug;
 /// use argmin::core::{
 ///     ArgminFloat, Solver, IterState, CostFunction, Error, KV, Problem, TerminationReason, TerminationStatus
 /// };
@@ -33,7 +34,7 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 /// impl<O, P, G, J, H, F> Solver<O, IterState<P, G, J, H, F>> for OptimizationAlgorithm
 /// where
 ///     O: CostFunction<Param = P, Output = F>,
-///     P: Clone,
+///     P: Clone + Debug,
 ///     F: ArgminFloat
 /// {
 ///     const NAME: &'static str = "OptimizationAlgorithm";

--- a/argmin/src/core/state/iterstate.rs
+++ b/argmin/src/core/state/iterstate.rs
@@ -9,7 +9,7 @@ use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationSta
 use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 /// Maintains the state from iteration to iteration of a solver
 ///
@@ -864,7 +864,7 @@ where
 
 impl<P, G, J, H, F> State for IterState<P, G, J, H, F>
 where
-    P: Clone,
+    P: Clone + Debug,
     F: ArgminFloat,
 {
     /// Type of parameter vector

--- a/argmin/src/core/state/linearprogramstate.rs
+++ b/argmin/src/core/state/linearprogramstate.rs
@@ -9,7 +9,7 @@ use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationSta
 use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 /// Maintains the state from iteration to iteration of a solver
 ///
@@ -155,7 +155,7 @@ impl<P, F> LinearProgramState<P, F> {
 
 impl<P, F> State for LinearProgramState<P, F>
 where
-    P: Clone,
+    P: Clone + Debug,
     F: ArgminFloat,
 {
     /// Type of parameter vector

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -14,7 +14,46 @@ pub use linearprogramstate::LinearProgramState;
 pub use populationstate::PopulationState;
 
 use crate::core::{ArgminFloat, Problem, TerminationReason, TerminationStatus};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, fmt::Debug};
+
+/// A set of values that can be queried using the [`State`] trait. Useful to configure
+/// an observer.
+#[derive(Copy, Clone, Debug)]
+pub enum StateData {
+    Param,
+    BestParam,
+    MaxIters,
+    Iter,
+    Cost,
+    BestCost,
+    TargetCost,
+    FunctionCounts,
+    Time,
+    LastBestIter,
+    IsBest,
+    TerminationStatus,
+    TerminationReason,
+}
+
+impl fmt::Display for StateData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StateData::BestCost => write!(f, "best_cost"),
+            StateData::BestParam => write!(f, "best_param"),
+            StateData::Cost => write!(f, "cost"),
+            StateData::FunctionCounts => write!(f, "function_counts"),
+            StateData::IsBest => write!(f, "is_best"),
+            StateData::Iter => write!(f, "iter"),
+            StateData::LastBestIter => write!(f, "last_best_iter"),
+            StateData::MaxIters => write!(f, "max_iters"),
+            StateData::Param => write!(f, "param"),
+            StateData::TargetCost => write!(f, "target_cost"),
+            StateData::TerminationReason => write!(f, "termination_reason"),
+            StateData::TerminationStatus => write!(f, "termination_status"),
+            StateData::Time => write!(f, "time"),
+        }
+    }
+}
 
 /// Minimal interface which struct used for managing state in solvers have to implement.
 ///
@@ -44,7 +83,7 @@ use std::collections::HashMap;
 /// for this (so far f32 and f64).
 pub trait State {
     /// Type of parameter vector
-    type Param;
+    type Param: Debug;
     /// Floating point precision (f32 or f64)
     type Float: ArgminFloat;
 

--- a/argmin/src/core/state/mod.rs
+++ b/argmin/src/core/state/mod.rs
@@ -20,18 +20,31 @@ use std::{collections::HashMap, fmt, fmt::Debug};
 /// an observer.
 #[derive(Copy, Clone, Debug)]
 pub enum StateData {
+    /// The Param data
     Param,
+    /// The best param data
     BestParam,
+    /// The maximum number of iterations
     MaxIters,
+    /// The iteration number
     Iter,
+    /// The cost of the current iteration
     Cost,
+    /// The best cost so far
     BestCost,
+    /// The target cost
     TargetCost,
+    /// How many times each function within the solver has been called
     FunctionCounts,
+    /// The current time
     Time,
+    /// Which iteration the last best cost was found
     LastBestIter,
+    /// Boolean of if this iteration is the best
     IsBest,
+    /// Basic yes/no status of if the solver has terminated
     TerminationStatus,
+    /// If the solver has terminated, what was the reason
     TerminationReason,
 }
 

--- a/argmin/src/core/state/populationstate.rs
+++ b/argmin/src/core/state/populationstate.rs
@@ -9,7 +9,7 @@ use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationSta
 use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 /// Maintains the state from iteration to iteration of a population-based solver
 ///
@@ -434,7 +434,7 @@ where
 
 impl<P, F> State for PopulationState<P, F>
 where
-    P: Clone,
+    P: Clone + Debug,
     F: ArgminFloat,
 {
     /// Type of an individual

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, Error, IterState, Operator, Problem, SerializeAlias, Solver, State, KV,
 };
@@ -93,6 +95,7 @@ impl<P, O, F> Solver<O, IterState<P, (), (), (), F>> for ConjugateGradient<P, F>
 where
     O: Operator<Param = P, Output = P>,
     P: Clone
+        + Debug
         + SerializeAlias
         + ArgminDot<P, F>
         + ArgminSub<P, P>

--- a/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, NLCGBetaUpdate, OptimizationResult, Problem, SerializeAlias, Solver, State, KV,
@@ -122,7 +124,7 @@ impl<O, P, G, L, B, F> Solver<O, IterState<P, G, (), (), F>>
     for NonlinearConjugateGradient<P, L, B, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminAdd<P, P> + ArgminMul<F, P>,
+    P: Clone + Debug + SerializeAlias + DeserializeOwnedAlias + ArgminAdd<P, P> + ArgminMul<F, P>,
     G: Clone
         + SerializeAlias
         + DeserializeOwnedAlias

--- a/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     Jacobian, LineSearch, Operator, OptimizationResult, Problem, SerializeAlias, Solver,
@@ -84,7 +86,7 @@ impl<L, F: ArgminFloat> GaussNewtonLS<L, F> {
 impl<O, L, F, P, G, J, U> Solver<O, IterState<P, G, J, (), F>> for GaussNewtonLS<L, F>
 where
     O: Operator<Param = P, Output = U> + Jacobian<Param = P, Jacobian = J>,
-    P: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, P>,
+    P: Clone + Debug + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, P>,
     G: Clone + SerializeAlias + DeserializeOwnedAlias,
     U: ArgminL2Norm<F>,
     J: Clone

--- a/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, Error, IterState, Jacobian, Operator, Problem, Solver, State, TerminationReason,
     TerminationStatus, KV,
@@ -112,7 +114,7 @@ impl<F: ArgminFloat> Default for GaussNewton<F> {
 impl<O, F, P, J, U> Solver<O, IterState<P, (), J, (), F>> for GaussNewton<F>
 where
     O: Operator<Param = P, Output = U> + Jacobian<Param = P, Jacobian = J>,
-    P: Clone + ArgminSub<P, P> + ArgminMul<F, P>,
+    P: Clone + Debug + ArgminSub<P, P> + ArgminMul<F, P>,
     U: ArgminL2Norm<F>,
     J: Clone
         + ArgminTranspose<J>

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, KV,
@@ -53,7 +55,7 @@ impl<L> SteepestDescent<L> {
 impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), F>> for SteepestDescent<L>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + DeserializeOwnedAlias,
+    P: Clone + Debug + SerializeAlias + DeserializeOwnedAlias,
     G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, P>,
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
     F: ArgminFloat,

--- a/argmin/src/solver/landweber/mod.rs
+++ b/argmin/src/solver/landweber/mod.rs
@@ -17,6 +17,8 @@
 //!
 //! <https://en.wikipedia.org/wiki/Landweber_iteration>
 
+use std::fmt::Debug;
+
 use crate::core::{ArgminFloat, Error, Gradient, IterState, Problem, Solver, KV};
 use argmin_math::ArgminScaledSub;
 #[cfg(feature = "serde1")]
@@ -66,7 +68,7 @@ impl<F> Landweber<F> {
 impl<O, F, P, G> Solver<O, IterState<P, G, (), (), F>> for Landweber<F>
 where
     O: Gradient<Param = P, Gradient = G>,
-    P: Clone + ArgminScaledSub<G, F, P>,
+    P: Clone + Debug + ArgminScaledSub<G, F, P>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Landweber";

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
     Solver, State, TerminationReason, TerminationStatus, KV,
@@ -176,7 +178,7 @@ where
 
 impl<O, P, G, L, F> Solver<O, IterState<P, G, (), (), F>> for BacktrackingLineSearch<P, G, L, F>
 where
-    P: Clone + SerializeAlias + ArgminScaledAdd<P, F, P>,
+    P: Clone + Debug + SerializeAlias + ArgminScaledAdd<P, F, P>,
     G: SerializeAlias + ArgminScaledAdd<P, F, P>,
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     L: LineSearchCondition<P, G, F> + SerializeAlias,

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, Error, Gradient, IterState, LineSearch, Problem, SerializeAlias,
     Solver, TerminationReason, TerminationStatus, KV,
@@ -496,7 +498,7 @@ impl<P, G, F> LineSearch<P, F> for HagerZhangLineSearch<P, G, F> {
 impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for HagerZhangLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
+    P: Clone + Debug + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
     G: Clone + SerializeAlias + ArgminDot<P, F>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -16,7 +16,7 @@ use crate::core::{
 use argmin_math::{ArgminDot, ArgminScaledAdd};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
+use std::{default::Default, fmt::Debug};
 
 /// # More-Thuente line search
 ///
@@ -299,7 +299,7 @@ where
 impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for MoreThuenteLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
+    P: Clone + Debug + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
     G: Clone + SerializeAlias + ArgminDot<P, F>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/neldermead/mod.rs
+++ b/argmin/src/solver/neldermead/mod.rs
@@ -25,7 +25,7 @@ use crate::core::{
 use argmin_math::{ArgminAdd, ArgminMul, ArgminSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::fmt::{self, Debug};
 
 /// # Nelder-Mead method
 ///
@@ -319,7 +319,7 @@ impl fmt::Display for Action {
 impl<O, P, F> Solver<O, IterState<P, (), (), (), F>> for NelderMead<P, F>
 where
     O: CostFunction<Param = P, Output = F>,
-    P: Clone + SerializeAlias + ArgminSub<P, P> + ArgminAdd<P, P> + ArgminMul<F, P>,
+    P: Clone + Debug + SerializeAlias + ArgminSub<P, P> + ArgminAdd<P, P> + ArgminMul<F, P>,
     F: ArgminFloat + std::iter::Sum<F>,
 {
     const NAME: &'static str = "Nelder-Mead method";

--- a/argmin/src/solver/newton/newton_cg.rs
+++ b/argmin/src/solver/newton/newton_cg.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian, IterState, LineSearch,
     Operator, OptimizationResult, Problem, SerializeAlias, Solver, State, TerminationReason,
@@ -110,6 +112,7 @@ impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for NewtonCG<L, F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
     P: Clone
+        + Debug
         + SerializeAlias
         + DeserializeOwnedAlias
         + ArgminSub<P, P>

--- a/argmin/src/solver/newton/newton_method.rs
+++ b/argmin/src/solver/newton/newton_method.rs
@@ -9,7 +9,7 @@ use crate::core::{ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Sol
 use argmin_math::{ArgminDot, ArgminInv, ArgminScaledSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
+use std::{default::Default, fmt::Debug};
 
 /// # Newton's method
 ///
@@ -88,7 +88,7 @@ where
 impl<O, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for Newton<F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
-    P: Clone + ArgminScaledSub<P, F, P>,
+    P: Clone + Debug + ArgminScaledSub<P, F, P>,
     H: ArgminInv<H> + ArgminDot<G, P>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -20,6 +20,8 @@
 //!
 //! \[1\] <https://en.wikipedia.org/wiki/Particle_swarm_optimization>
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, Error, PopulationState, Problem, SerializeAlias, Solver, SyncAlias,
     KV,
@@ -235,6 +237,7 @@ where
     O: CostFunction<Param = P, Output = F> + SyncAlias,
     P: SerializeAlias
         + Clone
+        + Debug
         + SyncAlias
         + ArgminAdd<P, P>
         + ArgminSub<P, P>

--- a/argmin/src/solver/quasinewton/bfgs.rs
+++ b/argmin/src/solver/quasinewton/bfgs.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
@@ -135,6 +137,7 @@ impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for BFGS<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
+        + Debug
         + SerializeAlias
         + DeserializeOwnedAlias
         + ArgminSub<P, P>

--- a/argmin/src/solver/quasinewton/dfp.rs
+++ b/argmin/src/solver/quasinewton/dfp.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
@@ -100,6 +102,7 @@ impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for DFP<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
+        + Debug
         + SerializeAlias
         + DeserializeOwnedAlias
         + ArgminSub<P, P>

--- a/argmin/src/solver/quasinewton/sr1.rs
+++ b/argmin/src/solver/quasinewton/sr1.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, IterState,
     LineSearch, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
@@ -149,6 +151,7 @@ impl<O, L, P, G, H, F> Solver<O, IterState<P, G, (), H, F>> for SR1<L, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone
+        + Debug
         + SerializeAlias
         + DeserializeOwnedAlias
         + ArgminSub<P, P>

--- a/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, DeserializeOwnedAlias, Error, Executor, Gradient, Hessian,
     IterState, OptimizationResult, Problem, SerializeAlias, Solver, TerminationReason,
@@ -186,6 +188,7 @@ where
         + Gradient<Param = P, Gradient = G>
         + Hessian<Param = P, Hessian = B>,
     P: Clone
+        + Debug
         + SerializeAlias
         + DeserializeOwnedAlias
         + ArgminSub<P, P>

--- a/argmin/src/solver/simulatedannealing/mod.rs
+++ b/argmin/src/solver/simulatedannealing/mod.rs
@@ -18,6 +18,8 @@
 //! Science 13 May 1983, Vol. 220, Issue 4598, pp. 671-680
 //! DOI: 10.1126/science.220.4598.671
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, CostFunction, Error, IterState, Problem, SerializeAlias, Solver,
     TerminationReason, TerminationStatus, KV,
@@ -438,7 +440,7 @@ where
 impl<O, P, F, R> Solver<O, IterState<P, (), (), (), F>> for SimulatedAnnealing<F, R>
 where
     O: CostFunction<Param = P, Output = F> + Anneal<Param = P, Output = P, Float = F>,
-    P: Clone,
+    P: Clone + Debug,
     F: ArgminFloat,
     R: Rng + SerializeAlias,
 {

--- a/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/argmin/src/solver/trustregion/cauchypoint.rs
@@ -54,7 +54,7 @@ where
 impl<O, F, P, G, H> Solver<O, IterState<P, G, (), H, F>> for CauchyPoint<F>
 where
     O: Gradient<Param = P, Gradient = G> + Hessian<Param = P, Hessian = H>,
-    P: Clone + ArgminMul<F, P> + ArgminWeightedDot<P, F, H>,
+    P: Clone + Debug + ArgminMul<F, P> + ArgminWeightedDot<P, F, H>,
     G: ArgminMul<F, P> + ArgminWeightedDot<G, F, H> + ArgminL2Norm<F>,
     F: ArgminFloat,
 {

--- a/argmin/src/solver/trustregion/dogleg.rs
+++ b/argmin/src/solver/trustregion/dogleg.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Solver, State, TerminationReason,
     TerminationStatus, TrustRegionRadius, KV,
@@ -57,6 +59,7 @@ impl<O, F, P, H> Solver<O, IterState<P, P, (), H, F>> for Dogleg<F>
 where
     O: Gradient<Param = P, Gradient = P> + Hessian<Param = P, Hessian = H>,
     P: Clone
+        + Debug
         + ArgminMul<F, P>
         + ArgminL2Norm<F>
         + ArgminDot<P, F>

--- a/argmin/src/solver/trustregion/steihaug.rs
+++ b/argmin/src/solver/trustregion/steihaug.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt::Debug;
+
 use crate::core::{
     ArgminFloat, Error, IterState, Problem, SerializeAlias, Solver, State, TerminationReason,
     TerminationStatus, TrustRegionRadius, KV,
@@ -181,6 +183,7 @@ where
 impl<P, O, F, H> Solver<O, IterState<P, P, (), H, F>> for Steihaug<P, F>
 where
     P: Clone
+        + Debug
         + SerializeAlias
         + ArgminMul<F, P>
         + ArgminL2Norm<F>

--- a/media/book/src/implementing_solver.md
+++ b/media/book/src/implementing_solver.md
@@ -61,6 +61,7 @@ Finally, the state is updated via `state.param(xkp1)` and returned by the functi
 ```rust
 # extern crate argmin;
 #
+use std::fmt::Debug;
 use argmin::core::{
     ArgminFloat, KV, Error, Gradient, IterState, Problem, Solver, State
 };
@@ -93,7 +94,7 @@ where
     O: Gradient<Param = P, Gradient = G>,
     // The parameter vector of type `P` needs to implement `ArgminScaledSub`
     // because of the update formula
-    P: Clone + ArgminScaledSub<G, F, P>,
+    P: Clone + Debug + ArgminScaledSub<G, F, P>,
     // `F` is the floating point type (`f32` or `f64`)
     F: ArgminFloat,
 {


### PR DESCRIPTION
I found myself wanting to be able to customize what data the `SlogLogger` observer was logging, so I attempted to implement this functionality via the builder pattern as shown in the doc example in the `data` method on `SlogLogger`.

To do this, I needed to add the `Debug` trait as a trait bound to the `type Param` associated types, hence why this PR touches so many files. This could cause breaking changes for users.

Since this uses a builder style pattern to define what data is logged, the default contains the same data as what was previously hard coded, so end users should not experience any breaking changes in their observer configurations. To customize the data that is logged, a new `enum` called `StateData` has been defined in the `state/mod.rs` file that covers all the available data you can get from the `State` trait. A user supplies a `Vec` of these enum variants and then the logger iterates through and emits them. The `Debug` trait was needed because I wanted to print out the `Param`s as well, which are generics.

The motivation for doing this was to actually be able to log the gradient of a problem as well, but since not every solver has a defined gradient, I'm less sure that can be done. I will need assistance in evaluating that possibility, since it would significantly help with debugging!

Let me know what you think! Thanks for building a cool crate :)