### PR TITLE
Added missing feature for testing argmin-math (docs)

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -54,7 +54,7 @@ serde1 = ["serde", "serde_json", "rand/serde1", "bincode", "slog-json", "rand_xo
 _ndarrayl = ["argmin-math/ndarray_latest-serde", "argmin-math/_dev_linalg_latest"]
 _nalgebral = ["argmin-math/nalgebra_latest-serde"]
 # When adding new features, please consider adding them to either `full` (for users)
-# or `_full_dev` (only for local development, tesing and computing test coverage).
+# or `_full_dev` (only for local development, testing and computing test coverage).
 full = ["default", "slog-logger", "serde1", "ctrlc"]
 _full_dev = ["full", "_ndarrayl", "_nalgebral"]
 

--- a/argmin/src/solver/conjugategradient/cg.rs
+++ b/argmin/src/solver/conjugategradient/cg.rs
@@ -247,10 +247,10 @@ mod tests {
 
         assert_relative_eq!(b[0], 1.0, epsilon = f64::EPSILON);
         assert_relative_eq!(b[1], 2.0, epsilon = f64::EPSILON);
-        let r0 = vec![2.0f64, 2.0];
+        let r0 = [2.0f64, 2.0];
         assert_relative_eq!(r0[0], r.as_ref().unwrap()[0], epsilon = f64::EPSILON);
         assert_relative_eq!(r0[1], r.as_ref().unwrap()[1], epsilon = f64::EPSILON);
-        let pp = vec![-2.0f64, -2.0];
+        let pp = [-2.0f64, -2.0];
         assert_relative_eq!(pp[0], p.as_ref().unwrap()[0], epsilon = f64::EPSILON);
         assert_relative_eq!(pp[1], p.as_ref().unwrap()[1], epsilon = f64::EPSILON);
         assert_relative_eq!(rtr, 8.0, epsilon = f64::EPSILON);

--- a/argmin/src/solver/linesearch/morethuente.rs
+++ b/argmin/src/solver/linesearch/morethuente.rs
@@ -544,7 +544,7 @@ fn cstep<F: ArgminFloat>(
         info = 1;
         bound = true;
         let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
-        let tmp = vec![theta, stx.gx, stp.gx];
+        let tmp = [theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
             return Err(argmin_error!(
@@ -578,7 +578,7 @@ fn cstep<F: ArgminFloat>(
         info = 2;
         bound = false;
         let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
-        let tmp = vec![theta, stx.gx, stp.gx];
+        let tmp = [theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
             return Err(argmin_error!(
@@ -612,7 +612,7 @@ fn cstep<F: ArgminFloat>(
         info = 3;
         bound = true;
         let theta = float!(3.0) * (stx.fx - stp.fx) / (stp.x - stx.x) + stx.gx + stp.gx;
-        let tmp = vec![theta, stx.gx, stp.gx];
+        let tmp = [theta, stx.gx, stp.gx];
         // Check for a NaN or Inf in tmp before sorting
         if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
             return Err(argmin_error!(
@@ -662,7 +662,7 @@ fn cstep<F: ArgminFloat>(
         bound = false;
         if brackt {
             let theta = float!(3.0) * (stp.fx - sty.fx) / (sty.x - stp.x) + sty.gx + stp.gx;
-            let tmp = vec![theta, sty.gx, stp.gx];
+            let tmp = [theta, sty.gx, stp.gx];
             // Check for a NaN or Inf in tmp before sorting
             if tmp.iter().any(|n| n.is_nan() || n.is_infinite()) {
                 return Err(argmin_error!(

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -198,8 +198,8 @@ where
 
         let mut particles = positions
             .into_iter()
-            .zip(velocities.into_iter())
-            .zip(costs.into_iter())
+            .zip(velocities)
+            .zip(costs)
             .map(|((p, v), c)| Particle::new(p, c, v))
             .collect::<Vec<_>>();
 

--- a/media/book/src/contributing.md
+++ b/media/book/src/contributing.md
@@ -31,7 +31,7 @@ cargo test -p argmin-math
 Or the default features plus the latest `ndarray`/`nalgebra` backends:
 
 ```bash
-cargo test -p argmin-math --features "latest_all"
+cargo test -p argmin-math --features "latest_all,_dev_linalg_latest"
 ```
 
 Individual backends can be tested as well; however, care has to be taken to not add two different versions of the same backend, as that may not work.


### PR DESCRIPTION
In the docs, the `_dev_linalg_latest` feature which is needed to run the argmin-math tests with all backends was not mentioned.  