### PR TITLE
Some minor optimizations

### DIFF
--- a/crates/argmin/src/core/executor.rs
+++ b/crates/argmin/src/core/executor.rs
@@ -69,7 +69,7 @@ where
             checkpoint: None,
             timeout: None,
             ctrlc: true,
-            timer: true,
+            timer: false,
         }
     }
 
@@ -383,9 +383,9 @@ where
         self
     }
 
-    /// Enables or disables timing of individual iterations (default: enabled).
+    /// Enables or disables timing of individual iterations (default: false).
     ///
-    /// Setting this to false will silently be ignored in case a timeout is set.
+    /// In case a timeout is set, this will automatically be set to true.
     ///
     /// # Example
     ///
@@ -768,7 +768,7 @@ mod tests {
         let problem = TestProblem::new();
         let timeout = std::time::Duration::from_secs(2);
 
-        let executor = Executor::new(problem, solver);
+        let executor = Executor::new(problem, solver).timer(true);
         assert!(executor.timer);
         assert!(executor.timeout.is_none());
 

--- a/crates/argmin/src/core/state/iterstate.rs
+++ b/crates/argmin/src/core/state/iterstate.rs
@@ -971,6 +971,20 @@ where
     pub fn take_prev_residuals(&mut self) -> Option<R> {
         self.prev_residuals.take()
     }
+
+    /// Overrides state of counting function executions (default: false)
+    /// ```
+    /// # use argmin::core::{IterState, State};
+    /// # let mut state: IterState<(), (), (), (), Vec<f64>, f64> = IterState::new();
+    /// # assert!(!state.counting_enabled);
+    /// let state = state.counting(true);
+    /// # assert!(state.counting_enabled);
+    /// ```
+    #[must_use]
+    pub fn counting(mut self, mode: bool) -> Self {
+        self.counting_enabled = mode;
+        self
+    }
 }
 
 impl<P, G, J, H, R, F> State for IterState<P, G, J, H, R, F>

--- a/crates/argmin/src/core/state/iterstate.rs
+++ b/crates/argmin/src/core/state/iterstate.rs
@@ -81,6 +81,8 @@ pub struct IterState<P, G, J, H, R, F> {
     pub max_iters: u64,
     /// Evaluation counts
     pub counts: HashMap<String, u64>,
+    /// Update evaluation counts?
+    pub counting_enabled: bool,
     /// Time required so far
     pub time: Option<instant::Duration>,
     /// Status of optimization execution
@@ -1039,6 +1041,7 @@ where
             last_best_iter: 0,
             max_iters: std::u64::MAX,
             counts: HashMap::new(),
+            counting_enabled: false,
             time: Some(instant::Duration::new(0, 0)),
             termination_status: TerminationStatus::NotTerminated,
         }
@@ -1338,7 +1341,7 @@ where
     /// ```
     /// # use std::collections::HashMap;
     /// # use argmin::core::{Problem, IterState, State, ArgminFloat};
-    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
+    /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new().counting(true);
     /// # assert_eq!(state.counts, HashMap::new());
     /// # state.counts.insert("test2".to_string(), 10u64);
     /// #
@@ -1355,9 +1358,11 @@ where
     /// # assert_eq!(state.counts, hm);
     /// ```
     fn func_counts<O>(&mut self, problem: &Problem<O>) {
-        for (k, &v) in problem.counts.iter() {
-            let count = self.counts.entry(k.to_string()).or_insert(0);
-            *count = v
+        if self.counting_enabled {
+            for (k, &v) in problem.counts.iter() {
+                let count = self.counts.entry(k.to_string()).or_insert(0);
+                *count = v
+            }
         }
     }
 

--- a/crates/argmin/src/solver/brent/brentopt.rs
+++ b/crates/argmin/src/solver/brent/brentopt.rs
@@ -231,7 +231,7 @@ mod tests {
         let cost = TestFunc {};
         let solver = BrentOpt::new(-10., 10.);
         let res = Executor::new(cost, solver)
-            .configure(|state| state.max_iters(13))
+            .configure(|state| state.counting(true).max_iters(13))
             .run()
             .unwrap();
         assert_eq!(

--- a/crates/argmin/src/solver/linesearch/backtracking.rs
+++ b/crates/argmin/src/solver/linesearch/backtracking.rs
@@ -640,7 +640,12 @@ mod tests {
         ls.search_direction(vec![2.0f64, 0.0]);
 
         let data = Executor::new(prob, ls.clone())
-            .configure(|config| config.param(ls.init_param.clone().unwrap()).max_iters(10))
+            .configure(|config| {
+                config
+                    .counting(true)
+                    .param(ls.init_param.clone().unwrap())
+                    .max_iters(10)
+            })
             .run();
         assert!(data.is_ok());
 
@@ -689,7 +694,12 @@ mod tests {
         ls.search_direction(vec![2.0f64, 0.0]);
 
         let data = Executor::new(prob, ls.clone())
-            .configure(|config| config.param(ls.init_param.clone().unwrap()).max_iters(10))
+            .configure(|config| {
+                config
+                    .counting(true)
+                    .param(ls.init_param.clone().unwrap())
+                    .max_iters(10)
+            })
             .run();
         assert!(data.is_ok());
 

--- a/crates/argmin/src/tests.rs
+++ b/crates/argmin/src/tests.rs
@@ -161,7 +161,12 @@ fn test_lbfgs_func_count() {
     let linesearch = MoreThuenteLineSearch::new();
     let solver = LBFGS::new(linesearch, 10);
     let res = Executor::new(cost.clone(), solver)
-        .configure(|config| config.param(cost.param_init.clone()).max_iters(100))
+        .configure(|config| {
+            config
+                .param(cost.param_init.clone())
+                .max_iters(100)
+                .counting(true)
+        })
         .run()
         .unwrap();
 


### PR DESCRIPTION
- Add a benchmark (that works on stable toolchain) to establish the baseline
- Disable timing by default, enable when needed
- Disable execution counting by default

after:
```
newton  fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ run  4.9 µs        │ 171.4 µs      │ 5.25 µs       │ 6.218 µs      │ 4723907 │ 4723907
```

before:
```
    newton  fastest       │ slowest       │ median        │ mean          │ samples │ iters
    ╰─ run  6.317 µs      │ 171.8 µs      │ 6.729 µs      │ 7.75 µs       │ 3807698 │ 3807698
```

Fixes #482