### PR TITLE
Removed unnecessary Serialize/Deserialize derives

### DIFF
--- a/crates/argmin/src/core/solver.rs
+++ b/crates/argmin/src/core/solver.rs
@@ -23,11 +23,8 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 /// use argmin::core::{
 ///     ArgminFloat, Solver, IterState, CostFunction, Error, KV, Problem, TerminationReason, TerminationStatus
 /// };
-/// #[cfg(feature = "serde1")]
-/// use serde::{Deserialize, Serialize};
 ///
 /// #[derive(Clone)]
-/// #[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 /// struct OptimizationAlgorithm {}
 ///
 /// impl<O, P, G, J, H, R, F> Solver<O, IterState<P, G, J, H, R, F>> for OptimizationAlgorithm

--- a/crates/argmin/src/tests.rs
+++ b/crates/argmin/src/tests.rs
@@ -17,11 +17,7 @@ use crate::solver::linesearch::{HagerZhangLineSearch, MoreThuenteLineSearch};
 use crate::solver::newton::NewtonCG;
 use crate::solver::quasinewton::{BFGS, DFP, LBFGS};
 
-#[cfg(feature = "serde1")]
-use serde::{Deserialize, Serialize};
-
 #[derive(Clone, Default, Debug)]
-#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 struct MaxEntropy {
     F: Array2<f64>,
     K: Array1<f64>,

--- a/python/argmin-testfunctions-py/.gitignore
+++ b/python/argmin-testfunctions-py/.gitignore
@@ -11,7 +11,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 .venv/
-.evn/
+.env/
 env/
 bin/
 build/


### PR DESCRIPTION
In the tests there were still a few remnants of the times where
serialization and deserialization were more ingrained in the system.
This commit removes these remnants.
It also fixes a typo in the .gitignore file in argmin-testfunctions-py.
