### PR TITLE
Interrupt handling now includes SIGINT, SIGTERM and SIGHUP, renamed `KeyboardInterrupt` to `Interrupt`

### DIFF
--- a/argmin/Cargo.toml
+++ b/argmin/Cargo.toml
@@ -24,7 +24,7 @@ rand_xoshiro = "0.6.0"
 thiserror = "1.0"
 argmin-math = { path = "../argmin-math", version = "0.3", default-features = false, features = ["primitives"] }
 # optional
-ctrlc = { version = "3.2.4", optional = true }
+ctrlc = { version = "3.2.4", features = ["termination"], optional = true }
 getrandom = { version = "0.2", optional = true }
 rayon = { version = "1.6.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/argmin/src/core/executor.rs
+++ b/argmin/src/core/executor.rs
@@ -272,7 +272,7 @@ where
 
         if interrupt.load(Ordering::SeqCst) {
             // Solver execution has been interrupted manually
-            state = state.terminate_with(TerminationReason::KeyboardInterrupt);
+            state = state.terminate_with(TerminationReason::Interrupt);
         }
 
         if !self.observers.is_empty() {

--- a/argmin/src/core/termination.rs
+++ b/argmin/src/core/termination.rs
@@ -30,7 +30,7 @@ impl TerminationStatus {
     /// assert!(TerminationStatus::Terminated(TerminationReason::MaxItersReached).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::TargetCostReached).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::SolverConverged).terminated());
-    /// assert!(TerminationStatus::Terminated(TerminationReason::KeyboardInterrupt).terminated());
+    /// assert!(TerminationStatus::Terminated(TerminationReason::Interrupt).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::Timeout).terminated());
     /// assert!(TerminationStatus::Terminated(TerminationReason::SolverExit("Exit reason".to_string())).terminated());
     /// ```
@@ -56,8 +56,8 @@ pub enum TerminationReason {
     MaxItersReached,
     /// Reached target cost function value
     TargetCostReached,
-    /// Algorithm manually interrupted with Ctrl+C
-    KeyboardInterrupt,
+    /// Algorithm manually interrupted with SIGINT (Ctrl+C), SIGTERM or SIGHUP
+    Interrupt,
     /// Converged
     SolverConverged,
     /// Timeout reached
@@ -83,8 +83,8 @@ impl TerminationReason {
     ///     "Target cost value reached"
     /// );
     /// assert_eq!(
-    ///     TerminationReason::KeyboardInterrupt.text(),
-    ///     "Keyboard interrupt"
+    ///     TerminationReason::Interrupt.text(),
+    ///     "Interrupt"
     /// );
     /// assert_eq!(
     ///     TerminationReason::SolverConverged.text(),
@@ -103,7 +103,7 @@ impl TerminationReason {
         match self {
             TerminationReason::MaxItersReached => "Maximum number of iterations reached",
             TerminationReason::TargetCostReached => "Target cost value reached",
-            TerminationReason::KeyboardInterrupt => "Keyboard interrupt",
+            TerminationReason::Interrupt => "Interrupt",
             TerminationReason::SolverConverged => "Solver converged",
             TerminationReason::Timeout => "Timeout reached",
             TerminationReason::SolverExit(reason) => reason.as_ref(),


### PR DESCRIPTION
As suggested a while ago on [reddit](https://www.reddit.com/r/rust/comments/10o6jml/comment/j6cu80v/?utm_source=share&utm_medium=web2x&context=3). By adding the `termination` feature to `ctrlc`, we are able to capture SIGINT (Ctrl+C), SIGTERM and SIGHUP.
I changed `TerminationReason::KeyboardInterrupt` to `TerminationReason::Interrupt` to reflect that.
