### PR TITLE
Add optional timeout to `Executor`

### DIFF
--- a/argmin/src/core/termination.rs
+++ b/argmin/src/core/termination.rs
@@ -31,6 +31,7 @@ impl TerminationStatus {
     /// assert!(TerminationStatus::Terminated(TerminationReason::TargetCostReached).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::SolverConverged).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::KeyboardInterrupt).terminated());
+    /// assert!(TerminationStatus::Terminated(TerminationReason::Timeout).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::SolverExit("Exit reason".to_string())).terminated());
     /// ```
     pub fn terminated(&self) -> bool {
@@ -59,6 +60,8 @@ pub enum TerminationReason {
     KeyboardInterrupt,
     /// Converged
     SolverConverged,
+    /// Timeout reached
+    Timeout,
     /// Solver exit with given reason
     SolverExit(String),
 }
@@ -88,6 +91,10 @@ impl TerminationReason {
     ///     "Solver converged"
     /// );
     /// assert_eq!(
+    ///     TerminationReason::Timeout.text(),
+    ///     "Timeout reached"
+    /// );
+    /// assert_eq!(
     ///     TerminationReason::SolverExit("Aborted".to_string()).text(),
     ///     "Aborted"
     /// );
@@ -98,6 +105,7 @@ impl TerminationReason {
             TerminationReason::TargetCostReached => "Target cost value reached",
             TerminationReason::KeyboardInterrupt => "Keyboard interrupt",
             TerminationReason::SolverConverged => "Solver converged",
+            TerminationReason::Timeout => "Timeout reached",
             TerminationReason::SolverExit(reason) => reason.as_ref(),
         }
     }

--- a/examples/timeout/Cargo.toml
+++ b/examples/timeout/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-timeout"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+argmin = { version = "*", path = "../../argmin" }
+argmin-math = { version = "*", features = ["vec"], path = "../../argmin-math" }
+argmin-observer-slog = { version = "*", path = "../../observers/slog/" }
+argmin_testfunctions = "*"
+rand = "0.8.5"
+rand_xoshiro = "0.6.0"

--- a/examples/timeout/src/main.rs
+++ b/examples/timeout/src/main.rs
@@ -1,0 +1,98 @@
+// Copyright 2018-2024 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+// This example shows how to add a timeout to an optimization run. The optimization will be
+// terminated once the 3 seconds timeout is reached.
+
+use argmin::{
+    core::{observers::ObserverMode, CostFunction, Error, Executor},
+    solver::simulatedannealing::{Anneal, SATempFunc, SimulatedAnnealing},
+};
+use argmin_observer_slog::SlogLogger;
+use argmin_testfunctions::rosenbrock;
+use rand::{distributions::Uniform, prelude::*};
+use rand_xoshiro::Xoshiro256PlusPlus;
+use std::sync::{Arc, Mutex};
+
+struct Rosenbrock {
+    a: f64,
+    b: f64,
+    lower_bound: Vec<f64>,
+    upper_bound: Vec<f64>,
+    rng: Arc<Mutex<Xoshiro256PlusPlus>>,
+}
+
+impl Rosenbrock {
+    pub fn new(a: f64, b: f64, lower_bound: Vec<f64>, upper_bound: Vec<f64>) -> Self {
+        Rosenbrock {
+            a,
+            b,
+            lower_bound,
+            upper_bound,
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
+        }
+    }
+}
+
+impl CostFunction for Rosenbrock {
+    type Param = Vec<f64>;
+    type Output = f64;
+
+    fn cost(&self, param: &Self::Param) -> Result<Self::Output, Error> {
+        Ok(rosenbrock(param, self.a, self.b))
+    }
+}
+
+impl Anneal for Rosenbrock {
+    type Param = Vec<f64>;
+    type Output = Vec<f64>;
+    type Float = f64;
+
+    fn anneal(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
+        let mut param_n = param.clone();
+        let mut rng = self.rng.lock().unwrap();
+        let distr = Uniform::from(0..param.len());
+        for _ in 0..(temp.floor() as u64 + 1) {
+            let idx = rng.sample(distr);
+            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1));
+            param_n[idx] += val;
+            param_n[idx] = param_n[idx].clamp(self.lower_bound[idx], self.upper_bound[idx]);
+        }
+        Ok(param_n)
+    }
+}
+
+fn run() -> Result<(), Error> {
+    let lower_bound: Vec<f64> = vec![-5.0, -5.0];
+    let upper_bound: Vec<f64> = vec![5.0, 5.0];
+    let operator = Rosenbrock::new(1.0, 100.0, lower_bound, upper_bound);
+    let init_param: Vec<f64> = vec![1.0, 1.2];
+    let temp = 15.0;
+    let solver = SimulatedAnnealing::new(temp)?.with_temp_func(SATempFunc::Boltzmann);
+
+    let res = Executor::new(operator, solver)
+        .configure(|state| state.param(init_param).max_iters(10_000_000))
+        .add_observer(SlogLogger::term(), ObserverMode::Always)
+        /////////////////////////////////////////////////////////////////////////////////////////
+        //                                                                                     //
+        //             Add a timeout of 3 seconds                                              //
+        //                                                                                     //
+        /////////////////////////////////////////////////////////////////////////////////////////
+        .timeout(std::time::Duration::from_secs(3))
+        .run()?;
+
+    // Print result
+    println!("{res}");
+    Ok(())
+}
+
+fn main() {
+    if let Err(ref e) = run() {
+        println!("{e}");
+        std::process::exit(1);
+    }
+}

--- a/media/book/src/running_solver.md
+++ b/media/book/src/running_solver.md
@@ -134,3 +134,6 @@ let function_evaluation_counts = res.state().get_func_counts();
 # }
 ```
 
+Optionally, `Executor` allows one to terminate a run after a given timeout, which can be set with the `timeout` method of `Executor`. 
+The check whether the overall runtime exceeds the timeout is performed after every iteration, therefore the actual runtime can be longer than the set timeout.
+In case of timeout, the run terminates with `TerminationReason::Timeout`.


### PR DESCRIPTION
Closes #332 

* [x] Timeout support in `Executor`
* [x] Docs and Doctests
* [x] Example
* [x] Test
* [x] Mention in book (?)