### PR TITLE
Correct line search to search over gradient

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -178,6 +178,10 @@ name = "steepestdescent"
 required-features = ["slog-logger"]
 
 [[example]]
+name = "steepestdescent_manifold"
+required-features = ["slog-logger"]
+
+[[example]]
 name = "trustregion_nd"
 required-features = ["argmin-math/ndarray_latest-serde", "slog-logger"]
 

--- a/argmin/examples/steepestdescent.rs
+++ b/argmin/examples/steepestdescent.rs
@@ -38,7 +38,7 @@ impl Gradient for Rosenbrock {
 }
 
 fn run() -> Result<(), Error> {
-    // Define cost function (must implement `ArgminOperator`)
+    // Define cost function (must implement `CostFunction` and `Gradient`)
     let cost = Rosenbrock { a: 1.0, b: 100.0 };
 
     // Define initial parameter vector

--- a/argmin/examples/steepestdescent_manifold.rs
+++ b/argmin/examples/steepestdescent_manifold.rs
@@ -1,0 +1,94 @@
+// Copyright 2018-2022 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![allow(unused_imports)]
+
+use argmin::core::observers::{ObserverMode, SlogLogger};
+use argmin::core::{CostFunction, Error, Executor, Gradient};
+use argmin::solver::gradientdescent::SteepestDescent;
+use argmin::solver::linesearch::condition::{ArmijoCondition, LineSearchCondition};
+use argmin::solver::linesearch::BacktrackingLineSearch;
+use argmin_math::ArgminScaledAdd;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug)]
+struct ClosestPointOnCircle {
+    x: f64,
+    y: f64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct CirclePoint {
+    angle: f64,
+}
+
+impl CostFunction for ClosestPointOnCircle {
+    type Param = CirclePoint;
+    type Output = f64;
+
+    fn cost(&self, p: &Self::Param) -> Result<Self::Output, Error> {
+        let x_circ = p.angle.cos();
+        let y_circ = p.angle.sin();
+        let x_diff = x_circ - self.x;
+        let y_diff = y_circ - self.y;
+        Ok(x_diff.powi(2) + y_diff.powi(2))
+    }
+}
+
+impl Gradient for ClosestPointOnCircle {
+    type Param = CirclePoint;
+    type Gradient = f64;
+
+    fn gradient(&self, p: &Self::Param) -> Result<Self::Gradient, Error> {
+        Ok(2.0 * (p.angle.cos() - self.x) * (-p.angle.sin())
+            + 2.0 * (p.angle.sin() - self.y) * p.angle.cos())
+    }
+}
+
+impl ArgminScaledAdd<f64, f64, CirclePoint> for CirclePoint {
+    fn scaled_add(&self, alpha: &f64, delta: &f64) -> Self {
+        CirclePoint {
+            angle: self.angle + alpha * delta,
+        }
+    }
+}
+
+fn run() -> Result<(), Error> {
+    // Define cost function (must implement `CostFunction` and `Gradient`)
+    let cost = ClosestPointOnCircle { x: 1.0, y: 1.0 };
+
+    // Define initial parameter vector
+    let init_param = CirclePoint { angle: 0.0 };
+
+    // Pick a line search.
+    let cond = ArmijoCondition::new(0.5)?;
+    let linesearch = BacktrackingLineSearch::new(cond);
+
+    // Set up solver
+    let solver = SteepestDescent::new(linesearch);
+
+    // Run solver
+    let res = Executor::new(cost, solver)
+        .configure(|state| state.param(init_param).max_iters(10))
+        .add_observer(SlogLogger::term(), ObserverMode::Always)
+        .run()?;
+
+    // Wait a second (lets the logger flush everything first)
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // print result
+    println!("{res}");
+    Ok(())
+}
+
+fn main() {
+    if let Err(ref e) = run() {
+        println!("{e}");
+        std::process::exit(1);
+    }
+}

--- a/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -54,8 +54,8 @@ impl<O, L, P, G, F> Solver<O, IterState<P, G, (), (), F>> for SteepestDescent<L>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
     P: Clone + SerializeAlias + DeserializeOwnedAlias,
-    G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, P>,
-    L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), F>>,
+    G: Clone + SerializeAlias + DeserializeOwnedAlias + ArgminMul<F, G>,
+    L: Clone + LineSearch<G, F> + Solver<O, IterState<P, G, (), (), F>>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Steepest Descent";

--- a/argmin/src/solver/linesearch/backtracking.rs
+++ b/argmin/src/solver/linesearch/backtracking.rs
@@ -39,7 +39,7 @@ pub struct BacktrackingLineSearch<P, G, L, F> {
     /// initial gradient
     init_grad: Option<G>,
     /// Search direction
-    search_direction: Option<P>,
+    search_direction: Option<G>,
     /// Contraction factor rho
     rho: F,
     /// Stopping condition
@@ -104,12 +104,12 @@ where
     }
 }
 
-impl<P, G, L, F> LineSearch<P, F> for BacktrackingLineSearch<P, G, L, F>
+impl<P, G, L, F> LineSearch<G, F> for BacktrackingLineSearch<P, G, L, F>
 where
     F: ArgminFloat,
 {
     /// Set search direction
-    fn search_direction(&mut self, search_direction: P) {
+    fn search_direction(&mut self, search_direction: G) {
         self.search_direction = Some(search_direction);
     }
 
@@ -128,8 +128,8 @@ where
 
 impl<P, G, L, F> BacktrackingLineSearch<P, G, L, F>
 where
-    P: ArgminScaledAdd<P, F, P>,
-    L: LineSearchCondition<P, G, F>,
+    P: ArgminScaledAdd<G, F, P>,
+    L: LineSearchCondition<G, G, F>,
     IterState<P, G, (), (), F>: State<Float = F>,
     F: ArgminFloat,
 {
@@ -176,10 +176,10 @@ where
 
 impl<O, P, G, L, F> Solver<O, IterState<P, G, (), (), F>> for BacktrackingLineSearch<P, G, L, F>
 where
-    P: Clone + SerializeAlias + ArgminScaledAdd<P, F, P>,
-    G: SerializeAlias + ArgminScaledAdd<P, F, P>,
+    P: Clone + SerializeAlias + ArgminScaledAdd<G, F, P>,
+    G: SerializeAlias + ArgminScaledAdd<G, F, G>,
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    L: LineSearchCondition<P, G, F> + SerializeAlias,
+    L: LineSearchCondition<G, G, F> + SerializeAlias,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Backtracking line search";

--- a/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/argmin/src/solver/linesearch/hagerzhang.rs
@@ -84,14 +84,15 @@ pub struct HagerZhangLineSearch<P, G, F> {
     /// initial gradient (builder)
     init_grad: Option<G>,
     /// Search direction (builder)
-    search_direction: Option<P>,
+    search_direction: Option<G>,
     /// Search direction in 1D
     dginit: F,
 }
 
 impl<P, G, F> HagerZhangLineSearch<P, G, F>
 where
-    P: ArgminScaledAdd<P, F, P> + ArgminDot<G, F>,
+    P: ArgminScaledAdd<G, F, P>,
+    G: ArgminDot<G, F>,
     F: ArgminFloat,
 {
     /// Construct a new instance of [`HagerZhangLineSearch`]
@@ -472,7 +473,8 @@ where
 
 impl<P, G, F> Default for HagerZhangLineSearch<P, G, F>
 where
-    P: ArgminScaledAdd<P, F, P> + ArgminDot<G, F>,
+    P: ArgminScaledAdd<G, F, P>,
+    G: ArgminDot<G, F>,
     F: ArgminFloat,
 {
     fn default() -> Self {
@@ -480,9 +482,9 @@ where
     }
 }
 
-impl<P, G, F> LineSearch<P, F> for HagerZhangLineSearch<P, G, F> {
+impl<P, G, F> LineSearch<G, F> for HagerZhangLineSearch<P, G, F> {
     /// Set search direction
-    fn search_direction(&mut self, search_direction: P) {
+    fn search_direction(&mut self, search_direction: G) {
         self.search_direction = Some(search_direction);
     }
 
@@ -496,8 +498,8 @@ impl<P, G, F> LineSearch<P, F> for HagerZhangLineSearch<P, G, F> {
 impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for HagerZhangLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
-    G: Clone + SerializeAlias + ArgminDot<P, F>,
+    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<G, F, P>,
+    G: Clone + SerializeAlias + ArgminDot<G, F>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "Hager-Zhang line search";

--- a/argmin/src/solver/linesearch/mod.rs
+++ b/argmin/src/solver/linesearch/mod.rs
@@ -55,16 +55,16 @@ pub use self::morethuente::MoreThuenteLineSearch;
 /// ```
 /// use argmin::solver::linesearch::LineSearch;
 ///
-/// struct MyLineSearch<P, F> {
-///     // `P` is the type of the search direction, typically the same as the parameter vector
-///     search_direction: P,
+/// struct MyLineSearch<D, F> {
+///     // `D` is the type of the search direction
+///     search_direction: D,
 ///     // `F` is a floating point value (f32 or f64)
 ///     init_step_length: F,
 ///     // ...
 /// }
 ///
-/// impl<P, F> LineSearch<P, F> for MyLineSearch<P, F> {
-///     fn search_direction(&mut self, direction: P) {
+/// impl<D, F> LineSearch<D, F> for MyLineSearch<D, F> {
+///     fn search_direction(&mut self, direction: D) {
 ///         self.search_direction = direction;
 ///     }
 ///
@@ -74,11 +74,11 @@ pub use self::morethuente::MoreThuenteLineSearch;
 ///     }
 /// }
 /// ```
-pub trait LineSearch<P, F> {
+pub trait LineSearch<D, F> {
     /// Set the search direction
     ///
     /// This is the direction in which the line search will be performed.
-    fn search_direction(&mut self, direction: P);
+    fn search_direction(&mut self, direction: D);
 
     /// Set the initial step length
     ///

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -54,7 +54,7 @@ use std::default::Default;
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 pub struct MoreThuenteLineSearch<P, G, F> {
     /// Search direction
-    search_direction: Option<P>,
+    search_direction: Option<G>,
     /// initial parameter vector
     init_param: Option<P>,
     /// initial cost
@@ -274,12 +274,12 @@ where
     }
 }
 
-impl<P, G, F> LineSearch<P, F> for MoreThuenteLineSearch<P, G, F>
+impl<P, G, F> LineSearch<G, F> for MoreThuenteLineSearch<P, G, F>
 where
     F: ArgminFloat,
 {
     /// Set search direction
-    fn search_direction(&mut self, search_direction: P) {
+    fn search_direction(&mut self, search_direction: G) {
         self.search_direction = Some(search_direction);
     }
 
@@ -299,8 +299,8 @@ where
 impl<P, G, O, F> Solver<O, IterState<P, G, (), (), F>> for MoreThuenteLineSearch<P, G, F>
 where
     O: CostFunction<Param = P, Output = F> + Gradient<Param = P, Gradient = G>,
-    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<P, F, P>,
-    G: Clone + SerializeAlias + ArgminDot<P, F>,
+    P: Clone + SerializeAlias + ArgminDot<G, F> + ArgminScaledAdd<G, F, P>,
+    G: Clone + SerializeAlias + ArgminDot<G, F>,
     F: ArgminFloat,
 {
     const NAME: &'static str = "More-Thuente Line search";


### PR DESCRIPTION
Previously, the line search operated directly over parameter space. This caused issues when there were different types for parameters vs gradients e.g. Lie Groups. This commit changes line searches to operate over gradient parameterization and incorporates gradient updates to parameters via ArgminScaledAdd.

I'm not sure sure what level of testing is needed for this but it passes all the unit tests with `cargo test` and I also ran the 3 line search examples and the steepest descent example