### PR TITLE
Defined version for argmin-testfunctions dev dependency in paramwriter

### DIFF
--- a/crates/argmin-observer-paramwriter/Cargo.toml
+++ b/crates/argmin-observer-paramwriter/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = { version = "1.0" }
 
 [dev-dependencies]
 argmin-math = { path = "../argmin-math", features = ["vec"] }
-argmin_testfunctions = { version = "*", path = "../argmin-testfunctions" }
+argmin_testfunctions = { path = "../argmin-testfunctions" }


### PR DESCRIPTION
Apparently one can't publish when a dev dependency doesn't have a
defined version.
