### PR TITLE
Nightly clippy lints

### DIFF
--- a/crates/argmin-checkpointing-file/src/lib.rs
+++ b/crates/argmin-checkpointing-file/src/lib.rs
@@ -41,7 +41,6 @@
 pub use argmin::core::checkpointing::{Checkpoint, CheckpointingFrequency};
 use argmin::core::Error;
 use serde::{de::DeserializeOwned, Serialize};
-use std::default::Default;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;

--- a/crates/argmin/src/core/executor.rs
+++ b/crates/argmin/src/core/executor.rs
@@ -10,7 +10,6 @@ use crate::core::observers::{Observe, ObserverMode, Observers};
 use crate::core::{
     Error, OptimizationResult, Problem, Solver, State, TerminationReason, TerminationStatus, KV,
 };
-use instant;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 

--- a/crates/argmin/src/core/state/iterstate.rs
+++ b/crates/argmin/src/core/state/iterstate.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationStatus};
-use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/argmin/src/core/state/linearprogramstate.rs
+++ b/crates/argmin/src/core/state/linearprogramstate.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationStatus};
-use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/argmin/src/core/state/populationstate.rs
+++ b/crates/argmin/src/core/state/populationstate.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::core::{ArgminFloat, Problem, State, TerminationReason, TerminationStatus};
-use instant;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/argmin/src/solver/brent/brentopt.rs
+++ b/crates/argmin/src/solver/brent/brentopt.rs
@@ -210,7 +210,6 @@ where
 mod tests {
     use super::*;
     use crate::core::{Executor, TerminationStatus};
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(brent, BrentOpt<f64>);

--- a/crates/argmin/src/solver/brent/brentroot.rs
+++ b/crates/argmin/src/solver/brent/brentroot.rs
@@ -181,7 +181,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
 
     test_trait_impl!(brent, BrentRoot<f64>);
 }

--- a/crates/argmin/src/solver/conjugategradient/beta.rs
+++ b/crates/argmin/src/solver/conjugategradient/beta.rs
@@ -255,7 +255,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_trait_impl;
 
     test_trait_impl!(fletcher_reeves, FletcherReeves);
     test_trait_impl!(polak_ribiere, PolakRibiere);

--- a/crates/argmin/src/solver/conjugategradient/cg.rs
+++ b/crates/argmin/src/solver/conjugategradient/cg.rs
@@ -154,8 +154,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, Problem};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError};
     use approx::assert_relative_eq;
 
     test_trait_impl!(conjugate_gradient, ConjugateGradient<Vec<f64>, f64>);

--- a/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -228,9 +228,8 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::let_unit_value)]
 mod tests {
-    #![allow(clippy::let_unit_value)]
-
     use super::*;
     use crate::core::test_utils::TestProblem;
     use crate::core::ArgminError;
@@ -238,7 +237,6 @@ mod tests {
     use crate::solver::linesearch::{
         condition::ArmijoCondition, BacktrackingLineSearch, MoreThuenteLineSearch,
     };
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     #[derive(Eq, PartialEq, Clone, Copy, Debug)]

--- a/crates/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
+++ b/crates/argmin/src/solver/gaussnewton/gaussnewton_linesearch.rs
@@ -219,15 +219,13 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::let_unit_value)]
 mod tests {
-    #![allow(clippy::let_unit_value)]
-
     use super::*;
     use crate::core::ArgminError;
     #[cfg(feature = "_ndarrayl")]
-    use crate::core::{IterState, State};
+    use crate::core::State;
     use crate::solver::linesearch::{condition::ArmijoCondition, BacktrackingLineSearch};
-    use crate::{assert_error, test_trait_impl};
     #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 

--- a/crates/argmin/src/solver/gaussnewton/gaussnewton_method.rs
+++ b/crates/argmin/src/solver/gaussnewton/gaussnewton_method.rs
@@ -188,7 +188,6 @@ mod tests {
     use crate::core::ArgminError;
     #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
-    use crate::test_trait_impl;
     #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 

--- a/crates/argmin/src/solver/goldensectionsearch/mod.rs
+++ b/crates/argmin/src/solver/goldensectionsearch/mod.rs
@@ -215,7 +215,6 @@ where
 mod tests {
     use super::*;
     use crate::core::{ArgminError, State};
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     #[derive(Clone)]

--- a/crates/argmin/src/solver/gradientdescent/steepestdescent.rs
+++ b/crates/argmin/src/solver/gradientdescent/steepestdescent.rs
@@ -120,11 +120,10 @@ where
 mod tests {
     use super::*;
     use crate::core::test_utils::TestProblem;
-    use crate::core::{ArgminError, State};
+    use crate::core::ArgminError;
     use crate::solver::linesearch::{
         condition::ArmijoCondition, BacktrackingLineSearch, MoreThuenteLineSearch,
     };
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(

--- a/crates/argmin/src/solver/landweber/mod.rs
+++ b/crates/argmin/src/solver/landweber/mod.rs
@@ -92,8 +92,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, Problem, State};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use approx::assert_relative_eq;
 
     test_trait_impl!(landweber, Landweber<f64>);

--- a/crates/argmin/src/solver/linesearch/backtracking.rs
+++ b/crates/argmin/src/solver/linesearch/backtracking.rs
@@ -253,9 +253,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_error;
-    use crate::core::{test_utils::TestProblem, ArgminError, Executor, State};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError, Executor};
     use approx::assert_relative_eq;
     use num_traits::Float;
 

--- a/crates/argmin/src/solver/linesearch/condition/armijo.rs
+++ b/crates/argmin/src/solver/linesearch/condition/armijo.rs
@@ -68,9 +68,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_error;
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
 
     test_trait_impl!(armijo, ArmijoCondition<f64>);
 

--- a/crates/argmin/src/solver/linesearch/condition/goldstein.rs
+++ b/crates/argmin/src/solver/linesearch/condition/goldstein.rs
@@ -71,9 +71,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_error;
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
 
     test_trait_impl!(goldstein, GoldsteinCondition<f64>);
 

--- a/crates/argmin/src/solver/linesearch/condition/strongwolfe.rs
+++ b/crates/argmin/src/solver/linesearch/condition/strongwolfe.rs
@@ -84,9 +84,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_error;
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
 
     test_trait_impl!(strongwolfe, StrongWolfeCondition<f64>);
 

--- a/crates/argmin/src/solver/linesearch/condition/wolfe.rs
+++ b/crates/argmin/src/solver/linesearch/condition/wolfe.rs
@@ -86,9 +86,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::assert_error;
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
 
     test_trait_impl!(wolfe, WolfeCondition<f64>);
 

--- a/crates/argmin/src/solver/linesearch/hagerzhang.rs
+++ b/crates/argmin/src/solver/linesearch/hagerzhang.rs
@@ -641,8 +641,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, Problem, State};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
 
     test_trait_impl!(hagerzhang, HagerZhangLineSearch<Vec<f64>, Vec<f64>, f64>);
 

--- a/crates/argmin/src/solver/linesearch/morethuente.rs
+++ b/crates/argmin/src/solver/linesearch/morethuente.rs
@@ -16,7 +16,6 @@ use crate::core::{
 use argmin_math::{ArgminDot, ArgminScaledAdd};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
 
 /// # More-Thuente line search
 ///
@@ -721,8 +720,7 @@ fn cstep<F: ArgminFloat>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, Problem};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError};
 
     test_trait_impl!(morethuente, MoreThuenteLineSearch<Vec<f64>, Vec<f64>, f64>);
 

--- a/crates/argmin/src/solver/neldermead/mod.rs
+++ b/crates/argmin/src/solver/neldermead/mod.rs
@@ -433,8 +433,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
-    use crate::test_trait_impl;
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use approx::assert_relative_eq;
 
     test_trait_impl!(nelder_mead, NelderMead<TestProblem, f64>);

--- a/crates/argmin/src/solver/newton/newton_cg.rs
+++ b/crates/argmin/src/solver/newton/newton_cg.rs
@@ -245,13 +245,11 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::let_unit_value)]
 mod tests {
-    #![allow(clippy::let_unit_value)]
-
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError};
     use crate::solver::linesearch::MoreThuenteLineSearch;
-    use crate::test_trait_impl;
 
     test_trait_impl!(
         newton_cg,

--- a/crates/argmin/src/solver/newton/newton_method.rs
+++ b/crates/argmin/src/solver/newton/newton_method.rs
@@ -9,7 +9,6 @@ use crate::core::{ArgminFloat, Error, Gradient, Hessian, IterState, Problem, Sol
 use argmin_math::{ArgminDot, ArgminInv, ArgminScaledSub};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
-use std::default::Default;
 
 /// # Newton's method
 ///
@@ -119,7 +118,6 @@ mod tests {
     use crate::core::ArgminError;
     #[cfg(feature = "_ndarrayl")]
     use crate::core::Executor;
-    use crate::test_trait_impl;
     #[cfg(feature = "_ndarrayl")]
     use approx::assert_relative_eq;
 

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -452,7 +452,6 @@ where
 mod tests {
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, State};
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(

--- a/crates/argmin/src/solver/quasinewton/bfgs.rs
+++ b/crates/argmin/src/solver/quasinewton/bfgs.rs
@@ -294,9 +294,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
-    use crate::test_trait_impl;
 
     test_trait_impl!(
         bfgs,

--- a/crates/argmin/src/solver/quasinewton/dfp.rs
+++ b/crates/argmin/src/solver/quasinewton/dfp.rs
@@ -237,9 +237,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
-    use crate::test_trait_impl;
 
     test_trait_impl!(
         dfp,

--- a/crates/argmin/src/solver/quasinewton/lbfgs.rs
+++ b/crates/argmin/src/solver/quasinewton/lbfgs.rs
@@ -517,10 +517,9 @@ mod tests {
     use super::*;
     use crate::core::{
         test_utils::{TestProblem, TestSparseProblem},
-        ArgminError, IterState, State,
+        ArgminError,
     };
     use crate::solver::linesearch::MoreThuenteLineSearch;
-    use crate::test_trait_impl;
 
     test_trait_impl!(
         lbfgs,

--- a/crates/argmin/src/solver/quasinewton/sr1.rs
+++ b/crates/argmin/src/solver/quasinewton/sr1.rs
@@ -292,9 +292,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use crate::solver::linesearch::MoreThuenteLineSearch;
-    use crate::test_trait_impl;
 
     test_trait_impl!(
         sr1,

--- a/crates/argmin/src/solver/quasinewton/sr1_trustregion.rs
+++ b/crates/argmin/src/solver/quasinewton/sr1_trustregion.rs
@@ -349,9 +349,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{test_utils::TestProblem, ArgminError, IterState, State};
+    use crate::core::{test_utils::TestProblem, ArgminError, State};
     use crate::solver::trustregion::CauchyPoint;
-    use crate::test_trait_impl;
 
     test_trait_impl!(sr1, SR1TrustRegion<CauchyPoint<f64>, f64>);
 

--- a/crates/argmin/src/solver/simulatedannealing/mod.rs
+++ b/crates/argmin/src/solver/simulatedannealing/mod.rs
@@ -571,7 +571,6 @@ where
 mod tests {
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError, State};
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(sa, SimulatedAnnealing<f64, StdRng>);

--- a/crates/argmin/src/solver/trustregion/cauchypoint.rs
+++ b/crates/argmin/src/solver/trustregion/cauchypoint.rs
@@ -131,7 +131,6 @@ where
 mod tests {
     use super::*;
     use crate::core::{test_utils::TestProblem, ArgminError};
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(cauchypoint, CauchyPoint<f64>);

--- a/crates/argmin/src/solver/trustregion/dogleg.rs
+++ b/crates/argmin/src/solver/trustregion/dogleg.rs
@@ -167,7 +167,6 @@ mod tests {
     use super::*;
     #[cfg(feature = "_ndarrayl")]
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
 
     test_trait_impl!(dogleg, Dogleg<f64>);
 

--- a/crates/argmin/src/solver/trustregion/steihaug.rs
+++ b/crates/argmin/src/solver/trustregion/steihaug.rs
@@ -330,7 +330,6 @@ mod tests {
     use super::*;
     use crate::core::test_utils::TestProblem;
     use crate::core::ArgminError;
-    use crate::test_trait_impl;
     use approx::assert_relative_eq;
 
     test_trait_impl!(steihaug, Steihaug<TestProblem, f64>);

--- a/crates/argmin/src/solver/trustregion/trustregion_method.rs
+++ b/crates/argmin/src/solver/trustregion/trustregion_method.rs
@@ -303,7 +303,6 @@ mod tests {
     use crate::core::test_utils::TestProblem;
     use crate::core::{ArgminError, State};
     use crate::solver::trustregion::{CauchyPoint, Steihaug};
-    use crate::test_trait_impl;
 
     test_trait_impl!(trustregion, TrustRegion<Steihaug<TestProblem, f64>, f64>);
 

--- a/crates/argmin/src/tests.rs
+++ b/crates/argmin/src/tests.rs
@@ -9,7 +9,6 @@
 
 use approx::assert_relative_eq;
 use ndarray::prelude::*;
-use ndarray::{Array1, Array2};
 
 use crate::core::{CostFunction, Error, Executor, Gradient, Hessian, State};
 use crate::solver::gradientdescent::SteepestDescent;


### PR DESCRIPTION
This PR fixes warnings raised by

```
cargo +nightly clippy -p argmin --all-targets --features "_full_dev" -- -D warnings
```

around [stricter `unused_imports` checks](https://github.com/rust-lang/rust/pull/117772).