### PR TITLE
allow user to set ParticleSwarm's random number generator

### DIFF
--- a/argmin-math/src/lib.rs
+++ b/argmin-math/src/lib.rs
@@ -337,7 +337,7 @@ pub trait ArgminInv<T> {
 /// Create a random number
 pub trait ArgminRandom {
     /// Get a random element between min and max,
-    fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Self;
+    fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> Self;
 }
 
 /// Minimum and Maximum of type `T`

--- a/argmin-math/src/lib.rs
+++ b/argmin-math/src/lib.rs
@@ -230,6 +230,7 @@ mod vec;
 pub use crate::vec::*;
 
 use anyhow::Error;
+use rand::Rng;
 
 /// Dot/scalar product of `T` and `self`
 pub trait ArgminDot<T, U> {
@@ -336,7 +337,7 @@ pub trait ArgminInv<T> {
 /// Create a random number
 pub trait ArgminRandom {
     /// Get a random element between min and max,
-    fn rand_from_range(min: &Self, max: &Self) -> Self;
+    fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Self;
 }
 
 /// Minimum and Maximum of type `T`

--- a/argmin-math/src/nalgebra_m/random.rs
+++ b/argmin-math/src/nalgebra_m/random.rs
@@ -22,11 +22,9 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn rand_from_range(min: &Self, max: &Self) -> OMatrix<N, R, C> {
+    fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> OMatrix<N, R, C> {
         assert!(!min.is_empty());
         assert_eq!(min.shape(), max.shape());
-
-        let mut rng = rand::thread_rng();
 
         Self::from_iterator_generic(
             R::from_usize(min.nrows()),
@@ -53,6 +51,7 @@ mod tests {
     use super::*;
     use nalgebra::{Matrix2x3, Vector3};
     use paste::item;
+    use rand::SeedableRng;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -61,7 +60,8 @@ mod tests {
                 fn [<test_random_vec_ $t>]() {
                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
                     let b = Vector3::new(2 as $t, 3 as $t, 4 as $t);
-                    let random = Vector3::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         assert!(random[i] >= a[i]);
                         assert!(random[i] <= b[i]);
@@ -74,7 +74,8 @@ mod tests {
                 fn [<test_random_vec_equal $t>]() {
                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-                    let random = Vector3::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         assert!((random[i] as f64 - a[i] as f64).abs() < std::f64::EPSILON);
                         assert!((random[i] as f64 - b[i] as f64).abs() < std::f64::EPSILON);
@@ -87,7 +88,8 @@ mod tests {
                 fn [<test_random_vec_reverse_ $t>]() {
                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
                     let a = Vector3::new(2 as $t, 3 as $t, 4 as $t);
-                    let random = Vector3::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         assert!(random[i] >= b[i]);
                         assert!(random[i] <= a[i]);
@@ -106,7 +108,8 @@ mod tests {
                         2 as $t, 4 as $t, 6 as $t,
                         3 as $t, 5 as $t, 7 as $t
                     );
-                    let random = Matrix2x3::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Matrix2x3::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         for j in 0..2 {
                             assert!(random[(j, i)] >= a[(j, i)]);

--- a/argmin-math/src/nalgebra_m/random.rs
+++ b/argmin-math/src/nalgebra_m/random.rs
@@ -22,7 +22,7 @@ where
     DefaultAllocator: Allocator<N, R, C>,
 {
     #[inline]
-    fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> OMatrix<N, R, C> {
+    fn rand_from_range<T: Rng>(min: &Self, max: &Self, rng: &mut T) -> OMatrix<N, R, C> {
         assert!(!min.is_empty());
         assert_eq!(min.shape(), max.shape());
 

--- a/argmin-math/src/ndarray_m/random.rs
+++ b/argmin-math/src/ndarray_m/random.rs
@@ -12,7 +12,7 @@ use crate::ArgminRandom;
 macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for ndarray::Array1<$t> {
-            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> ndarray::Array1<$t> {
+            fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> ndarray::Array1<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
 
@@ -33,7 +33,7 @@ macro_rules! make_random {
         }
 
         impl ArgminRandom for ndarray::Array2<$t> {
-            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> ndarray::Array2<$t> {
+            fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> ndarray::Array2<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.raw_dim(), max.raw_dim());
 

--- a/argmin-math/src/ndarray_m/random.rs
+++ b/argmin-math/src/ndarray_m/random.rs
@@ -5,18 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 
 use crate::ArgminRandom;
 
 macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for ndarray::Array1<$t> {
-            fn rand_from_range(min: &Self, max: &Self) -> ndarray::Array1<$t> {
+            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> ndarray::Array1<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
-
-                let mut rng = rand::thread_rng();
 
                 ndarray::Array1::from_iter(min.iter().zip(max.iter()).map(|(a, b)| {
                     // Do not require a < b:
@@ -35,11 +33,9 @@ macro_rules! make_random {
         }
 
         impl ArgminRandom for ndarray::Array2<$t> {
-            fn rand_from_range(min: &Self, max: &Self) -> ndarray::Array2<$t> {
+            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> ndarray::Array2<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.raw_dim(), max.raw_dim());
-
-                let mut rng = rand::thread_rng();
 
                 ndarray::Array2::from_shape_fn(min.raw_dim(), |(i, j)| {
                     let a = min.get((i, j)).unwrap();
@@ -78,6 +74,7 @@ mod tests {
     use super::*;
     use ndarray::{array, Array1, Array2};
     use paste::item;
+    use rand::SeedableRng;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -86,7 +83,8 @@ mod tests {
                 fn [<test_random_vec_ $t>]() {
                     let a = array![1 as $t, 2 as $t, 4 as $t];
                     let b = array![2 as $t, 3 as $t, 5 as $t];
-                    let random = Array1::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Array1::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3usize {
                         assert!(random[i] >= a[i]);
                         assert!(random[i] <= b[i]);
@@ -105,7 +103,8 @@ mod tests {
                         [2 as $t, 3 as $t, 5 as $t],
                         [3 as $t, 4 as $t, 6 as $t]
                     ];
-                    let random = Array2::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Array2::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         for j in 0..2 {
                             assert!(random[(j, i)] >= a[(j, i)]);

--- a/argmin-math/src/primitives/random.rs
+++ b/argmin-math/src/primitives/random.rs
@@ -12,8 +12,8 @@ macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for $t {
             #[inline]
-            fn rand_from_range(min: &Self, max: &Self) -> $t {
-                rand::thread_rng().gen_range(*min..*max)
+            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> $t {
+                rng.gen_range(*min..*max)
             }
         }
     };
@@ -36,6 +36,7 @@ make_random!(usize);
 mod tests {
     use super::*;
     use paste::item;
+    use rand::SeedableRng;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -44,7 +45,8 @@ mod tests {
                 fn [<test_random_vec_ $t>]() {
                     let a = 1 as $t;
                     let b = 2 as $t;
-                    let random = $t::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = $t::rand_from_range(&a, &b, &mut rng);
                     assert!(random >= a);
                     assert!(random <= b);
                 }

--- a/argmin-math/src/primitives/random.rs
+++ b/argmin-math/src/primitives/random.rs
@@ -12,7 +12,7 @@ macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for $t {
             #[inline]
-            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> $t {
+            fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> $t {
                 rng.gen_range(*min..*max)
             }
         }

--- a/argmin-math/src/vec/random.rs
+++ b/argmin-math/src/vec/random.rs
@@ -11,11 +11,9 @@ use rand::Rng;
 macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for Vec<$t> {
-            fn rand_from_range(min: &Self, max: &Self) -> Vec<$t> {
+            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Vec<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
-
-                let mut rng = rand::thread_rng();
 
                 min.iter()
                     .zip(max.iter())
@@ -37,12 +35,12 @@ macro_rules! make_random {
         }
 
         impl ArgminRandom for Vec<Vec<$t>> {
-            fn rand_from_range(min: &Self, max: &Self) -> Vec<Vec<$t>> {
+            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Vec<Vec<$t>> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
                 min.iter()
                     .zip(max.iter())
-                    .map(|(a, b)| Vec::<$t>::rand_from_range(a, b))
+                    .map(|(a, b)| Vec::<$t>::rand_from_range(a, b, rng))
                     .collect()
             }
         }
@@ -66,6 +64,7 @@ make_random!(usize);
 mod tests {
     use super::*;
     use paste::item;
+    use rand::SeedableRng;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -74,7 +73,8 @@ mod tests {
                 fn [<test_random_vec_ $t>]() {
                     let a = vec![1 as $t, 2 as $t, 4 as $t];
                     let b = vec![2 as $t, 3 as $t, 5 as $t];
-                    let random = Vec::<$t>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Vec::<$t>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3usize {
                         assert!(random[i] >= a[i]);
                         assert!(random[i] <= b[i]);
@@ -93,7 +93,8 @@ mod tests {
                         vec![2 as $t, 3 as $t, 5 as $t],
                         vec![3 as $t, 4 as $t, 6 as $t]
                     ];
-                    let random = Vec::<Vec<$t>>::rand_from_range(&a, &b);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = Vec::<Vec<$t>>::rand_from_range(&a, &b, &mut rng);
                     for i in 0..3 {
                         for j in 0..2 {
                             assert!(random[j][i] >= a[j][i]);

--- a/argmin-math/src/vec/random.rs
+++ b/argmin-math/src/vec/random.rs
@@ -11,7 +11,7 @@ use rand::Rng;
 macro_rules! make_random {
     ($t:ty) => {
         impl ArgminRandom for Vec<$t> {
-            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Vec<$t> {
+            fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> Vec<$t> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
 
@@ -35,7 +35,7 @@ macro_rules! make_random {
         }
 
         impl ArgminRandom for Vec<Vec<$t>> {
-            fn rand_from_range<G: Rng>(min: &Self, max: &Self, rng: &mut G) -> Vec<Vec<$t>> {
+            fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> Vec<Vec<$t>> {
                 assert!(!min.is_empty());
                 assert_eq!(min.len(), max.len());
                 min.iter()

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -115,7 +115,7 @@ where
 {
     /// Set the random number generator
     ///
-    /// Defaults to `rand::rngs::StdRng::seed_from_u64(42)`
+    /// Defaults to `rand::rngs::StdRng::from_entropy()`
     ///
     /// # Example
     /// ```

--- a/argmin/src/solver/particleswarm/mod.rs
+++ b/argmin/src/solver/particleswarm/mod.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 /// \[1\] <https://en.wikipedia.org/wiki/Particle_swarm_optimization>
 #[derive(Clone)]
 #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
-pub struct ParticleSwarm<P, F, G> {
+pub struct ParticleSwarm<P, F, R> {
     /// Inertia weight
     weight_inertia: F,
     /// Cognitive acceleration coefficient
@@ -63,7 +63,7 @@ pub struct ParticleSwarm<P, F, G> {
     /// Number of particles
     num_particles: usize,
     /// Random number generator
-    rng_generator: G,
+    rng_generator: R,
 }
 
 impl<P, F> ParticleSwarm<P, F, rand::rngs::StdRng>
@@ -103,15 +103,15 @@ where
             weight_social: float!(0.5 + 2.0f64.ln()),
             bounds,
             num_particles,
-            rng_generator: rand::rngs::StdRng::seed_from_u64(42),
+            rng_generator: rand::rngs::StdRng::from_entropy(),
         }
     }
 }
-impl<P, F, G0> ParticleSwarm<P, F, G0>
+impl<P, F, R0> ParticleSwarm<P, F, R0>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,
     F: ArgminFloat,
-    G0: Rng,
+    R0: Rng,
 {
     /// Set the random number generator
     ///
@@ -131,7 +131,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_rng_generator<G1: Rng>(self, generator: G1) -> ParticleSwarm<P, F, G1> {
+    pub fn with_rng_generator<R1: Rng>(self, generator: R1) -> ParticleSwarm<P, F, R1> {
         ParticleSwarm {
             weight_inertia: self.weight_inertia,
             weight_cognitive: self.weight_cognitive,
@@ -143,11 +143,11 @@ where
     }
 }
 
-impl<P, F, G> ParticleSwarm<P, F, G>
+impl<P, F, R> ParticleSwarm<P, F, R>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,
     F: ArgminFloat,
-    G: Rng,
+    R: Rng,
 {
     /// Set inertia factor on particle velocity
     ///
@@ -276,7 +276,7 @@ where
     }
 }
 
-impl<O, P, F, G> Solver<O, PopulationState<Particle<P, F>, F>> for ParticleSwarm<P, F, G>
+impl<O, P, F, R> Solver<O, PopulationState<Particle<P, F>, F>> for ParticleSwarm<P, F, R>
 where
     O: CostFunction<Param = P, Output = F> + SyncAlias,
     P: SerializeAlias
@@ -289,7 +289,7 @@ where
         + ArgminRandom
         + ArgminMinMax,
     F: ArgminFloat,
-    G: Rng,
+    R: Rng,
 {
     const NAME: &'static str = "Particle Swarm Optimization";
 


### PR DESCRIPTION
Initially I had restricted the trait requirements for G (Generator) to be `Rng+SeedableRng`, however with just `Rng` a user is perfectly able to use a `SeedableRng`, so I don't think it is necessary to set the extra requirement (the default provided by the constructor is itself seeded so a user can just pass a differently seeded generator, as in the provided doctests). 

With this change we can pin the behaviour of ParticleSwarm in tests and bechmarks.