### PR TITLE
Make `Solver` object safe

### DIFF
--- a/crates/argmin/src/core/executor.rs
+++ b/crates/argmin/src/core/executor.rs
@@ -180,7 +180,8 @@ where
                 let kv = kv.unwrap_or(kv![]);
 
                 // Observe after init
-                self.observers.observe_init(S::NAME, &state, &kv)?;
+                self.observers
+                    .observe_init(self.solver.name(), &state, &kv)?;
             }
 
             state.func_counts(&self.problem);
@@ -681,7 +682,9 @@ mod tests {
             P: Clone,
             F: ArgminFloat,
         {
-            const NAME: &'static str = "OptimizationAlgorithm";
+            fn name(&self) -> &str {
+                "OptimizationAlgorithm"
+            }
 
             // Only resets internal_state to 1
             fn init(

--- a/crates/argmin/src/core/result.rs
+++ b/crates/argmin/src/core/result.rs
@@ -124,7 +124,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         writeln!(f, "OptimizationResult:")?;
-        writeln!(f, "    Solver:        {}", S::NAME)?;
+        writeln!(f, "    Solver:        {}", self.solver.name())?;
         writeln!(
             f,
             "    param (best):  {}",

--- a/crates/argmin/src/core/solver.rs
+++ b/crates/argmin/src/core/solver.rs
@@ -33,7 +33,7 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 ///     P: Clone,
 ///     F: ArgminFloat
 /// {
-///     const NAME: &'static str = "OptimizationAlgorithm";
+///     fn name(&self) -> &str { "OptimizationAlgorithm" }
 ///
 ///     fn init(
 ///         &mut self,
@@ -64,7 +64,7 @@ use crate::core::{Error, Problem, State, TerminationReason, TerminationStatus, K
 /// ```
 pub trait Solver<O, I: State> {
     /// Name of the solver. Mainly used in [Observers](`crate::core::observers::Observe`).
-    const NAME: &'static str;
+    fn name(&self) -> &str;
 
     /// Initializes the algorithm.
     ///

--- a/crates/argmin/src/core/test_utils.rs
+++ b/crates/argmin/src/core/test_utils.rs
@@ -327,7 +327,9 @@ impl TestSolver {
 }
 
 impl<O> Solver<O, IterState<Vec<f64>, (), (), (), (), f64>> for TestSolver {
-    const NAME: &'static str = "TestSolver";
+    fn name(&self) -> &str {
+        "TestSolver"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/brent/brentopt.rs
+++ b/crates/argmin/src/solver/brent/brentopt.rs
@@ -102,7 +102,9 @@ where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "BrentOpt";
+    fn name(&self) -> &str {
+        "BrentOpt"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/brent/brentroot.rs
+++ b/crates/argmin/src/solver/brent/brentroot.rs
@@ -80,7 +80,9 @@ where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "BrentRoot";
+    fn name(&self) -> &str {
+        "BrentRoot"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/conjugategradient/cg.rs
+++ b/crates/argmin/src/solver/conjugategradient/cg.rs
@@ -91,7 +91,9 @@ where
     R: ArgminMul<F, R> + ArgminMul<F, P> + ArgminConj + ArgminDot<R, F> + ArgminScaledAdd<P, F, R>,
     F: ArgminFloat + ArgminL2Norm<F>,
 {
-    const NAME: &'static str = "Conjugate Gradient";
+    fn name(&self) -> &str {
+        "Conjugate Gradient"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -128,7 +128,9 @@ where
     B: NLCGBetaUpdate<G, P, F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Nonlinear Conjugate Gradient";
+    fn name(&self) -> &str {
+        "Nonlinear Conjugate Gradient"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/crates/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -96,7 +96,9 @@ where
     F: ArgminFloat,
     R: Clone,
 {
-    const NAME: &'static str = "Gauss-Newton method with line search";
+    fn name(&self) -> &str {
+        "Gauss-Newton method with line search"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/crates/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -122,7 +122,9 @@ where
         + ArgminDot<P, P>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Gauss-Newton method";
+    fn name(&self) -> &str {
+        "Gauss-Newton method"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/crates/argmin/src/solver/goldensectionsearch/mod.rs
@@ -139,7 +139,9 @@ where
     O: CostFunction<Param = F, Output = F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Golden-section search";
+    fn name(&self) -> &str {
+        "Golden-section search"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/crates/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -58,7 +58,9 @@ where
     L: Clone + LineSearch<G, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Steepest Descent";
+    fn name(&self) -> &str {
+        "Steepest Descent"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/landweber/mod.rs
+++ b/crates/argmin/src/solver/landweber/mod.rs
@@ -69,7 +69,9 @@ where
     P: Clone + ArgminScaledSub<G, F, P>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Landweber";
+    fn name(&self) -> &str {
+        "Landweber"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/linesearch/backtracking.rs
+++ b/crates/argmin/src/solver/linesearch/backtracking.rs
@@ -183,7 +183,9 @@ where
     L: LineSearchCondition<G, G, F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Backtracking line search";
+    fn name(&self) -> &str {
+        "Backtracking line search"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/crates/argmin/src/solver/linesearch/hagerzhang.rs
@@ -502,7 +502,9 @@ where
     G: Clone + ArgminDot<G, F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Hager-Zhang line search";
+    fn name(&self) -> &str {
+        "Hager-Zhang line search"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/linesearch/morethuente.rs
+++ b/crates/argmin/src/solver/linesearch/morethuente.rs
@@ -303,7 +303,9 @@ where
     G: Clone + ArgminDot<G, F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "More-Thuente Line search";
+    fn name(&self) -> &str {
+        "More-Thuente Line search"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/neldermead/mod.rs
+++ b/crates/argmin/src/solver/neldermead/mod.rs
@@ -322,7 +322,9 @@ where
     P: Clone + ArgminSub<P, P> + ArgminAdd<P, P> + ArgminMul<F, P>,
     F: ArgminFloat + std::iter::Sum<F>,
 {
-    const NAME: &'static str = "Nelder-Mead method";
+    fn name(&self) -> &str {
+        "Nelder-Mead method"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/newton/newton_cg.rs
+++ b/crates/argmin/src/solver/newton/newton_cg.rs
@@ -120,7 +120,9 @@ where
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat + ArgminL2Norm<F>,
 {
-    const NAME: &'static str = "Newton-CG";
+    fn name(&self) -> &str {
+        "Newton-CG"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/newton/newton_method.rs
+++ b/crates/argmin/src/solver/newton/newton_method.rs
@@ -92,7 +92,9 @@ where
     H: ArgminInv<H> + ArgminDot<G, P>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Newton method";
+    fn name(&self) -> &str {
+        "Newton method"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -289,7 +289,9 @@ where
     F: ArgminFloat,
     R: Rng,
 {
-    const NAME: &'static str = "Particle Swarm Optimization";
+    fn name(&self) -> &str {
+        "Particle Swarm Optimization"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/quasinewton/bfgs.rs
+++ b/crates/argmin/src/solver/quasinewton/bfgs.rs
@@ -145,7 +145,9 @@ where
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "BFGS";
+    fn name(&self) -> &str {
+        "BFGS"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/quasinewton/dfp.rs
+++ b/crates/argmin/src/solver/quasinewton/dfp.rs
@@ -104,7 +104,9 @@ where
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "DFP";
+    fn name(&self) -> &str {
+        "DFP"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/crates/argmin/src/solver/quasinewton/lbfgs.rs
@@ -333,7 +333,9 @@ where
         + Solver<LineSearchProblem<O, P, G, F>, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "L-BFGS";
+    fn name(&self) -> &str {
+        "L-BFGS"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/quasinewton/sr1.rs
+++ b/crates/argmin/src/solver/quasinewton/sr1.rs
@@ -159,7 +159,9 @@ where
     L: Clone + LineSearch<P, F> + Solver<O, IterState<P, G, (), (), (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "SR1";
+    fn name(&self) -> &str {
+        "SR1"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/crates/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -196,7 +196,9 @@ where
     R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), B, (), F>>,
     F: ArgminFloat + ArgminL2Norm<F>,
 {
-    const NAME: &'static str = "SR1 trust region";
+    fn name(&self) -> &str {
+        "SR1 trust region"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/simulatedannealing/mod.rs
+++ b/crates/argmin/src/solver/simulatedannealing/mod.rs
@@ -442,7 +442,9 @@ where
     F: ArgminFloat,
     R: Rng,
 {
-    const NAME: &'static str = "Simulated Annealing";
+    fn name(&self) -> &str {
+        "Simulated Annealing"
+    }
     fn init(
         &mut self,
         problem: &mut Problem<O>,

--- a/crates/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/crates/argmin/src/solver/trustregion/cauchypoint.rs
@@ -58,7 +58,9 @@ where
     G: ArgminMul<F, P> + ArgminWeightedDot<G, F, H> + ArgminL2Norm<F>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Cauchy Point";
+    fn name(&self) -> &str {
+        "Cauchy Point"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/trustregion/dogleg.rs
+++ b/crates/argmin/src/solver/trustregion/dogleg.rs
@@ -65,7 +65,9 @@ where
     H: ArgminInv<H> + ArgminDot<P, P>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Dogleg";
+    fn name(&self) -> &str {
+        "Dogleg"
+    }
 
     fn next_iter(
         &mut self,

--- a/crates/argmin/src/solver/trustregion/steihaug.rs
+++ b/crates/argmin/src/solver/trustregion/steihaug.rs
@@ -189,7 +189,9 @@ where
     H: ArgminDot<P, P>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Steihaug";
+    fn name(&self) -> &str {
+        "Steihaug"
+    }
 
     fn init(
         &mut self,

--- a/crates/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/crates/argmin/src/solver/trustregion/trustregion_method.rs
@@ -167,7 +167,9 @@ where
     R: Clone + TrustRegionRadius<F> + Solver<O, IterState<P, G, (), H, (), F>>,
     F: ArgminFloat,
 {
-    const NAME: &'static str = "Trust region";
+    fn name(&self) -> &str {
+        "Trust region"
+    }
 
     fn init(
         &mut self,

--- a/media/book/src/implementing_solver.md
+++ b/media/book/src/implementing_solver.md
@@ -98,7 +98,7 @@ where
     F: ArgminFloat,
 {
     // This gives the solver a name which will be used for logging
-    const NAME: &'static str = "Landweber";
+    fn name(&self) -> &str { "Landweber" }
 
     // Defines the computations performed in a single iteration.
     fn next_iter(


### PR DESCRIPTION
Replace associated constant for solver names with a method to make `Solver` object safe.

> A trait is object safe if it has the following qualities (defined in [RFC 255](https://github.com/rust-lang/rfcs/blob/master/text/0255-object-safety.md)):
> 
>    - [...]
>    - It must not have any associated constants.

https://doc.rust-lang.org/beta/reference/items/traits.html#object-safety