### PR TITLE
Feature/412 add faer rs backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
         run: cargo test -p argmin-math --no-default-features --features "nalgebra_v0_30"
       - name: argmin-math (nalgebra_v0_29)
         run: cargo test -p argmin-math --no-default-features --features "nalgebra_v0_29"
+      # faer
+      - name: argmin-math (faer_latest)
+        run: cargo test -p argmin-math --no-default-features --features "faer_latest"
+      - name: argmin-math (faer_v0_20)
+        run: cargo test -p argmin-math --no-default-features --features "faer_v0_20"
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -14,11 +14,6 @@ categories = ["science"]
 exclude = []
 
 [dependencies]
-#faer
-#@todo(geo) make optional
-faer_0_20 = {package = "faer", version = "0.20"}
-# faer_core_0_17 = {package = "faer-core", version = "0.17"}
-
 # nalgebra
 nalgebra_0_33 = { package = "nalgebra", version = "0.33", optional = true }
 nalgebra_0_32 = { package = "nalgebra", version = "0.32", optional = true }
@@ -34,6 +29,10 @@ ndarray-linalg_0_16 = { package = "ndarray-linalg", version = "0.16", optional =
 ndarray_0_14 = { package = "ndarray", version = "0.14", optional = true }
 ## v0.13
 ndarray_0_13 = { package = "ndarray", version = "0.13", optional = true }
+
+#faer
+#@todo(geo) TODO make optional true
+faer_0_20 = { package = "faer", version = "0.20", optional = false }
 
 # general
 num-complex_0_4 = { package = "num-complex", version = "0.4", optional = true, default-features = false, features = ["std"] }
@@ -73,6 +72,11 @@ nalgebra_v0_29 = ["nalgebra_0_29", "num-complex_0_4", "nalgebra_all"]
 # ndarray
 ndarray_all = ["primitives"]
 ndarray_latest = ["ndarray_v0_15"]
+
+#faer
+# faer_all = ["primitives"]
+# faer_latest = ["faer_v0_20"]
+# faer_v0_20  = ["faer_0_20", "num-complex_0_4", "faer_all"]
 
 ## With `ndarray-linalg`
 ndarray_v0_15 = ["ndarray_0_15", "ndarray-linalg_0_16", "num-complex_0_4", "ndarray_all"]

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["science"]
 exclude = []
 
 [dependencies]
+#faer
+#@todo(geo) make optional
+faer_0_20 = {package = "faer", version = "0.20"}
+
 # nalgebra
 nalgebra_0_33 = { package = "nalgebra", version = "0.33", optional = true }
 nalgebra_0_32 = { package = "nalgebra", version = "0.32", optional = true }

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -17,6 +17,7 @@ exclude = []
 #faer
 #@todo(geo) make optional
 faer_0_20 = {package = "faer", version = "0.20"}
+# faer_core_0_17 = {package = "faer-core", version = "0.17"}
 
 # nalgebra
 nalgebra_0_33 = { package = "nalgebra", version = "0.33", optional = true }

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -31,8 +31,7 @@ ndarray_0_14 = { package = "ndarray", version = "0.14", optional = true }
 ndarray_0_13 = { package = "ndarray", version = "0.13", optional = true }
 
 #faer
-#@todo(geo) TODO make optional true
-faer_0_20 = { package = "faer", version = "0.20", optional = false }
+faer_0_20 = { package = "faer", version = "0.20", optional = true}
 
 # general
 num-complex_0_4 = { package = "num-complex", version = "0.4", optional = true, default-features = false, features = ["std"] }
@@ -74,9 +73,9 @@ ndarray_all = ["primitives"]
 ndarray_latest = ["ndarray_v0_15"]
 
 #faer
-# faer_all = ["primitives"]
-# faer_latest = ["faer_v0_20"]
-# faer_v0_20  = ["faer_0_20", "num-complex_0_4", "faer_all"]
+faer_all = ["primitives"]
+faer_latest = ["faer_v0_20"]
+faer_v0_20  = ["faer_0_20", "num-complex_0_4", "faer_all"]
 
 ## With `ndarray-linalg`
 ndarray_v0_15 = ["ndarray_0_15", "ndarray-linalg_0_16", "num-complex_0_4", "ndarray_all"]

--- a/crates/argmin-math/README.md
+++ b/crates/argmin-math/README.md
@@ -47,7 +47,7 @@
 
 
 This create provides a abstractions for mathematical operations needed in [argmin](https://argmin-rs.org).
-The supported math backends so far are basic `Vec`s, `ndarray` and `nalgebra`.
+The supported math backends so far are basic `Vec`s, `ndarray`, `nalgebra`, and `faer`.
 Please consult the documentation for details.
 
 

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -34,8 +34,6 @@ where
     }
 }
 
-//@todo(geo) also add scalar + Matrix and matrix + Scalar (and reference variants?)
-
 /// Mat + Scalar -> Mat
 impl<E, R, C> ArgminAdd<E, Mat<E, R, C>> for Mat<E, R, C>
 where
@@ -73,7 +71,7 @@ where
 {
     #[inline]
     fn add(&self, other: &MatRef<'a, E>) -> Mat<E> {
-        <_ as Add>::add(self, other)
+        self + other
     }
 }
 
@@ -81,6 +79,14 @@ where
 impl<E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn add(&self, other: &Mat<E>) -> Mat<E> {
+        self + other
+    }
+}
+
+/// Mat + MatRef -> Mat
+impl<E: Entity + ComplexField> ArgminAdd<MatRef<'_, E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn add(&self, other: &MatRef<'_, E>) -> Mat<E> {
         self + other
     }
 }
@@ -109,9 +115,13 @@ mod tests {
                     let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
                     let b = 34 as $t;
                     let target = vector3_new(35 as $t, 38 as $t, 42 as $t);
-                    let res = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    let res1 = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    let res2 = <_ as ArgminAdd<$t, _>>::add(&a.as_mat_ref(), &b);
+                    assert_eq!(res1, res2);
+                    assert_eq!(res1.nrows(), 3);
+                    assert_eq!(res1.ncols(), 1);
                     for i in 0..3 {
-                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(target[(i,0)] as f64, res1[(i,0)] as f64, epsilon = f64::EPSILON);
                     }
                 }
             }
@@ -122,9 +132,13 @@ mod tests {
                     let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
                     let b = 34 as $t;
                     let target = vector3_new(35 as $t, 38 as $t, 42 as $t);
-                    let res = <$t as ArgminAdd<_,_>>::add(&b, &a);
+                    let res1 = <_ as ArgminAdd<_, _>>::add(&b, &a);
+                    let res2 = <_ as ArgminAdd<_, _>>::add(&b, &a.as_mat_ref());
+                    assert_eq!(res1, res2);
+                    assert_eq!(res1.nrows(), 3);
+                    assert_eq!(res1.ncols(), 1);
                     for i in 0..3 {
-                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(target[(i,0)] as f64, res1[(i,0)] as f64, epsilon = f64::EPSILON);
                     }
                 }
             }
@@ -187,10 +201,18 @@ mod tests {
                         42 as $t, 42 as $t, 42 as $t,
                         42 as $t, 42 as $t, 42 as $t
                     );
-                    let res = <_ as ArgminAdd<_, _>>::add(&a, &b);
+                    let res1 = <_ as ArgminAdd<_, _>>::add(&a, &b);
+                    let res2 = <_ as ArgminAdd<_, _>>::add(&a.as_mat_ref(), &b);
+                    let res3 = <_ as ArgminAdd<_, _>>::add(&a, &b.as_mat_ref());
+                    let res4 = <_ as ArgminAdd<_, _>>::add(&a.as_mat_ref(), &b.as_mat_ref());
+                    assert_eq!(res1, res2);
+                    assert_eq!(res1, res3);
+                    assert_eq!(res1, res4);
+                    assert_eq!(res1.nrows(), 2);
+                    assert_eq!(res1.ncols(), 3);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(target[(j, i)] as f64, res1[(j, i)] as f64, epsilon = f64::EPSILON);
                         }
                     }
                 }
@@ -208,10 +230,14 @@ mod tests {
                         3 as $t, 6 as $t, 10 as $t,
                         4 as $t, 7 as $t, 11 as $t
                     );
-                    let res = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    let res1 = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    let res2 = <_ as ArgminAdd<$t, _>>::add(&a.as_mat_ref(), &b);
+                    assert_eq!(res1, res2);
+                    assert_eq!(res1.nrows(), 2);
+                    assert_eq!(res1.ncols(), 3);
                     for i in 0..3 {
                         for j in 0..2 {
-                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(target[(j, i)] as f64, res1[(j, i)] as f64, epsilon = f64::EPSILON);
                         }
                     }
                 }

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -8,7 +8,7 @@ use faer::{
 use std::ops::{Add, AddAssign};
 
 /// MatRef + Scalar -> Mat
-impl<'a, E, R, C> ArgminAdd<E, Mat<E, R, C>> for MatRef<'a, E, R, C>
+impl<E, R, C> ArgminAdd<E, Mat<E, R, C>> for MatRef<'_, E, R, C>
 where
     E: Entity + Add<E, Output = E>,
     R: faer::Shape,
@@ -67,7 +67,7 @@ where
 }
 
 /// MatRef + MatRef -> Mat
-impl<'a, 'b, E> ArgminAdd<MatRef<'a, E>, Mat<E>> for MatRef<'b, E>
+impl<'a, E> ArgminAdd<MatRef<'a, E>, Mat<E>> for MatRef<'_, E>
 where
     E: Entity + ComplexField,
 {
@@ -78,7 +78,7 @@ where
 }
 
 /// MatRef + Mat -> Mat
-impl<'a, 'b, E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn add(&self, other: &Mat<E>) -> Mat<E> {
         self + other

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -1,4 +1,3 @@
-use super::RealEntity;
 use crate::ArgminAdd;
 use faer::{
     mat::{AsMatMut, AsMatRef},

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -1,0 +1,32 @@
+use std::ops::AddAssign;
+
+use crate::ArgminAdd;
+use faer::{mat::AsMatRef, Conjugate, Mat, MatRef, SimpleEntity};
+
+impl<'a, E> ArgminAdd<E, Mat<E::Canonical>> for MatRef<'a, E>
+where
+    E: SimpleEntity + Conjugate<Canonical = E>,
+    E::Canonical: AddAssign<E>,
+{
+    fn add(&self, other: &E) -> Mat<E::Canonical> {
+        let mut owned = MatRef::to_owned(self);
+        owned
+            .col_iter_mut()
+            .flat_map(|col_iter| col_iter.iter_mut())
+            .for_each(|elem| elem.add_assign(*other));
+
+        owned
+    }
+}
+
+#[test]
+fn test_blah() {
+    fn add_scalar(scalar: f64, mat: &Mat<f64>) -> Mat<f64> {
+        <MatRef<f64> as ArgminAdd<f64, Mat<f64>>>::add(&mat.as_mat_ref(), &scalar)
+    }
+    let mat = Mat::<f64>::zeros(10, 11);
+    let mut expected = Mat::<f64>::zeros(10, 11);
+    let mat = add_scalar(1., &mat);
+    expected.fill(1.);
+    assert_eq!(mat, expected);
+}

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -78,7 +78,7 @@ where
 }
 
 /// MatRef + Mat -> Mat
-impl<'a, E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'_, E> {
+impl<E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn add(&self, other: &Mat<E>) -> Mat<E> {
         self + other
@@ -86,7 +86,7 @@ impl<'a, E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'_, E> {
 }
 
 /// Mat + Mat -> Mat
-impl<'a, 'b, E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for Mat<E> {
+impl<E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn add(&self, other: &Mat<E>) -> Mat<E> {
         self + other

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -1,13 +1,19 @@
-use std::ops::AddAssign;
-
+use super::RealEntity;
 use crate::ArgminAdd;
-use faer::{mat::AsMatRef, Conjugate, Mat, MatRef, SimpleEntity};
+use faer::{
+    mat::AsMatRef,
+    reborrow::{IntoConst, Reborrow, ReborrowMut},
+    ComplexField, Conjugate, Entity, Mat, MatMut, MatRef, SimpleEntity,
+};
+use std::ops::{Add, AddAssign};
 
+/// MatRef + Scalar -> Mat
 impl<'a, E> ArgminAdd<E, Mat<E::Canonical>> for MatRef<'a, E>
 where
-    E: SimpleEntity + Conjugate<Canonical = E>,
+    E: RealEntity,
     E::Canonical: AddAssign<E>,
 {
+    #[inline]
     fn add(&self, other: &E) -> Mat<E::Canonical> {
         let mut owned = MatRef::to_owned(self);
         owned
@@ -19,14 +25,61 @@ where
     }
 }
 
-#[test]
-fn test_blah() {
-    fn add_scalar(scalar: f64, mat: &Mat<f64>) -> Mat<f64> {
-        <MatRef<f64> as ArgminAdd<f64, Mat<f64>>>::add(&mat.as_mat_ref(), &scalar)
+//@todo(geo) also add scalar + Matrix and matrix + Scalar (and reference variants?)
+
+/// Mat + Scalar -> Mat
+impl<E> ArgminAdd<E, Mat<E::Canonical>> for Mat<E>
+where
+    E: RealEntity,
+    E::Canonical: AddAssign<E>,
+{
+    #[inline]
+    fn add(&self, other: &E) -> Mat<E::Canonical> {
+        <MatRef<E> as ArgminAdd<_, _>>::add(&self.as_mat_ref(), other)
     }
-    let mat = Mat::<f64>::zeros(10, 11);
-    let mut expected = Mat::<f64>::zeros(10, 11);
-    let mat = add_scalar(1., &mat);
-    expected.fill(1.);
-    assert_eq!(mat, expected);
+}
+
+/// MatRef + MatRef -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminAdd<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+    #[inline]
+    fn add(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        <_ as Add>::add(self, other)
+    }
+}
+
+/// MatRef + Mat -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for MatRef<'b, E> {
+    #[inline]
+    fn add(&self, other: &Mat<E>) -> Mat<E> {
+        self + other
+    }
+}
+
+/// Mat + Mat -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn add(&self, other: &Mat<E>) -> Mat<E> {
+        self + other
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_scalar() {
+        fn add_scalar(scalar: f64, mat: &Mat<f64>) -> Mat<f64> {
+            <MatRef<f64> as ArgminAdd<f64, Mat<f64>>>::add(&mat.as_mat_ref(), &scalar)
+        }
+        let mat = Mat::<f64>::zeros(10, 11);
+        let mut expected = Mat::<f64>::zeros(10, 11);
+        let mat = add_scalar(1., &mat);
+        expected.fill(1.);
+        assert_eq!(mat, expected);
+    }
+
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
 }

--- a/crates/argmin-math/src/faer_m/add.rs
+++ b/crates/argmin-math/src/faer_m/add.rs
@@ -94,22 +94,159 @@ impl<E: Entity + ComplexField> ArgminAdd<Mat<E>, Mat<E>> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::super::test_helper::*;
     use super::*;
-    #[test]
-    fn test_scalar() {
-        fn add_scalar(scalar: f64, mat: &Mat<f64>) -> Mat<f64> {
-            <MatRef<f64> as ArgminAdd<f64, Mat<f64>>>::add(&mat.as_mat_ref(), &scalar)
-        }
-        let mat = Mat::<f64>::zeros(10, 11);
-        let mut expected = Mat::<f64>::zeros(10, 11);
-        let mat = add_scalar(1., &mat);
-        expected.fill(1.);
-        assert_eq!(mat, expected);
+    use approx::assert_relative_eq;
+    use faer::mat::AsMatRef;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_add_vec_scalar_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 34 as $t;
+                    let target = vector3_new(35 as $t, 38 as $t, 42 as $t);
+                    let res = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_scalar_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 34 as $t;
+                    let target = vector3_new(35 as $t, 38 as $t, 42 as $t);
+                    let res = <$t as ArgminAdd<_,_>>::add(&b, &a);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_vec_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = vector3_new(41 as $t, 38 as $t, 34 as $t);
+                    let target = vector3_new(42 as $t, 42 as $t, 42 as $t);
+                    let res = <_ as ArgminAdd<_, _>>::add(&a, &b);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_ $t>]() {
+                    let a = column_vector_from_vec(vec![1 as $t, 4 as $t]);
+                    let b = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <_ as ArgminAdd<_,_>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_2_ $t>]() {
+                    let a = column_vector_from_vec(vec![]);
+                    let b = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <_ as ArgminAdd<_, _>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_vec_vec_panic_3_ $t>]() {
+                    let a = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    let b = column_vector_from_vec(vec![]);
+                    <_ as ArgminAdd<_, _>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_mat_ $t>]() {
+                    let a = matrix2x3_new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = matrix2x3_new(
+                        41 as $t, 38 as $t, 34 as $t,
+                        40 as $t, 37 as $t, 33 as $t
+                    );
+                    let target = matrix2x3_new(
+                        42 as $t, 42 as $t, 42 as $t,
+                        42 as $t, 42 as $t, 42 as $t
+                    );
+                    let res = <_ as ArgminAdd<_, _>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_add_mat_scalar_ $t>]() {
+                    let a = matrix2x3_new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = 2 as $t;
+                    let target = matrix2x3_new(
+                        3 as $t, 6 as $t, 10 as $t,
+                        4 as $t, 7 as $t, 11 as $t
+                    );
+                    let res = <_ as ArgminAdd<$t, _>>::add(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_2_ $t>]() {
+                    let a = faer::mat![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = faer::mat![
+                        [41 as $t, 38 as $t]
+                    ];
+                    <_ as ArgminAdd<_, _>>::add(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_add_mat_mat_panic_3_ $t>]() {
+                    let a = faer::mat![
+                        [1 as $t, 4 as $t, 8 as $t],
+                        [2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let b = faer::Mat::new();
+                    <_ as ArgminAdd<_, _>>::add(&a, &b);
+                }
+            }
+        };
     }
 
-    #[test]
-    fn more_tests() {
-        todo!()
-    }
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/conj.rs
+++ b/crates/argmin-math/src/faer_m/conj.rs
@@ -1,15 +1,13 @@
 use crate::ArgminConj;
 use faer::{mat::AsMatRef, reborrow::ReborrowMut, Conjugate, Entity, Mat, MatMut, MatRef};
 
-use super::RealEntity;
-
 impl<'a, E: Entity + Conjugate<Conj = E>> ArgminConj for MatRef<'a, E> {
     fn conj(&self) -> Self {
         self.conjugate()
     }
 }
 
-impl<E: RealEntity> ArgminConj for Mat<E> {
+impl<E: Entity + Conjugate<Canonical = E, Conj = E>> ArgminConj for Mat<E> {
     #[inline]
     fn conj(&self) -> Self {
         self.as_mat_ref().conj().to_owned()

--- a/crates/argmin-math/src/faer_m/conj.rs
+++ b/crates/argmin-math/src/faer_m/conj.rs
@@ -1,0 +1,38 @@
+use crate::ArgminConj;
+use faer::{mat::AsMatRef, reborrow::ReborrowMut, Conjugate, Entity, Mat, MatMut, MatRef};
+
+use super::RealEntity;
+
+impl<'a, E: Entity + Conjugate<Conj = E>> ArgminConj for MatRef<'a, E> {
+    fn conj(&self) -> Self {
+        self.conjugate()
+    }
+}
+
+impl<E: RealEntity> ArgminConj for Mat<E> {
+    #[inline]
+    fn conj(&self) -> Self {
+        self.as_mat_ref().conj().to_owned()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ArgminConj;
+    use faer::{
+        mat::{AsMatMut, AsMatRef},
+        Mat,
+    };
+
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+
+    #[test]
+    fn test_conj() {
+        let mat = Mat::<f64>::zeros(3, 2);
+        let expected = mat.conjugate();
+        assert_eq!(expected, <_ as ArgminConj>::conj(&mat.as_mat_ref()))
+    }
+}

--- a/crates/argmin-math/src/faer_m/conj.rs
+++ b/crates/argmin-math/src/faer_m/conj.rs
@@ -1,36 +1,68 @@
 use crate::ArgminConj;
-use faer::{mat::AsMatRef, reborrow::ReborrowMut, Conjugate, Entity, Mat, MatMut, MatRef};
+use faer::{
+    mat::AsMatRef, reborrow::ReborrowMut, unzipped, Conjugate, Entity, Mat, MatMut, MatRef,
+    SimpleEntity,
+};
+use num_complex::ComplexFloat;
 
-impl<E: Entity + Conjugate<Conj = E>> ArgminConj for MatRef<'_, E> {
-    fn conj(&self) -> Self {
-        self.conjugate()
-    }
-}
-
-impl<E: Entity + Conjugate<Canonical = E, Conj = E>> ArgminConj for Mat<E> {
+impl<E: Entity + num_complex::ComplexFloat> ArgminConj for Mat<E> {
     #[inline]
     fn conj(&self) -> Self {
-        self.as_mat_ref().conj().to_owned()
+        //@note(geo-ant): we can't directly use the `conjugate()' function
+        // on the MatRef struct since it's not guaranteed to return matrix same type.
+        // Thus, we implement the conjugation using the num-complex trait manually
+        faer::zipped_rw!(self).map(|unzipped!(this)| ComplexFloat::conj(this.read()))
     }
 }
 
 #[cfg(test)]
-mod test {
-    use crate::ArgminConj;
-    use faer::{
-        mat::{AsMatMut, AsMatRef},
-        Mat,
-    };
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::linalg::entity::complex_split::ComplexConj;
+    use num_complex::Complex;
+    use paste::item;
 
-    #[test]
-    fn more_tests() {
-        todo!()
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_conj_complex_faer_ $t>]() {
+                        let a : Mat<Complex<$t>> = vector3_new(
+                        Complex::new(1 as $t, 2 as $t),
+                        Complex::new(4 as $t, -3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    );
+                    let b = vector3_new(
+                        Complex::new(1 as $t, -2 as $t),
+                        Complex::new(4 as $t, 3 as $t),
+                        Complex::new(8 as $t, 0 as $t)
+                    );
+                    let res: Mat<_> = <Mat<Complex<$t>> as ArgminConj>::conj(&a);
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(b.read(i,0).re(), res.read(i,0).re(), epsilon = $t::EPSILON);
+                        assert_relative_eq!(b.read(i,0).im(), res.read(i,0).im(), epsilon = $t::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_conj_faer_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let res = <_ as ArgminConj>::conj(&a);
+                    for i in 0..3 {
+                        assert_relative_eq!(b[(i,0)], res[(i,0)], epsilon = $t::EPSILON);
+                    }
+                }
+            }
+        };
     }
 
-    #[test]
-    fn test_conj() {
-        let mat = Mat::<f64>::zeros(3, 2);
-        let expected = mat.conjugate();
-        assert_eq!(expected, <_ as ArgminConj>::conj(&mat.as_mat_ref()))
-    }
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/conj.rs
+++ b/crates/argmin-math/src/faer_m/conj.rs
@@ -1,7 +1,7 @@
 use crate::ArgminConj;
 use faer::{mat::AsMatRef, reborrow::ReborrowMut, Conjugate, Entity, Mat, MatMut, MatRef};
 
-impl<'a, E: Entity + Conjugate<Conj = E>> ArgminConj for MatRef<'a, E> {
+impl<E: Entity + Conjugate<Conj = E>> ArgminConj for MatRef<'_, E> {
     fn conj(&self) -> Self {
         self.conjugate()
     }

--- a/crates/argmin-math/src/faer_m/div.rs
+++ b/crates/argmin-math/src/faer_m/div.rs
@@ -7,7 +7,7 @@ use faer::{
 use std::ops::{Div, DivAssign};
 
 /// MatRef / Scalar -> MatRef
-impl<'a, E> ArgminDiv<E, Mat<E>> for MatRef<'a, E>
+impl<E> ArgminDiv<E, Mat<E>> for MatRef<'_, E>
 where
     E: Entity + Div<E, Output = E>,
 {
@@ -59,7 +59,7 @@ where
 }
 
 /// MatRef / MatRef -> Mat
-impl<'a, 'b, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn div(&self, other: &MatRef<'a, E>) -> Mat<E> {
         zipped_rw!(self, other).map(|unzipped!(this, other)| this.read() / other.read())
@@ -75,7 +75,7 @@ impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for Ma
 }
 
 /// MatRef / Mat-> Mat
-impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for MatRef<'a, E> {
+impl<E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn div(&self, other: &Mat<E>) -> Mat<E> {
         <_ as ArgminDiv<_, _>>::div(self, &other.as_mat_ref())

--- a/crates/argmin-math/src/faer_m/div.rs
+++ b/crates/argmin-math/src/faer_m/div.rs
@@ -58,7 +58,7 @@ where
     }
 }
 
-/// MatRef / MatRef -> Mat
+/// MatRef / MatRef -> Mat (pointwise division)
 impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn div(&self, other: &MatRef<'a, E>) -> Mat<E> {
@@ -66,7 +66,7 @@ impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for Ma
     }
 }
 
-/// Mat / MatRef -> Mat
+/// Mat / MatRef -> Mat (pointwise division)
 impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for Mat<E> {
     #[inline]
     fn div(&self, other: &MatRef<'a, E>) -> Mat<E> {
@@ -74,7 +74,7 @@ impl<'a, E: Entity + Div<E, Output = E>> ArgminDiv<MatRef<'a, E>, Mat<E>> for Ma
     }
 }
 
-/// MatRef / Mat-> Mat
+/// MatRef / Mat-> Mat (pointwise division)
 impl<E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn div(&self, other: &Mat<E>) -> Mat<E> {
@@ -82,7 +82,7 @@ impl<E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for MatRef<'_, E>
     }
 }
 
-/// Mat / Mat-> Mat
+/// Mat / Mat-> Mat (pointwise division)
 impl<E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn div(&self, other: &Mat<E>) -> Mat<E> {
@@ -91,9 +91,160 @@ impl<E: Entity + Div<E, Output = E>> ArgminDiv<Mat<E>, Mat<E>> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat::AsMatRef;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_div_vec_scalar_ $t>]() {
+                    let a = vector3_new(4 as $t, 16 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = vector3_new(2 as $t, 8 as $t, 4 as $t);
+                    let res1 = <_ as ArgminDiv<$t, _>>::div(&a, &b);
+                    let res2 = <_ as ArgminDiv<$t, _>>::div(&a.as_mat_ref(), &b);
+                    assert_eq!(res1,res2);
+                    assert_eq!(res1.nrows(),3);
+                    assert_eq!(res1.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res1[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_scalar_vec_ $t>]() {
+                    let a = vector3_new(2 as $t, 4 as $t, 8 as $t);
+                    let b = 32 as $t;
+                    let target = vector3_new(16 as $t, 8 as $t, 4 as $t);
+                    let res1 = <$t as ArgminDiv<_, _>>::div(&b, &a);
+                    let res2 = <$t as ArgminDiv<_, _>>::div(&b, &a);
+                    assert_eq!(res1,res2);
+                    assert_eq!(res1.nrows(),3);
+                    assert_eq!(res1.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res1[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_vec_vec_ $t>]() {
+                    let a = vector3_new(4 as $t, 9 as $t, 8 as $t);
+                    let b = vector3_new(2 as $t, 3 as $t, 4 as $t);
+                    let target = vector3_new(2 as $t, 3 as $t, 2 as $t);
+                    let res1 :Mat<$t> = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res2 :Mat<$t> = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res3 :Mat<$t> = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res4 :Mat<$t> = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    assert_eq!(res1,res2);
+                    assert_eq!(res1,res3);
+                    assert_eq!(res1,res4);
+                    assert_eq!(res1.nrows(),3);
+                    assert_eq!(res1.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res1[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_ $t>]() {
+                    let a = column_vector_from_vec(vec![1 as $t, 4 as $t]);
+                    let b = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    <_ as ArgminDiv<_, _>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_2_ $t>]() {
+                    let a = column_vector_from_vec(vec![]); let b = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]); <_ as ArgminDiv<_, _>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_vec_vec_panic_3_ $t>]() {
+                    let a = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    let b = column_vector_from_vec(vec![]);
+                    <_ as ArgminDiv<_,_>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_div_mat_mat_ $t>]() {
+                    let a = matrix2x3_new(
+                        4 as $t, 12 as $t, 8 as $t,
+                        9 as $t, 20 as $t, 45 as $t
+                    );
+                    let b = matrix2x3_new(
+                        2 as $t, 3 as $t, 4 as $t,
+                        3 as $t, 4 as $t, 5 as $t
+                    );
+                    let target = matrix2x3_new(
+                        2 as $t, 4 as $t, 2 as $t,
+                        3 as $t, 5 as $t, 9 as $t
+                    );
+                    let res1 = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res2 = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res3 = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    let res4 = <_ as ArgminDiv<_, _>>::div(&a, &b);
+                    assert_eq!(res1,res2);
+                    assert_eq!(res1,res3);
+                    assert_eq!(res1,res4);
+                    assert_eq!(res1.nrows(),2);
+                    assert_eq!(res1.ncols(),3);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res1[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_2_ $t>]() {
+                    let a = matrix2x3_new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = faer::mat![
+                        [41 as $t, 38 as $t]
+                    ];
+                    <_ as ArgminDiv<_, _>>::div(&a, &b);
+                }
+            }
+
+            item! {
+                #[test]
+                #[should_panic]
+                fn [<test_div_mat_mat_panic_3_ $t>]() {
+                    let a = matrix2x3_new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = Mat::new();
+                    <_ as ArgminDiv<_, _>>::div(&a, &b);
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/div.rs
+++ b/crates/argmin-math/src/faer_m/div.rs
@@ -1,0 +1,43 @@
+use super::RealEntity;
+use crate::ArgminDiv;
+use faer::{
+    mat::AsMatRef,
+    reborrow::{IntoConst, Reborrow, ReborrowMut},
+    Conjugate, Mat, MatMut, MatRef, SimpleEntity,
+};
+use std::ops::DivAssign;
+
+impl<'a, E> ArgminDiv<E, Mat<E::Canonical>> for MatRef<'a, E>
+where
+    E: RealEntity,
+    E::Canonical: DivAssign<E>,
+{
+    fn div(&self, other: &E) -> Mat<E::Canonical> {
+        let mut owned = MatRef::to_owned(self);
+        owned
+            .col_iter_mut()
+            .flat_map(|col_iter| col_iter.iter_mut())
+            .for_each(|elem| elem.div_assign(*other));
+
+        owned
+    }
+}
+
+impl<E> ArgminDiv<E, Mat<E::Canonical>> for Mat<E>
+where
+    E: RealEntity,
+    E::Canonical: DivAssign<E>,
+{
+    #[inline]
+    fn div(&self, other: &E) -> Mat<E::Canonical> {
+        <MatRef<E> as ArgminDiv<_, _>>::div(&self.as_mat_ref(), other)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -1,5 +1,5 @@
 use crate::ArgminDot;
-use faer::{ComplexField, Mat, MatRef, SimpleEntity};
+use faer::{mat::AsMatRef, ComplexField, Mat, MatRef, SimpleEntity};
 use std::ops::Mul;
 
 //@note(geo): the order is important here.
@@ -9,27 +9,35 @@ use std::ops::Mul;
 // where it says "dot product of T and Self"
 
 /// MatRef . MatRef -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'a, E> {
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
     #[inline]
     fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
-        //@todo(geo) maybe this is faster using the matmul with
+        //@note(geo-ant) maybe this would be faster using the matmul with conjugation
         self.conjugate() * other
     }
 }
 
-/// MatRef . MatRef -> Mat
+/// MatRef . Mat -> Mat
 impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'a, E> {
     #[inline]
     fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        self.conjugate() * other
+        <_ as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())
     }
 }
 
 /// Mat . MatRef -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
+impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), other)
+    }
+}
+
+/// Mat . Mat -> Mat
+impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        self.conjugate() * other
+        <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), &other.as_mat_ref())
     }
 }
 

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -9,7 +9,7 @@ use std::ops::Mul;
 // where it says "dot product of T and Self"
 
 /// MatRef . MatRef -> Mat
-impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
         //@note(geo-ant) maybe this would be faster using the matmul with conjugation
@@ -18,7 +18,7 @@ impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> fo
 }
 
 /// MatRef . Mat -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'a, E> {
+impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn dot(&self, other: &Mat<E>) -> Mat<E> {
         <_ as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -1,0 +1,41 @@
+use crate::ArgminDot;
+use faer::{ComplexField, Mat, MatRef, SimpleEntity};
+use std::ops::Mul;
+
+//@note(geo): the order is important here.
+// the way it is implemented with nalgebra suggests that this calculates
+// self.transpose() * other
+// which is in contrast to the documentation of the trait itself,
+// where it says "dot product of T and Self"
+
+/// MatRef . MatRef -> Mat
+impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'a, E> {
+    #[inline]
+    fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        self.transpose() * other
+    }
+}
+
+/// MatRef . MatRef -> Mat
+impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'a, E> {
+    #[inline]
+    fn dot(&self, other: &Mat<E>) -> Mat<E> {
+        self.transpose() * other
+    }
+}
+
+/// Mat . MatRef -> Mat
+impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn dot(&self, other: &Mat<E>) -> Mat<E> {
+        self.transpose() * other
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -42,9 +42,166 @@ impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_vec_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 2 as $t, 3 as $t);
+                    let b = vector3_new(4 as $t, 5 as $t, 6 as $t);
+                    let res: $t = <Vector3<$t> as ArgminDot<Vector3<$t>, $t>>::dot(&a, &b);
+                    assert_relative_eq!(res as f64, 32 as f64, epsilon = f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_vec_scalar_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = 2 as $t;
+                    let product: Vector3<$t> =
+                        <Vector3<$t> as ArgminDot<$t, Vector3<$t>>>::dot(&a, &b);
+                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+                    for i in 0..3 {
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_scalar_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = 2 as $t;
+                    let product: Vector3<$t> =
+                        <$t as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&b, &a);
+                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+                    for i in 0..3 {
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_ $t>]() {
+                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let b = RowVector3::new(4 as $t, 5 as $t, 6 as $t);
+                    let res = Matrix3::new(
+                        4 as $t, 5 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        12 as $t, 15 as $t, 18 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Vector3<$t> as ArgminDot<RowVector3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_vec_2_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        7 as $t, 8 as $t, 9 as $t
+                    );
+                    let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+                    let res = Vector3::new(14 as $t, 32 as $t, 50 as $t);
+                    let product: Vector3<$t> =
+                        <Matrix3<$t> as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_mat_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let b = Matrix3::new(
+                        3 as $t, 2 as $t, 1 as $t,
+                        6 as $t, 5 as $t, 4 as $t,
+                        2 as $t, 4 as $t, 3 as $t
+                    );
+                    let res = Matrix3::new(
+                        21 as $t, 24 as $t, 18 as $t,
+                        54 as $t, 57 as $t, 42 as $t,
+                        23 as $t, 20 as $t, 14 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Matrix3<$t> as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mat_primitive_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let res = Matrix3::new(
+                        2 as $t, 4 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        6 as $t, 4 as $t, 2 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <Matrix3<$t> as ArgminDot<$t, Matrix3<$t>>>::dot(&a, &(2 as $t));
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_primitive_mat_ $t>]() {
+                    let a = Matrix3::new(
+                        1 as $t, 2 as $t, 3 as $t,
+                        4 as $t, 5 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 1 as $t
+                    );
+                    let res = Matrix3::new(
+                        2 as $t, 4 as $t, 6 as $t,
+                        8 as $t, 10 as $t, 12 as $t,
+                        6 as $t, 4 as $t, 2 as $t
+                    );
+                    let product: Matrix3<$t> =
+                        <$t as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&(2 as $t), &a);
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -71,8 +71,8 @@ mod scalar_product {
                 "vectors for dot product must have same number of elements"
             );
 
-            let value: Mat<E> =
-                <_ as ArgminDot<_, _>>::dot(&self.as_shape(count, 1), &other.as_shape(count, 1));
+            todo!("this logic is still incorrect");
+            let value: Mat<E> = self.as_shape(count, 1) * &other.as_shape(1, count);
             debug_assert_eq!(value.nrows(), 1);
             debug_assert_eq!(value.ncols(), 1);
             value[(0, 0)]
@@ -104,11 +104,17 @@ mod scalar_product {
     }
 }
 
+//@note(geo) implemented for compatibility with the nalgebra implementations,
+// but this should probably not have to exist, since the functionality is
+// already covered with ArgminMul
+mod matrix_and_scalar_product {}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helper::*;
     use super::*;
     use approx::assert_relative_eq;
+    use faer::mat::AsMatRef;
     use paste::item;
 
     macro_rules! make_test {
@@ -118,8 +124,15 @@ mod tests {
                 fn [<test_vec_vec_ $t>]() {
                     let a = vector3_new(1 as $t, 2 as $t, 3 as $t);
                     let b = vector3_new(4 as $t, 5 as $t, 6 as $t);
-                    let res: $t = <_ as ArgminDot<_, _>>::dot(&a, &b);
-                    assert_relative_eq!(res as f64, 32 as f64, epsilon = f64::EPSILON);
+                    // all owned and reference type combinations
+                    let res1: $t = <_ as ArgminDot<_, _>>::dot(&a, &b);
+                    let res2: $t = <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b);
+                    let res3: $t = <_ as ArgminDot<_, _>>::dot(&a, &b.as_mat_ref());
+                    let res4: $t = <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b.as_mat_ref());
+                    assert_relative_eq!(res1 as f64, 32 as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(res2 as f64, 32 as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(res3 as f64, 32 as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(res4 as f64, 32 as f64, epsilon = f64::EPSILON);
                 }
             }
 
@@ -161,11 +174,20 @@ mod tests {
                         8 as $t, 10 as $t, 12 as $t,
                         12 as $t, 15 as $t, 18 as $t
                     );
-                    let product: Mat<$t> =
+                    let product1: Mat<$t> =
                         <_ as ArgminDot<_, _>>::dot(&a, &b);
+                    let product2: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b);
+                    let product3: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b.as_mat_ref());
+                    let product4: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b.as_mat_ref());
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product1[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product2[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product3[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product4[(i, j)] as f64, epsilon = f64::EPSILON);
                         }
                     }
                 }
@@ -181,10 +203,19 @@ mod tests {
                     );
                     let b = vector3_new(1 as $t, 2 as $t, 3 as $t);
                     let res = vector3_new(14 as $t, 32 as $t, 50 as $t);
-                    let product: Mat<$t> =
+                    let product1: Mat<$t> =
                         <_ as ArgminDot<_, _>>::dot(&a, &b);
+                    let product2: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b);
+                    let product3: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b.as_mat_ref());
+                    let product4: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b.as_mat_ref());
                     for i in 0..3 {
-                        assert_relative_eq!(res[(i,0)] as f64, product[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(res[(i,0)] as f64, product1[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(res[(i,0)] as f64, product2[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(res[(i,0)] as f64, product3[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(res[(i,0)] as f64, product4[(i,0)] as f64, epsilon = f64::EPSILON);
                     }
                 }
             }
@@ -207,11 +238,20 @@ mod tests {
                         54 as $t, 57 as $t, 42 as $t,
                         23 as $t, 20 as $t, 14 as $t
                     );
-                    let product: Mat<$t> =
+                    let product1: Mat<$t> =
                         <_ as ArgminDot<_, _>>::dot(&a, &b);
+                    let product2: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b);
+                    let product3: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b.as_mat_ref());
+                    let product4: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a.as_mat_ref(), &b.as_mat_ref());
                     for i in 0..3 {
                         for j in 0..3 {
-                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product1[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product2[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product3[(i, j)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(res[(i, j)] as f64, product4[(i, j)] as f64, epsilon = f64::EPSILON);
                         }
                     }
                 }

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -12,7 +12,8 @@ use std::ops::Mul;
 impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'a, E> {
     #[inline]
     fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
-        self.transpose() * other
+        //@todo(geo) maybe this is faster using the matmul with
+        self.conjugate() * other
     }
 }
 
@@ -20,7 +21,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for Ma
 impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'a, E> {
     #[inline]
     fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        self.transpose() * other
+        self.conjugate() * other
     }
 }
 
@@ -28,7 +29,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'a
 impl<'a, E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        self.transpose() * other
+        self.conjugate() * other
     }
 }
 

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -4,40 +4,103 @@ use std::ops::Mul;
 
 //@note(geo): the order is important here.
 // the way it is implemented with nalgebra suggests that this calculates
-// self.transpose() * other
+// self.conjugate() * other
 // which is in contrast to the documentation of the trait itself,
 // where it says "dot product of T and Self"
 
-/// MatRef . MatRef -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
-    #[inline]
-    fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
-        //@note(geo-ant) maybe this would be faster using the matmul with conjugation
-        self.conjugate() * other
+/// ArgminDot implementation for matrix multiplication: Matrix . Matrix -> Matrix
+mod matrix_matrix_multiplication {
+    use super::*;
+
+    /// MatRef . MatRef -> Mat
+    impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
+        #[inline]
+        fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
+            //@note(geo-ant) maybe this would be faster using the matmul with conjugation
+            self.conjugate() * other
+        }
+    }
+
+    /// MatRef . Mat -> Mat
+    impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'_, E> {
+        #[inline]
+        fn dot(&self, other: &Mat<E>) -> Mat<E> {
+            <_ as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())
+        }
+    }
+
+    /// Mat . MatRef -> Mat
+    impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for Mat<E> {
+        #[inline]
+        fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
+            <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), other)
+        }
+    }
+
+    /// Mat . Mat -> Mat
+    impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
+        #[inline]
+        fn dot(&self, other: &Mat<E>) -> Mat<E> {
+            <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), &other.as_mat_ref())
+        }
     }
 }
 
-/// MatRef . Mat -> Mat
-impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for MatRef<'_, E> {
-    #[inline]
-    fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        <_ as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())
-    }
-}
+/// contains implementations for the scalar product of two column vectors of
+/// the same length.
+//@note(geo-ant) the corresponding nalgebra implementations allow taking a scalar
+// product of any two matrices of same shape ("as vectors"). I've opted to not
+// reproduce this behavior here, since it's likely invoked in error.
+mod scalar_product {
+    use super::*;
+    /// MatRef . MatRef -> Mat
+    impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, E> for MatRef<'_, E> {
+        #[inline]
+        fn dot(&self, other: &MatRef<'a, E>) -> E {
+            //@note(geo): we allow the scalar dot product between two vectors
+            // of same length (but possibly different shape).
+            assert!(
+                (self.nrows() == 1 || self.ncols() == 1)
+                    && (other.nrows() == 1 || other.ncols() == 1),
+                "arguments for dot product must be vectors"
+            );
+            let count = std::cmp::max(self.nrows(), self.ncols());
+            let count_rhs = std::cmp::max(other.nrows(), other.ncols());
+            assert_eq!(
+                count, count_rhs,
+                "vectors for dot product must have same number of elements"
+            );
 
-/// Mat . MatRef -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, Mat<E>> for Mat<E> {
-    #[inline]
-    fn dot(&self, other: &MatRef<'a, E>) -> Mat<E> {
-        <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), other)
+            let value: Mat<E> =
+                <_ as ArgminDot<_, _>>::dot(&self.as_shape(count, 1), &other.as_shape(count, 1));
+            debug_assert_eq!(value.nrows(), 1);
+            debug_assert_eq!(value.ncols(), 1);
+            value[(0, 0)]
+        }
     }
-}
 
-/// Mat . Mat -> Mat
-impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, Mat<E>> for Mat<E> {
-    #[inline]
-    fn dot(&self, other: &Mat<E>) -> Mat<E> {
-        <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), &other.as_mat_ref())
+    /// MatRef . Mat -> Mat
+    impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, E> for MatRef<'_, E> {
+        #[inline]
+        fn dot(&self, other: &Mat<E>) -> E {
+            <_ as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())
+        }
+    }
+
+    /// Mat . MatRef -> Mat
+    impl<'a, E: SimpleEntity + ComplexField> ArgminDot<MatRef<'a, E>, E> for Mat<E> {
+        #[inline]
+        fn dot(&self, other: &MatRef<'a, E>) -> E {
+            <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), other)
+        }
+    }
+
+    /// Mat . Mat -> Mat
+    impl<E: SimpleEntity + ComplexField> ArgminDot<Mat<E>, E> for Mat<E> {
+        #[inline]
+        fn dot(&self, other: &Mat<E>) -> E {
+            <_ as ArgminDot<_, _>>::dot(&self.as_mat_ref(), &other.as_mat_ref())
+        }
     }
 }
 
@@ -55,51 +118,51 @@ mod tests {
                 fn [<test_vec_vec_ $t>]() {
                     let a = vector3_new(1 as $t, 2 as $t, 3 as $t);
                     let b = vector3_new(4 as $t, 5 as $t, 6 as $t);
-                    let res: $t = <Vector3<$t> as ArgminDot<Vector3<$t>, $t>>::dot(&a, &b);
+                    let res: $t = <_ as ArgminDot<_, _>>::dot(&a, &b);
                     assert_relative_eq!(res as f64, 32 as f64, epsilon = f64::EPSILON);
                 }
             }
 
-            item! {
-                #[test]
-                fn [<test_vec_scalar_ $t>]() {
-                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-                    let b = 2 as $t;
-                    let product: Vector3<$t> =
-                        <Vector3<$t> as ArgminDot<$t, Vector3<$t>>>::dot(&a, &b);
-                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
-                    for i in 0..3 {
-                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
-                    }
-                }
-            }
+            // item! {
+            //     #[test]
+            //     fn [<test_vec_scalar_ $t>]() {
+            //         let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+            //         let b = 2 as $t;
+            //         let product: Vector3<$t> =
+            //             <Vector3<$t> as ArgminDot<$t, Vector3<$t>>>::dot(&a, &b);
+            //         let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+            //         for i in 0..3 {
+            //             assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+            //         }
+            //     }
+            // }
 
-            item! {
-                #[test]
-                fn [<test_scalar_vec_ $t>]() {
-                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-                    let b = 2 as $t;
-                    let product: Vector3<$t> =
-                        <$t as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&b, &a);
-                    let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
-                    for i in 0..3 {
-                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
-                    }
-                }
-            }
+            // item! {
+            //     #[test]
+            //     fn [<test_scalar_vec_ $t>]() {
+            //         let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+            //         let b = 2 as $t;
+            //         let product: Vector3<$t> =
+            //             <$t as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&b, &a);
+            //         let res = Vector3::new(2 as $t, 4 as $t, 6 as $t);
+            //         for i in 0..3 {
+            //             assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+            //         }
+            //     }
+            // }
 
             item! {
                 #[test]
                 fn [<test_mat_vec_ $t>]() {
-                    let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-                    let b = RowVector3::new(4 as $t, 5 as $t, 6 as $t);
-                    let res = Matrix3::new(
+                    let a = vector3_new(1 as $t, 2 as $t, 3 as $t);
+                    let b = row_vector3_new(4 as $t, 5 as $t, 6 as $t);
+                    let res = matrix3_new(
                         4 as $t, 5 as $t, 6 as $t,
                         8 as $t, 10 as $t, 12 as $t,
                         12 as $t, 15 as $t, 18 as $t
                     );
-                    let product: Matrix3<$t> =
-                        <Vector3<$t> as ArgminDot<RowVector3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    let product: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b);
                     for i in 0..3 {
                         for j in 0..3 {
                             assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
@@ -111,17 +174,17 @@ mod tests {
             item! {
                 #[test]
                 fn [<test_mat_vec_2_ $t>]() {
-                    let a = Matrix3::new(
+                    let a = matrix3_new(
                         1 as $t, 2 as $t, 3 as $t,
                         4 as $t, 5 as $t, 6 as $t,
                         7 as $t, 8 as $t, 9 as $t
                     );
-                    let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-                    let res = Vector3::new(14 as $t, 32 as $t, 50 as $t);
-                    let product: Vector3<$t> =
-                        <Matrix3<$t> as ArgminDot<Vector3<$t>, Vector3<$t>>>::dot(&a, &b);
+                    let b = vector3_new(1 as $t, 2 as $t, 3 as $t);
+                    let res = vector3_new(14 as $t, 32 as $t, 50 as $t);
+                    let product: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b);
                     for i in 0..3 {
-                        assert_relative_eq!(res[i] as f64, product[i] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(res[(i,0)] as f64, product[(i,0)] as f64, epsilon = f64::EPSILON);
                     }
                 }
             }
@@ -129,23 +192,23 @@ mod tests {
             item! {
                 #[test]
                 fn [<test_mat_mat_ $t>]() {
-                    let a = Matrix3::new(
+                    let a = matrix3_new(
                         1 as $t, 2 as $t, 3 as $t,
                         4 as $t, 5 as $t, 6 as $t,
                         3 as $t, 2 as $t, 1 as $t
                     );
-                    let b = Matrix3::new(
+                    let b = matrix3_new(
                         3 as $t, 2 as $t, 1 as $t,
                         6 as $t, 5 as $t, 4 as $t,
                         2 as $t, 4 as $t, 3 as $t
                     );
-                    let res = Matrix3::new(
+                    let res = matrix3_new(
                         21 as $t, 24 as $t, 18 as $t,
                         54 as $t, 57 as $t, 42 as $t,
                         23 as $t, 20 as $t, 14 as $t
                     );
-                    let product: Matrix3<$t> =
-                        <Matrix3<$t> as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&a, &b);
+                    let product: Mat<$t> =
+                        <_ as ArgminDot<_, _>>::dot(&a, &b);
                     for i in 0..3 {
                         for j in 0..3 {
                             assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
@@ -154,51 +217,51 @@ mod tests {
                 }
             }
 
-            item! {
-                #[test]
-                fn [<test_mat_primitive_ $t>]() {
-                    let a = Matrix3::new(
-                        1 as $t, 2 as $t, 3 as $t,
-                        4 as $t, 5 as $t, 6 as $t,
-                        3 as $t, 2 as $t, 1 as $t
-                    );
-                    let res = Matrix3::new(
-                        2 as $t, 4 as $t, 6 as $t,
-                        8 as $t, 10 as $t, 12 as $t,
-                        6 as $t, 4 as $t, 2 as $t
-                    );
-                    let product: Matrix3<$t> =
-                        <Matrix3<$t> as ArgminDot<$t, Matrix3<$t>>>::dot(&a, &(2 as $t));
-                    for i in 0..3 {
-                        for j in 0..3 {
-                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
-                        }
-                    }
-                }
-            }
+            // item! {
+            //     #[test]
+            //     fn [<test_mat_primitive_ $t>]() {
+            //         let a = Matrix3::new(
+            //             1 as $t, 2 as $t, 3 as $t,
+            //             4 as $t, 5 as $t, 6 as $t,
+            //             3 as $t, 2 as $t, 1 as $t
+            //         );
+            //         let res = Matrix3::new(
+            //             2 as $t, 4 as $t, 6 as $t,
+            //             8 as $t, 10 as $t, 12 as $t,
+            //             6 as $t, 4 as $t, 2 as $t
+            //         );
+            //         let product: Matrix3<$t> =
+            //             <Matrix3<$t> as ArgminDot<$t, Matrix3<$t>>>::dot(&a, &(2 as $t));
+            //         for i in 0..3 {
+            //             for j in 0..3 {
+            //                 assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+            //             }
+            //         }
+            //     }
+            // }
 
-            item! {
-                #[test]
-                fn [<test_primitive_mat_ $t>]() {
-                    let a = Matrix3::new(
-                        1 as $t, 2 as $t, 3 as $t,
-                        4 as $t, 5 as $t, 6 as $t,
-                        3 as $t, 2 as $t, 1 as $t
-                    );
-                    let res = Matrix3::new(
-                        2 as $t, 4 as $t, 6 as $t,
-                        8 as $t, 10 as $t, 12 as $t,
-                        6 as $t, 4 as $t, 2 as $t
-                    );
-                    let product: Matrix3<$t> =
-                        <$t as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&(2 as $t), &a);
-                    for i in 0..3 {
-                        for j in 0..3 {
-                            assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
-                        }
-                    }
-                }
-            }
+            // item! {
+            //     #[test]
+            //     fn [<test_primitive_mat_ $t>]() {
+            //         let a = Matrix3::new(
+            //             1 as $t, 2 as $t, 3 as $t,
+            //             4 as $t, 5 as $t, 6 as $t,
+            //             3 as $t, 2 as $t, 1 as $t
+            //         );
+            //         let res = Matrix3::new(
+            //             2 as $t, 4 as $t, 6 as $t,
+            //             8 as $t, 10 as $t, 12 as $t,
+            //             6 as $t, 4 as $t, 2 as $t
+            //         );
+            //         let product: Matrix3<$t> =
+            //             <$t as ArgminDot<Matrix3<$t>, Matrix3<$t>>>::dot(&(2 as $t), &a);
+            //         for i in 0..3 {
+            //             for j in 0..3 {
+            //                 assert_relative_eq!(res[(i, j)] as f64, product[(i, j)] as f64, epsilon = f64::EPSILON);
+            //             }
+            //         }
+            //     }
+            // }
         };
     }
 

--- a/crates/argmin-math/src/faer_m/dot.rs
+++ b/crates/argmin-math/src/faer_m/dot.rs
@@ -124,7 +124,7 @@ mod multiply_matrix_with_scalar {
     use std::ops::Mul;
 
     // MatRef . Scalar -> Mat
-    impl<'a, E: Entity + Mul<E, Output = E>> ArgminDot<E, Mat<E>> for MatRef<'a, E> {
+    impl<E: Entity + Mul<E, Output = E>> ArgminDot<E, Mat<E>> for MatRef<'_, E> {
         #[inline]
         fn dot(&self, other: &E) -> Mat<E> {
             <Self as ArgminMul<E, _>>::mul(self, other)
@@ -148,7 +148,7 @@ mod multiply_matrix_with_scalar {
     }
 
     // Mat . Scalar -> Mat
-    impl<'a, E: Entity + Mul<E, Output = E>> ArgminDot<Mat<E>, Mat<E>> for E {
+    impl<E: Entity + Mul<E, Output = E>> ArgminDot<Mat<E>, Mat<E>> for E {
         #[inline]
         fn dot(&self, other: &Mat<E>) -> Mat<E> {
             <E as ArgminDot<_, _>>::dot(self, &other.as_mat_ref())

--- a/crates/argmin-math/src/faer_m/eye.rs
+++ b/crates/argmin-math/src/faer_m/eye.rs
@@ -25,9 +25,55 @@ where
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_eye_ $t>]() {
+                    let e: Mat<$t> = <_ as ArgminEye>::eye(3);
+                    let res = matrix3_new(
+                        1 as $t, 0 as $t, 0 as $t,
+                        0 as $t, 1 as $t, 0 as $t,
+                        0 as $t, 0 as $t, 1 as $t
+                    );
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, e[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_eye_like_ $t>]() {
+                    let a = matrix3_new(
+                        0 as $t, 2 as $t, 6 as $t,
+                        3 as $t, 2 as $t, 7 as $t,
+                        9 as $t, 8 as $t, 1 as $t
+                    );
+                    let e: Mat<$t> = a.eye_like();
+                    let res = matrix3_new(
+                        1 as $t, 0 as $t, 0 as $t,
+                        0 as $t, 1 as $t, 0 as $t,
+                        0 as $t, 0 as $t, 1 as $t
+                    );
+                    for i in 0..3 {
+                        for j in 0..3 {
+                            assert_relative_eq!(res[(i, j)] as f64, e[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/eye.rs
+++ b/crates/argmin-math/src/faer_m/eye.rs
@@ -1,18 +1,26 @@
 use crate::ArgminEye;
-use faer::{ComplexField, Entity, Mat};
+use faer::{ComplexField, Entity, Mat, Shape};
 
-impl<E: Entity + ComplexField> ArgminEye for Mat<E> {
+impl<E: Entity + ComplexField, R: Shape, C: Shape> ArgminEye for Mat<E, R, C>
+where
+    R: TryFrom<usize>,
+    C: TryFrom<usize>,
+{
     fn eye(n: usize) -> Self {
-        Mat::<_>::identity(n, n)
+        let (nr, nc) = match (R::try_from(n), C::try_from(n)) {
+            (Ok(nr), Ok(nc)) => (nr, nc),
+            _ => panic!("invalid matrix size for index type"),
+        };
+
+        Mat::identity(nr, nc)
     }
 
     fn eye_like(&self) -> Self {
-        let n = self.nrows();
-        //@note(geo-ant) this constraint is enforced in the nalgebra implementation.
-        // faer does not need it, but I felt it's better to keep the same runtime
-        // invariants.
-        assert_eq!(n, self.ncols(), "internal error: expected square matrix");
-        Mat::<_>::identity(n, n)
+        let nr = self.nrows();
+        let nc = self.ncols();
+        //@note(geo-ant) in the nalgebra implementation we also enforce
+        // that the matrix is square, which we don't enforce here
+        Mat::identity(nr, nc)
     }
 }
 

--- a/crates/argmin-math/src/faer_m/eye.rs
+++ b/crates/argmin-math/src/faer_m/eye.rs
@@ -1,0 +1,25 @@
+use crate::ArgminEye;
+use faer::{ComplexField, Entity, Mat};
+
+impl<E: Entity + ComplexField> ArgminEye for Mat<E> {
+    fn eye(n: usize) -> Self {
+        Mat::<_>::identity(n, n)
+    }
+
+    fn eye_like(&self) -> Self {
+        let n = self.nrows();
+        //@note(geo-ant) this constraint is enforced in the nalgebra implementation.
+        // faer does not need it, but I felt it's better to keep the same runtime
+        // invariants.
+        assert_eq!(n, self.ncols(), "internal error: expected square matrix");
+        Mat::<_>::identity(n, n)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/inv.rs
+++ b/crates/argmin-math/src/faer_m/inv.rs
@@ -31,7 +31,7 @@ impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'_, E> {
 }
 
 /// calculate the inverse by using LU decomposition with partial pivoting
-impl<'a, E: Entity + ComplexField> ArgminInv<Mat<E>> for Mat<E> {
+impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for Mat<E> {
     #[inline]
     fn inv(&self) -> Result<Mat<E>, anyhow::Error> {
         if self.nrows() != self.ncols() || self.nrows() == 0 {

--- a/crates/argmin-math/src/faer_m/inv.rs
+++ b/crates/argmin-math/src/faer_m/inv.rs
@@ -1,0 +1,51 @@
+use crate::ArgminInv;
+use faer::{
+    dyn_stack::{GlobalPodBuffer, PodStack},
+    linalg::lu::partial_pivoting::compute::{lu_in_place, lu_in_place_req},
+    mat::{AsMatMut, AsMatRef},
+    prelude::SolverCore,
+    reborrow::ReborrowMut,
+    ComplexField, Entity, Mat, MatRef, SimpleEntity,
+};
+use std::fmt;
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+struct InverseError;
+
+impl fmt::Display for InverseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Non-invertible matrix")
+    }
+}
+
+/// calculate the inverse by using LU decomposition with partial pivoting
+impl<'a, E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'a, E> {
+    #[inline]
+    fn inv(&self) -> Result<Mat<E>, anyhow::Error> {
+        if self.nrows() != self.ncols() || self.nrows() == 0 {
+            Err(InverseError.into())
+        } else {
+            Ok(self.partial_piv_lu().inverse())
+        }
+    }
+}
+
+/// calculate the inverse by using LU decomposition with partial pivoting
+impl<'a, E: Entity + ComplexField> ArgminInv<Mat<E>> for Mat<E> {
+    #[inline]
+    fn inv(&self) -> Result<Mat<E>, anyhow::Error> {
+        if self.nrows() != self.ncols() || self.nrows() == 0 {
+            Err(InverseError.into())
+        } else {
+            Ok(self.partial_piv_lu().inverse())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/inv.rs
+++ b/crates/argmin-math/src/faer_m/inv.rs
@@ -18,7 +18,7 @@ impl fmt::Display for InverseError {
     }
 }
 
-/// calculate the inverse by using LU decomposition with partial pivoting
+/// calculate the inverse via LU decomposition with partial pivoting
 impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn inv(&self) -> Result<Mat<E>, anyhow::Error> {
@@ -30,7 +30,7 @@ impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'_, E> {
     }
 }
 
-/// calculate the inverse by using LU decomposition with partial pivoting
+/// calculate the inverse via LU decomposition with partial pivoting
 impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for Mat<E> {
     #[inline]
     fn inv(&self) -> Result<Mat<E>, anyhow::Error> {

--- a/crates/argmin-math/src/faer_m/inv.rs
+++ b/crates/argmin-math/src/faer_m/inv.rs
@@ -19,7 +19,7 @@ impl fmt::Display for InverseError {
 }
 
 /// calculate the inverse by using LU decomposition with partial pivoting
-impl<'a, E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'a, E> {
+impl<E: Entity + ComplexField> ArgminInv<Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn inv(&self) -> Result<Mat<E>, anyhow::Error> {
         if self.nrows() != self.ncols() || self.nrows() == 0 {

--- a/crates/argmin-math/src/faer_m/l1norm.rs
+++ b/crates/argmin-math/src/faer_m/l1norm.rs
@@ -1,7 +1,7 @@
 use crate::ArgminL1Norm;
 use faer::{ComplexField, Entity, Mat, MatRef, SimpleEntity};
 
-impl<'a, E: Entity + ComplexField> ArgminL1Norm<E::Real> for MatRef<'a, E> {
+impl<E: Entity + ComplexField> ArgminL1Norm<E::Real> for MatRef<'_, E> {
     fn l1_norm(&self) -> E::Real {
         self.norm_l1()
     }

--- a/crates/argmin-math/src/faer_m/l1norm.rs
+++ b/crates/argmin-math/src/faer_m/l1norm.rs
@@ -7,7 +7,7 @@ impl<E: Entity + ComplexField> ArgminL1Norm<E::Real> for MatRef<'_, E> {
     }
 }
 
-impl<'a, E: Entity + ComplexField> ArgminL1Norm<E::Real> for Mat<E> {
+impl<E: Entity + ComplexField> ArgminL1Norm<E::Real> for Mat<E> {
     fn l1_norm(&self) -> E::Real {
         self.norm_l1()
     }

--- a/crates/argmin-math/src/faer_m/l1norm.rs
+++ b/crates/argmin-math/src/faer_m/l1norm.rs
@@ -14,9 +14,43 @@ impl<E: Entity + ComplexField> ArgminL1Norm<E::Real> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_l1norm_ $t>]() {
+                    let a = vector2_new(4 as $t, 3 as $t);
+                    let res = <_ as ArgminL1Norm<$t>>::l1_norm(&a);
+                    let target = 7 as $t;
+                    assert_relative_eq!(target as $t, res as $t, epsilon = $t::EPSILON);
+                }
+            }
+        };
     }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_l1norm_signed_ $t>]() {
+                    let a = vector2_new(-4 as $t, -3 as $t);
+                    let res = <_ as ArgminL1Norm<$t>>::l1_norm(&a);
+                    let target = 7 as $t;
+                    assert_relative_eq!(target as $t, res as $t, epsilon = $t::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(f32);
+    make_test_signed!(f64);
 }

--- a/crates/argmin-math/src/faer_m/l1norm.rs
+++ b/crates/argmin-math/src/faer_m/l1norm.rs
@@ -1,0 +1,22 @@
+use crate::ArgminL1Norm;
+use faer::{ComplexField, Entity, Mat, MatRef, SimpleEntity};
+
+impl<'a, E: Entity + ComplexField> ArgminL1Norm<E::Real> for MatRef<'a, E> {
+    fn l1_norm(&self) -> E::Real {
+        self.norm_l1()
+    }
+}
+
+impl<'a, E: Entity + ComplexField> ArgminL1Norm<E::Real> for Mat<E> {
+    fn l1_norm(&self) -> E::Real {
+        self.norm_l1()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/l2norm.rs
+++ b/crates/argmin-math/src/faer_m/l2norm.rs
@@ -1,7 +1,7 @@
 use crate::ArgminL2Norm;
 use faer::{ComplexField, Entity, Mat, MatRef, SimpleEntity};
 
-impl<'a, E: Entity + ComplexField> ArgminL2Norm<E::Real> for MatRef<'a, E> {
+impl<E: Entity + ComplexField> ArgminL2Norm<E::Real> for MatRef<'_, E> {
     fn l2_norm(&self) -> E::Real {
         self.norm_l2()
     }

--- a/crates/argmin-math/src/faer_m/l2norm.rs
+++ b/crates/argmin-math/src/faer_m/l2norm.rs
@@ -1,0 +1,22 @@
+use crate::ArgminL2Norm;
+use faer::{ComplexField, Entity, Mat, MatRef, SimpleEntity};
+
+impl<'a, E: Entity + ComplexField> ArgminL2Norm<E::Real> for MatRef<'a, E> {
+    fn l2_norm(&self) -> E::Real {
+        self.norm_l2()
+    }
+}
+
+impl<'a, E: Entity + ComplexField> ArgminL2Norm<E::Real> for Mat<E> {
+    fn l2_norm(&self) -> E::Real {
+        self.norm_l2()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/l2norm.rs
+++ b/crates/argmin-math/src/faer_m/l2norm.rs
@@ -7,7 +7,7 @@ impl<E: Entity + ComplexField> ArgminL2Norm<E::Real> for MatRef<'_, E> {
     }
 }
 
-impl<'a, E: Entity + ComplexField> ArgminL2Norm<E::Real> for Mat<E> {
+impl<E: Entity + ComplexField> ArgminL2Norm<E::Real> for Mat<E> {
     fn l2_norm(&self) -> E::Real {
         self.norm_l2()
     }

--- a/crates/argmin-math/src/faer_m/l2norm.rs
+++ b/crates/argmin-math/src/faer_m/l2norm.rs
@@ -14,9 +14,43 @@ impl<E: Entity + ComplexField> ArgminL2Norm<E::Real> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_ $t>]() {
+                    let a = vector2_new(4 as $t, 3 as $t);
+                    let res = <_ as ArgminL2Norm<$t>>::l2_norm(&a);
+                    let target = 5 as $t;
+                    assert_relative_eq!(target as $t, res as $t, epsilon = $t::EPSILON);
+                }
+            }
+        };
     }
+
+    macro_rules! make_test_signed {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_norm_signed_ $t>]() {
+                    let a = vector2_new(-4 as $t, -3 as $t);
+                    let res = <_ as ArgminL2Norm<$t>>::l2_norm(&a);
+                    let target = 5 as $t;
+                    assert_relative_eq!(target as $t, res as $t, epsilon = $t::EPSILON);
+                }
+            }
+        };
+    }
+
+    make_test!(f32);
+    make_test!(f64);
+
+    make_test_signed!(f32);
+    make_test_signed!(f64);
 }

--- a/crates/argmin-math/src/faer_m/minmax.rs
+++ b/crates/argmin-math/src/faer_m/minmax.rs
@@ -1,0 +1,43 @@
+use faer::{mat, unzipped, zipped, Entity, Mat};
+
+use crate::ArgminMinMax;
+
+impl<'a, E: Entity + PartialOrd> ArgminMinMax for Mat<E> {
+    #[inline]
+    fn max(a: &Self, b: &Self) -> Self {
+        let mut res = Mat::<E>::zeros(a.nrows(), a.ncols());
+        faer::zipped_rw!(res.as_mut(), a.as_ref(), b.as_ref()).for_each(
+            |faer::unzipped!(mut res, a, b)| {
+                let aa = a.read();
+                let bb = b.read();
+                //@note(geo-ant) directly cribbed from the nalgebra implementation
+                // will have the same problems with NaN values.
+                res.write(if aa > bb { aa } else { bb });
+            },
+        );
+        res
+    }
+
+    #[inline]
+    fn min(a: &Mat<E>, b: &Mat<E>) -> Mat<E> {
+        let mut res = Mat::<E>::zeros(a.nrows(), a.ncols());
+        faer::zipped_rw!(res.as_mut(), a.as_ref(), b.as_ref()).for_each(
+            |faer::unzipped!(mut res, a, b)| {
+                let aa = a.read();
+                let bb = b.read();
+                //@note(geo-ant) directly cribbed from the nalgebra implementation
+                // will have the same problems with NaN values.
+                res.write(if aa < bb { aa } else { bb });
+            },
+        );
+        res
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn add_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/minmax.rs
+++ b/crates/argmin-math/src/faer_m/minmax.rs
@@ -1,36 +1,36 @@
-use faer::{mat, unzipped, zipped, Entity, Mat};
+use faer::{mat, unzipped, zipped, Entity, Mat, SimpleEntity};
 
 use crate::ArgminMinMax;
 
-impl<'a, E: Entity + PartialOrd> ArgminMinMax for Mat<E> {
+impl<'a, E: SimpleEntity + PartialOrd> ArgminMinMax for Mat<E> {
     #[inline]
     fn max(a: &Self, b: &Self) -> Self {
-        let mut res = Mat::<E>::zeros(a.nrows(), a.ncols());
-        faer::zipped_rw!(res.as_mut(), a.as_ref(), b.as_ref()).for_each(
-            |faer::unzipped!(mut res, a, b)| {
-                let aa = a.read();
-                let bb = b.read();
-                //@note(geo-ant) directly cribbed from the nalgebra implementation
-                // will have the same problems with NaN values.
-                res.write(if aa > bb { aa } else { bb });
-            },
-        );
-        res
+        faer::zipped!(a, b).map(|faer::unzipped!(a, b)| {
+            let aa = *a;
+            let bb = *b;
+            //@note(geo-ant) directly cribbed from the nalgebra implementation
+            // will have the same problems with NaN values.
+            if aa > bb {
+                aa
+            } else {
+                bb
+            }
+        })
     }
 
     #[inline]
     fn min(a: &Mat<E>, b: &Mat<E>) -> Mat<E> {
-        let mut res = Mat::<E>::zeros(a.nrows(), a.ncols());
-        faer::zipped_rw!(res.as_mut(), a.as_ref(), b.as_ref()).for_each(
-            |faer::unzipped!(mut res, a, b)| {
-                let aa = a.read();
-                let bb = b.read();
-                //@note(geo-ant) directly cribbed from the nalgebra implementation
-                // will have the same problems with NaN values.
-                res.write(if aa < bb { aa } else { bb });
-            },
-        );
-        res
+        faer::zipped!(a, b).map(|faer::unzipped!(a, b)| {
+            let aa = *a;
+            let bb = *b;
+            //@note(geo-ant) directly cribbed from the nalgebra implementation
+            // will have the same problems with NaN values.
+            if aa < bb {
+                aa
+            } else {
+                bb
+            }
+        })
     }
 }
 

--- a/crates/argmin-math/src/faer_m/minmax.rs
+++ b/crates/argmin-math/src/faer_m/minmax.rs
@@ -35,9 +35,62 @@ impl<E: SimpleEntity + PartialOrd> ArgminMinMax for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn add_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_minmax_vec_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = vector3_new(2 as $t, 3 as $t, 4 as $t);
+                    let target_max = vector3_new(2 as $t, 4 as $t, 8 as $t);
+                    let target_min = vector3_new(1 as $t, 3 as $t, 4 as $t);
+                    let res_max = <_ as ArgminMinMax>::max(&a, &b);
+                    let res_min = <_ as ArgminMinMax>::min(&a, &b);
+                    for i in 0..3 {
+                        assert_relative_eq!(target_max[(i,0)] as f64, res_max[(i,0)] as f64, epsilon = f64::EPSILON);
+                        assert_relative_eq!(target_min[(i,0)] as f64, res_min[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_minmax_mat_mat_ $t>]() {
+                    let a = matrix2x3_new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = matrix2x3_new(
+                        2 as $t, 3 as $t, 4 as $t,
+                        3 as $t, 4 as $t, 5 as $t
+                    );
+                    let target_max = matrix2x3_new(
+                        2 as $t, 4 as $t, 8 as $t,
+                        3 as $t, 5 as $t, 9 as $t
+                    );
+                    let target_min = matrix2x3_new(
+                        1 as $t, 3 as $t, 4 as $t,
+                        2 as $t, 4 as $t, 5 as $t
+                    );
+                    let res_max = <_ as ArgminMinMax>::max(&a, &b);
+                    let res_min = <_ as ArgminMinMax>::min(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target_max[(j, i)] as f64, res_max[(j, i)] as f64, epsilon = f64::EPSILON);
+                            assert_relative_eq!(target_min[(j, i)] as f64, res_min[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/minmax.rs
+++ b/crates/argmin-math/src/faer_m/minmax.rs
@@ -1,8 +1,8 @@
-use faer::{mat, unzipped, zipped, Entity, Mat, SimpleEntity};
+use faer::{mat, unzipped, zipped, Entity, Mat, MatRef, SimpleEntity};
 
 use crate::ArgminMinMax;
 
-impl<'a, E: SimpleEntity + PartialOrd> ArgminMinMax for Mat<E> {
+impl<E: SimpleEntity + PartialOrd> ArgminMinMax for Mat<E> {
     #[inline]
     fn max(a: &Self, b: &Self) -> Self {
         faer::zipped!(a, b).map(|faer::unzipped!(a, b)| {

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -23,7 +23,7 @@ mod eye;
 mod inv;
 mod l1norm;
 mod l2norm;
-// mod minmax;
+mod minmax;
 // mod mul;
 // mod random;
 // mod scaledadd;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -27,8 +27,8 @@ mod random;
 // mod scaledsub;
 mod signum;
 mod sub;
-// mod transpose;
-// mod zero;
+mod transpose;
+mod zero;
 
 pub use add::*;
 pub use conj::*;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -1,0 +1,44 @@
+// Copyright 2018-2024 argmin developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![allow(unused_imports)]
+
+mod add;
+// mod conj;
+// mod div;
+// mod dot;
+// mod eye;
+// mod inv;
+// mod l1norm;
+// mod l2norm;
+// mod minmax;
+// mod mul;
+// mod random;
+// mod scaledadd;
+// mod scaledsub;
+// mod signum;
+// mod sub;
+// mod transpose;
+// mod zero;
+
+pub use add::*;
+// pub use conj::*;
+// pub use div::*;
+// pub use dot::*;
+// pub use eye::*;
+// pub use inv::*;
+// pub use l1norm::*;
+// pub use l2norm::*;
+// pub use minmax::*;
+// pub use mul::*;
+// pub use random::*;
+// pub use scaledadd::*;
+// pub use scaledsub::*;
+// pub use signum::*;
+// pub use sub::*;
+// pub use transpose::*;
+// pub use zero::*;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -7,14 +7,22 @@
 
 #![allow(unused_imports)]
 
+use faer::{Conjugate, SimpleEntity};
+/// minimal helper trait describing real numbers (which are their own
+/// conjugate). Additional bounds like Add, AddAssign, etc are used
+/// where they are required to make a future refactoring easier if
+/// we want to extend the implementations in here for complex numbers.
+trait RealEntity: SimpleEntity + Conjugate<Conj = Self, Canonical = Self> {}
+impl<T: SimpleEntity + Conjugate<Conj = Self, Canonical = T>> RealEntity for T {}
+
 mod add;
-// mod conj;
-// mod div;
-// mod dot;
-// mod eye;
-// mod inv;
-// mod l1norm;
-// mod l2norm;
+mod conj;
+mod div;
+mod dot;
+mod eye;
+mod inv;
+mod l1norm;
+mod l2norm;
 // mod minmax;
 // mod mul;
 // mod random;
@@ -26,13 +34,13 @@ mod add;
 // mod zero;
 
 pub use add::*;
-// pub use conj::*;
-// pub use div::*;
-// pub use dot::*;
-// pub use eye::*;
-// pub use inv::*;
-// pub use l1norm::*;
-// pub use l2norm::*;
+pub use conj::*;
+pub use div::*;
+pub use dot::*;
+pub use eye::*;
+pub use inv::*;
+pub use l1norm::*;
+pub use l2norm::*;
 // pub use minmax::*;
 // pub use mul::*;
 // pub use random::*;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -17,7 +17,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
-// mod random;
+mod random;
 // mod scaledadd;
 // mod scaledsub;
 // mod signum;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -7,14 +7,6 @@
 
 #![allow(unused_imports)]
 
-use faer::{Conjugate, SimpleEntity};
-/// minimal helper trait describing real numbers (which are their own
-/// conjugate). Additional bounds like Add, AddAssign, etc are used
-/// where they are required to make a future refactoring easier if
-/// we want to extend the implementations in here for complex numbers.
-trait RealEntity: SimpleEntity + Conjugate<Conj = Self, Canonical = Self> {}
-impl<T: SimpleEntity + Conjugate<Conj = Self, Canonical = T>> RealEntity for T {}
-
 mod add;
 mod conj;
 mod div;
@@ -24,7 +16,7 @@ mod inv;
 mod l1norm;
 mod l2norm;
 mod minmax;
-// mod mul;
+mod mul;
 // mod random;
 // mod scaledadd;
 // mod scaledsub;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -38,12 +38,16 @@ pub use eye::*;
 pub use inv::*;
 pub use l1norm::*;
 pub use l2norm::*;
-// pub use minmax::*;
-// pub use mul::*;
-// pub use random::*;
+pub use minmax::*;
+pub use mul::*;
+pub use random::*;
+//@note(geo-ant) see above
 // pub use scaledadd::*;
 // pub use scaledsub::*;
-// pub use signum::*;
-// pub use sub::*;
-// pub use transpose::*;
-// pub use zero::*;
+pub use signum::*;
+pub use sub::*;
+pub use transpose::*;
+pub use zero::*;
+
+#[cfg(test)]
+mod test_helper;

--- a/crates/argmin-math/src/faer_m/mod.rs
+++ b/crates/argmin-math/src/faer_m/mod.rs
@@ -18,10 +18,15 @@ mod l2norm;
 mod minmax;
 mod mul;
 mod random;
+//@note(geo-ant):
+// scaled addition and subtraction rely on a blanket implementation
+// for now and don't need to be tested separately for faer.
+// Once specialization becomes stable (or the upstream blanket impl is removed)
+// we should re-add these modules.
 // mod scaledadd;
 // mod scaledsub;
-// mod signum;
-// mod sub;
+mod signum;
+mod sub;
 // mod transpose;
 // mod zero;
 

--- a/crates/argmin-math/src/faer_m/mul.rs
+++ b/crates/argmin-math/src/faer_m/mul.rs
@@ -8,7 +8,7 @@ use faer::{
 use std::ops::Mul;
 
 /// MatRef * Scalar -> Mat
-impl<'a, E> ArgminMul<E, Mat<E>> for MatRef<'a, E>
+impl<E> ArgminMul<E, Mat<E>> for MatRef<'_, E>
 where
     E: Entity + Mul<E, Output = E>,
 {
@@ -57,7 +57,7 @@ where
 }
 
 /// MatRef * MatRef -> Mat
-impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
         <_ as Mul>::mul(self, other)
@@ -65,7 +65,7 @@ impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> fo
 }
 
 /// MatRef * Mat -> Mat
-impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn mul(&self, other: &Mat<E>) -> Mat<E> {
         self * other

--- a/crates/argmin-math/src/faer_m/mul.rs
+++ b/crates/argmin-math/src/faer_m/mul.rs
@@ -1,0 +1,90 @@
+use crate::ArgminMul;
+use faer::{
+    mat::{AsMatMut, AsMatRef},
+    reborrow::{IntoConst, Reborrow, ReborrowMut},
+    unzipped, zipped, zipped_rw, ComplexField, Conjugate, Entity, Mat, MatMut, MatRef,
+    SimpleEntity,
+};
+use std::ops::Mul;
+
+/// MatRef * Scalar -> Mat
+impl<'a, E> ArgminMul<E, Mat<E>> for MatRef<'a, E>
+where
+    E: Entity + Mul<E, Output = E>,
+{
+    #[inline]
+    fn mul(&self, other: &E) -> Mat<E> {
+        zipped_rw!(self).map(|unzipped!(this)| this.read() * *other)
+    }
+}
+
+/// Scalar * MatRef-> Mat
+impl<'a, E> ArgminMul<MatRef<'a, E>, Mat<E>> for E
+where
+    E: Entity + Mul<E, Output = E>,
+{
+    #[inline]
+    fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        // commutative with MatRef + Scalar so we can fall back on that case
+        <_ as ArgminMul<_, _>>::mul(other, self)
+    }
+}
+
+/// Mat * Scalar -> Mat
+impl<E> ArgminMul<E, Mat<E>> for Mat<E>
+where
+    E: Entity + Mul<E, Output = E>,
+{
+    #[inline]
+    fn mul(&self, other: &E) -> Mat<E> {
+        //@note(geo-ant) because we are taking self by reference we
+        // cannot mutate the matrix in place, so we can just as well
+        // reuse the reference code
+        <_ as ArgminMul<_, _>>::mul(&self.as_mat_ref(), other)
+    }
+}
+
+/// Scalar + Mat -> Mat
+impl<E> ArgminMul<Mat<E>, Mat<E>> for E
+where
+    E: Entity + Mul<E, Output = E>,
+{
+    #[inline]
+    fn mul(&self, other: &Mat<E>) -> Mat<E> {
+        // commutative with Mat * Scalar so we can fall back on that case
+        <_ as ArgminMul<_, _>>::mul(other, self)
+    }
+}
+
+/// MatRef * MatRef -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+    #[inline]
+    fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        <_ as Mul>::mul(self, other)
+    }
+}
+
+/// MatRef * Mat -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'b, E> {
+    #[inline]
+    fn mul(&self, other: &Mat<E>) -> Mat<E> {
+        self * other
+    }
+}
+
+/// Mat * Mat -> Mat
+impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn mul(&self, other: &Mat<E>) -> Mat<E> {
+        self * other
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/mul.rs
+++ b/crates/argmin-math/src/faer_m/mul.rs
@@ -44,7 +44,7 @@ where
     }
 }
 
-/// Scalar + Mat -> Mat
+/// Scalar * Mat -> Mat
 impl<E> ArgminMul<Mat<E>, Mat<E>> for E
 where
     E: Entity + Mul<E, Output = E>,
@@ -56,7 +56,7 @@ where
     }
 }
 
-/// MatRef * MatRef -> Mat
+/// MatRef * MatRef -> Mat (pointwise multiplication)
 impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
@@ -64,7 +64,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for Ma
     }
 }
 
-/// MatRef * Mat -> Mat
+/// MatRef * Mat -> Mat (pointwise multiplication)
 impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn mul(&self, other: &Mat<E>) -> Mat<E> {
@@ -72,7 +72,7 @@ impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E>
     }
 }
 
-/// Mat * MatRef-> Mat
+/// Mat * MatRef-> Mat (pointwise multiplication)
 impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for Mat<E> {
     #[inline]
     fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
@@ -80,7 +80,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for Ma
     }
 }
 
-/// Mat * Mat -> Mat
+/// Mat * Mat -> Mat (pointwise multiplication)
 impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn mul(&self, other: &Mat<E>) -> Mat<E> {

--- a/crates/argmin-math/src/faer_m/mul.rs
+++ b/crates/argmin-math/src/faer_m/mul.rs
@@ -72,6 +72,14 @@ impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E>
     }
 }
 
+/// Mat * MatRef-> Mat
+impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn mul(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        self * other
+    }
+}
+
 /// Mat * Mat -> Mat
 impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
@@ -81,10 +89,140 @@ impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat::AsMatRef;
+    use faer::Mat;
+    use faer::MatRef;
+    use paste::item;
 
-    #[test]
-    fn more_tests() {
-        todo!()
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_mul_vec_scalar_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = vector3_new(2 as $t, 8 as $t, 16 as $t);
+                    let res = <_ as ArgminMul<_, _>>::mul(&a, &b);
+                    let res2 = <_ as ArgminMul<_, _>>::mul(&a.as_mat_ref(), &b);
+                    assert_eq!(res,res2);
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = 2 as $t;
+                    let target = vector3_new(2 as $t, 8 as $t, 16 as $t);
+                    let res = <_ as ArgminMul<_,_>>::mul(&b, &a);
+                    let res2 = <_ as ArgminMul<_, _>>::mul(&b, &a.as_mat_ref());
+                    assert_eq!(res,res2);
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_vec_vec_ $t>]() {
+                    let a = vector3_new(1 as $t, 4 as $t, 8 as $t);
+                    let b = vector3_new(2 as $t, 3 as $t, 4 as $t);
+                    let target = vector3_new(2 as $t, 12 as $t, 32 as $t);
+                    let res = <_ as ArgminMul<_,_>>::mul(&a, &b);
+                    let res2 = <_ as ArgminMul<_,_>>::mul(&a.as_mat_ref(), &b);
+                    let res3 = <_ as ArgminMul<_,_>>::mul(&a, &b.as_mat_ref());
+                    let res4 = <_ as ArgminMul<_,_>>::mul(&a.as_mat_ref(), &b.as_mat_ref());
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_mat_mat_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = Matrix2x3::new(
+                        2 as $t, 3 as $t, 4 as $t,
+                        3 as $t, 4 as $t, 5 as $t
+                    );
+                    let target = Matrix2x3::new(
+                        2 as $t, 12 as $t, 32 as $t,
+                        6 as $t, 20 as $t, 45 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminMul<Matrix2x3<$t>, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_1_ $t>]() {
+                    let a = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let b = 2 as $t;
+                    let target = Matrix2x3::new(
+                        2 as $t, 8 as $t, 16 as $t,
+                        4 as $t, 10 as $t, 18 as $t
+                    );
+                    let res = <Matrix2x3<$t> as ArgminMul<$t, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_mul_scalar_mat_2_ $t>]() {
+                    let b = Matrix2x3::new(
+                        1 as $t, 4 as $t, 8 as $t,
+                        2 as $t, 5 as $t, 9 as $t
+                    );
+                    let a = 2 as $t;
+                    let target = Matrix2x3::new(
+                        2 as $t, 8 as $t, 16 as $t,
+                        4 as $t, 10 as $t, 18 as $t
+                    );
+                    let res = <$t as ArgminMul<Matrix2x3<$t>, Matrix2x3<$t>>>::mul(&a, &b);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/mul.rs
+++ b/crates/argmin-math/src/faer_m/mul.rs
@@ -65,7 +65,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminMul<MatRef<'a, E>, Mat<E>> for Ma
 }
 
 /// MatRef * Mat -> Mat
-impl<'a, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E> {
+impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn mul(&self, other: &Mat<E>) -> Mat<E> {
         self * other
@@ -73,7 +73,7 @@ impl<'a, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for MatRef<'_
 }
 
 /// Mat * Mat -> Mat
-impl<'a, 'b, E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
+impl<E: SimpleEntity + ComplexField> ArgminMul<Mat<E>, Mat<E>> for Mat<E> {
     #[inline]
     fn mul(&self, other: &Mat<E>) -> Mat<E> {
         self * other

--- a/crates/argmin-math/src/faer_m/random.rs
+++ b/crates/argmin-math/src/faer_m/random.rs
@@ -34,10 +34,89 @@ impl<E: Entity + PartialOrd + SampleUniform> ArgminRandom for Mat<E> {
     }
 }
 
-#[cfg(test)]
-mod test {
-    #[test]
-    fn add_tests() {
-        todo!()
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use nalgebra::{Matrix2x3, Vector3};
+//     use paste::item;
+//     use rand::SeedableRng;
+
+//     macro_rules! make_test {
+//         ($t:ty) => {
+//             item! {
+//                 #[test]
+//                 fn [<test_random_vec_ $t>]() {
+//                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+//                     let b = Vector3::new(2 as $t, 3 as $t, 4 as $t);
+//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
+//                     for i in 0..3 {
+//                         assert!(random[i] >= a[i]);
+//                         assert!(random[i] <= b[i]);
+//                     }
+//                 }
+//             }
+
+//             item! {
+//                 #[test]
+//                 fn [<test_random_vec_equal $t>]() {
+//                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+//                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
+//                     for i in 0..3 {
+//                         assert!((random[i] as f64 - a[i] as f64).abs() < f64::EPSILON);
+//                         assert!((random[i] as f64 - b[i] as f64).abs() < f64::EPSILON);
+//                     }
+//                 }
+//             }
+
+//             item! {
+//                 #[test]
+//                 fn [<test_random_vec_reverse_ $t>]() {
+//                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
+//                     let a = Vector3::new(2 as $t, 3 as $t, 4 as $t);
+//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
+//                     for i in 0..3 {
+//                         assert!(random[i] >= b[i]);
+//                         assert!(random[i] <= a[i]);
+//                     }
+//                 }
+//             }
+
+//             item! {
+//                 #[test]
+//                 fn [<test_random_mat_ $t>]() {
+//                     let a = Matrix2x3::new(
+//                         1 as $t, 3 as $t, 5 as $t,
+//                         2 as $t, 4 as $t, 6 as $t
+//                     );
+//                     let b = Matrix2x3::new(
+//                         2 as $t, 4 as $t, 6 as $t,
+//                         3 as $t, 5 as $t, 7 as $t
+//                     );
+//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+//                     let random = Matrix2x3::<$t>::rand_from_range(&a, &b, &mut rng);
+//                     for i in 0..3 {
+//                         for j in 0..2 {
+//                             assert!(random[(j, i)] >= a[(j, i)]);
+//                             assert!(random[(j, i)] <= b[(j, i)]);
+//                         }
+//                     }
+//                 }
+//             }
+//         };
+//     }
+
+//     make_test!(i8);
+//     make_test!(u8);
+//     make_test!(i16);
+//     make_test!(u16);
+//     make_test!(i32);
+//     make_test!(u32);
+//     make_test!(i64);
+//     make_test!(u64);
+//     make_test!(f32);
+//     make_test!(f64);
+// }

--- a/crates/argmin-math/src/faer_m/random.rs
+++ b/crates/argmin-math/src/faer_m/random.rs
@@ -24,11 +24,11 @@ impl<E: Entity + PartialOrd + SampleUniform> ArgminRandom for Mat<E> {
             // We do want to know if a and b are *exactly* the same.
             #[allow(clippy::float_cmp)]
             if a == b {
-                a.clone()
+                a
             } else if a < b {
-                rng.gen_range(a.clone()..b.clone())
+                rng.gen_range(a..b)
             } else {
-                rng.gen_range(b.clone()..a.clone())
+                rng.gen_range(b..a)
             }
         })
     }

--- a/crates/argmin-math/src/faer_m/random.rs
+++ b/crates/argmin-math/src/faer_m/random.rs
@@ -1,0 +1,43 @@
+use faer::{unzipped, Entity, Mat};
+use rand::distributions::uniform::SampleUniform;
+
+use crate::ArgminRandom;
+
+impl<E: Entity + PartialOrd + SampleUniform> ArgminRandom for Mat<E> {
+    fn rand_from_range<R: rand::Rng>(min: &Self, max: &Self, rng: &mut R) -> Self {
+        assert!(
+            min.nrows() != 0 || min.ncols() != 0,
+            "internal error: empty matrix unexpected"
+        );
+        assert_eq!(
+            min.shape(),
+            max.shape(),
+            "internal error: matrices of same shape expected"
+        );
+
+        faer::zipped_rw!(min, max).map(|unzipped!(min, max)| {
+            let a = min.read();
+            let b = max.read();
+            //@note(geo-ant) code was copied from the nalgebra implementation
+            // to get the exact same behaviour
+            // Do not require a < b:
+            // We do want to know if a and b are *exactly* the same.
+            #[allow(clippy::float_cmp)]
+            if a == b {
+                a.clone()
+            } else if a < b {
+                rng.gen_range(a.clone()..b.clone())
+            } else {
+                rng.gen_range(b.clone()..a.clone())
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn add_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/random.rs
+++ b/crates/argmin-math/src/faer_m/random.rs
@@ -34,89 +34,83 @@ impl<E: Entity + PartialOrd + SampleUniform> ArgminRandom for Mat<E> {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use nalgebra::{Matrix2x3, Vector3};
-//     use paste::item;
-//     use rand::SeedableRng;
+#[cfg(test)]
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use faer::mat;
+    use faer::Mat;
+    use paste::item;
+    use rand::SeedableRng;
 
-//     macro_rules! make_test {
-//         ($t:ty) => {
-//             item! {
-//                 #[test]
-//                 fn [<test_random_vec_ $t>]() {
-//                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-//                     let b = Vector3::new(2 as $t, 3 as $t, 4 as $t);
-//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
-//                     for i in 0..3 {
-//                         assert!(random[i] >= a[i]);
-//                         assert!(random[i] <= b[i]);
-//                     }
-//                 }
-//             }
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_random_vec_ $t>]() {
+                    let a = column_vector_from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = column_vector_from_vec(vec![2 as $t, 3 as $t, 4 as $t]);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = <_ as ArgminRandom>::rand_from_range(&a, &b, &mut rng);
+                    for i in 0..3 {
+                        assert!(random[(i,0)] >= a[(i,0)]);
+                        assert!(random[(i,0)] <= b[(i,0)]);
+                    }
+                }
+            }
 
-//             item! {
-//                 #[test]
-//                 fn [<test_random_vec_equal $t>]() {
-//                     let a = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-//                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
-//                     for i in 0..3 {
-//                         assert!((random[i] as f64 - a[i] as f64).abs() < f64::EPSILON);
-//                         assert!((random[i] as f64 - b[i] as f64).abs() < f64::EPSILON);
-//                     }
-//                 }
-//             }
+            item! {
+                #[test]
+                fn [<test_random_vec_equal $t>]() {
+                    let a = column_vector_from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let b = column_vector_from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = <_ as ArgminRandom>::rand_from_range(&a, &b, &mut rng);
+                    for i in 0..3 {
+                        assert!((random[(i,0)] as f64 - a[(i,0)] as f64).abs() < f64::EPSILON);
+                        assert!((random[(i,0)] as f64 - b[(i,0)] as f64).abs() < f64::EPSILON);
+                    }
+                }
+            }
 
-//             item! {
-//                 #[test]
-//                 fn [<test_random_vec_reverse_ $t>]() {
-//                     let b = Vector3::new(1 as $t, 2 as $t, 3 as $t);
-//                     let a = Vector3::new(2 as $t, 3 as $t, 4 as $t);
-//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-//                     let random = Vector3::<$t>::rand_from_range(&a, &b, &mut rng);
-//                     for i in 0..3 {
-//                         assert!(random[i] >= b[i]);
-//                         assert!(random[i] <= a[i]);
-//                     }
-//                 }
-//             }
+            item! {
+                #[test]
+                fn [<test_random_vec_reverse_ $t>]() {
+                    let b = column_vector_from_vec(vec![1 as $t, 2 as $t, 3 as $t]);
+                    let a = column_vector_from_vec(vec![2 as $t, 3 as $t, 4 as $t]);
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = <_ as ArgminRandom>::rand_from_range(&a, &b, &mut rng);
+                    for i in 0..3 {
+                        assert!(random[(i,0)] >= b[(i,0)]);
+                        assert!(random[(i,0)] <= a[(i,0)]);
+                    }
+                }
+            }
 
-//             item! {
-//                 #[test]
-//                 fn [<test_random_mat_ $t>]() {
-//                     let a = Matrix2x3::new(
-//                         1 as $t, 3 as $t, 5 as $t,
-//                         2 as $t, 4 as $t, 6 as $t
-//                     );
-//                     let b = Matrix2x3::new(
-//                         2 as $t, 4 as $t, 6 as $t,
-//                         3 as $t, 5 as $t, 7 as $t
-//                     );
-//                     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
-//                     let random = Matrix2x3::<$t>::rand_from_range(&a, &b, &mut rng);
-//                     for i in 0..3 {
-//                         for j in 0..2 {
-//                             assert!(random[(j, i)] >= a[(j, i)]);
-//                             assert!(random[(j, i)] <= b[(j, i)]);
-//                         }
-//                     }
-//                 }
-//             }
-//         };
-//     }
+            item! {
+                #[test]
+                fn [<test_random_mat_ $t>]() {
+                    let a = mat![
+                        [1 as $t, 3 as $t, 5 as $t],
+                        [2 as $t, 4 as $t, 6 as $t]
+                    ];
+                    let b = mat![
+                        [2 as $t, 4 as $t, 6 as $t],
+                        [3 as $t, 5 as $t, 7 as $t]
+                    ];
+                    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+                    let random = <_ as ArgminRandom>::rand_from_range(&a, &b, &mut rng);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert!(random[(j, i)] >= a[(j, i)]);
+                            assert!(random[(j, i)] <= b[(j, i)]);
+                        }
+                    }
+                }
+            }
+        };
+    }
 
-//     make_test!(i8);
-//     make_test!(u8);
-//     make_test!(i16);
-//     make_test!(u16);
-//     make_test!(i32);
-//     make_test!(u32);
-//     make_test!(i64);
-//     make_test!(u64);
-//     make_test!(f32);
-//     make_test!(f64);
-// }
+    make_test!(f32);
+    make_test!(f64);
+}

--- a/crates/argmin-math/src/faer_m/signum.rs
+++ b/crates/argmin-math/src/faer_m/signum.rs
@@ -1,0 +1,66 @@
+use crate::ArgminSignum;
+use faer::{unzipped, zipped_rw, Entity, Mat, MatRef, Shape};
+use num_complex::Complex;
+
+/// helper trait that indicates the signum of a numeric value can
+/// be calculated
+//@note(geo-ant): one could also decide to implement ArgminSignum
+// on the primitive types themselves.
+trait SignumInternal {
+    fn signum_internal(self) -> Self;
+}
+
+macro_rules! make_signum {
+    ($t:ty) => {
+        impl SignumInternal for $t {
+            fn signum_internal(self) -> Self {
+                self.signum()
+            }
+        }
+    };
+}
+
+macro_rules! make_signum_complex {
+    ($t:ty) => {
+        impl SignumInternal for $t {
+            fn signum_internal(self) -> Self {
+                Complex {
+                    re: self.re.signum(),
+                    im: self.im.signum(),
+                }
+            }
+        }
+    };
+}
+
+make_signum!(i8);
+make_signum!(i16);
+make_signum!(i32);
+make_signum!(i64);
+make_signum!(f32);
+make_signum!(f64);
+make_signum_complex!(Complex<i8>);
+make_signum_complex!(Complex<i16>);
+make_signum_complex!(Complex<i32>);
+make_signum_complex!(Complex<i64>);
+make_signum_complex!(Complex<f32>);
+make_signum_complex!(Complex<f64>);
+
+impl<'a, E, R, C> ArgminSignum for Mat<E, R, C>
+where
+    E: Entity + SignumInternal,
+    R: Shape,
+    C: Shape,
+{
+    fn signum(self) -> Self {
+        zipped_rw!(self).map(|unzipped!(elem)| elem.read().signum_internal())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn add_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/signum.rs
+++ b/crates/argmin-math/src/faer_m/signum.rs
@@ -46,7 +46,7 @@ make_signum_complex!(Complex<i64>);
 make_signum_complex!(Complex<f32>);
 make_signum_complex!(Complex<f64>);
 
-impl<'a, E, R, C> ArgminSignum for Mat<E, R, C>
+impl<E, R, C> ArgminSignum for Mat<E, R, C>
 where
     E: Entity + SignumInternal,
     R: Shape,

--- a/crates/argmin-math/src/faer_m/signum.rs
+++ b/crates/argmin-math/src/faer_m/signum.rs
@@ -52,15 +52,57 @@ where
     R: Shape,
     C: Shape,
 {
+    #[inline]
     fn signum(self) -> Self {
         zipped_rw!(self).map(|unzipped!(elem)| elem.read().signum_internal())
     }
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn add_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat;
+    use faer::Mat;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_signum_ $t>]() {
+                    let a = column_vector_from_vec(vec![3 as $t, -4 as $t, -8 as $t]);
+                    let b = column_vector_from_vec(vec![1 as $t, -1 as $t, -1 as $t]);
+                    let res = <_ as ArgminSignum>::signum(a);
+                    for i in 0..3 {
+                        assert_relative_eq!(b[(i,0)], res[(i,0)], epsilon = $t::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_signum_scalar_mat_2_ $t>]() {
+                    let b = mat![
+                        [3 as $t, -4 as $t, 8 as $t],
+                        [-2 as $t, -5 as $t, 9 as $t]
+                    ];
+                    let target = mat![
+                        [1 as $t, -1 as $t, 1 as $t],
+                        [-1 as $t, -1 as $t, 1 as $t]
+                    ];
+                    let res = b.signum();
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)], res[(j, i)], epsilon = $t::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/sub.rs
+++ b/crates/argmin-math/src/faer_m/sub.rs
@@ -92,8 +92,134 @@ impl<E: Entity + Sub<E, Output = E>> ArgminSub<Mat<E>, Mat<E>> for Mat<E> {
 
 #[cfg(test)]
 mod test {
-    #[test]
-    fn more_tests() {
-        todo!()
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat;
+    use faer::mat::{AsMatRef, MatRef};
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_sub_vec_scalar_ $t>]() {
+                    let a: Mat<$t> = column_vector_from_vec(vec![36 as $t, 39 as $t, 43 as $t]);
+                    let b: $t = 1 as $t;
+                    let target: Mat<$t> = column_vector_from_vec(vec![35 as $t, 38 as $t, 42 as $t]);
+                    // make sure we get the same answer regardless whether we
+                    // use owned matrices or matrix references.
+                    let res = <_ as ArgminSub<_,_>>::sub(&a, &b);
+                    let res2 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b);
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    assert_eq!(res,res2);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_scalar_vec_ $t>]() {
+                    let a = column_vector_from_vec(vec![1 as $t, 4 as $t, 8 as $t]);
+                    let b = 34 as $t;
+                    let target = column_vector_from_vec(vec![33 as $t, 30 as $t, 26 as $t]);
+                    let res = <$t as ArgminSub<_,_>>::sub(&b, &a);
+                    let res2 = <$t as ArgminSub<_,_>>::sub(&b, &a.as_mat_ref());
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    assert_eq!(res,res2);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_vec_vec_ $t>]() {
+                    let a: Mat<$t> = column_vector_from_vec(vec![41 as $t, 38 as $t, 34 as $t]);
+                    let b: Mat<$t> = column_vector_from_vec(vec![1 as $t, 4 as $t, 8 as $t]);
+                    let target: Mat<$t> = column_vector_from_vec(vec![40 as $t, 34 as $t, 26 as $t]);
+                    // all combinations of references and owned matrices
+                    let res = <_ as ArgminSub<_,_>>::sub(&a, &b);
+                    let res2 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b);
+                    let res3 = <_ as ArgminSub<_,_>>::sub(&a, &b.as_mat_ref());
+                    let res4 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b.as_mat_ref());
+                    assert_eq!(res.nrows(),3);
+                    assert_eq!(res.ncols(),1);
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[(i,0)] as f64, res[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_mat_ $t>]() {
+                    let a = mat![
+                        [43 as $t, 46 as $t, 50 as $t],
+                        [44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = mat![
+                        [1 as $t, 4 as $t, 8 as $t],
+                       [ 2 as $t, 5 as $t, 9 as $t]
+                    ];
+                    let target = mat![
+                        [42 as $t, 42 as $t, 42 as $t],
+                        [42 as $t, 42 as $t, 42 as $t]
+                    ];
+                    // all possible combinations of owned matrices and references
+                    let res = <_ as ArgminSub<_,_>>::sub(&a, &b);
+                    let res2 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b);
+                    let res3 = <_ as ArgminSub<_,_>>::sub(&a, &b.as_mat_ref());
+                    let res4 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b.as_mat_ref());
+                    assert_eq!(res.nrows(),2);
+                    assert_eq!(res.ncols(),3);
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_sub_mat_scalar_ $t>]() {
+                    let a = mat![
+                        [43 as $t, 46 as $t, 50 as $t],
+                        [44 as $t, 47 as $t, 51 as $t]
+                    ];
+                    let b = 2 as $t;
+                    let target = mat![
+                        [41 as $t, 44 as $t, 48 as $t],
+                        [42 as $t, 45 as $t, 49 as $t]
+                    ];
+                    // combinations of references and owned matrices
+                    let res = <_ as ArgminSub<_,_>>::sub(&a, &b);
+                    let res2 = <_ as ArgminSub<_,_>>::sub(&a.as_mat_ref(), &b);
+                    assert_eq!(res.nrows(),2);
+                    assert_eq!(res.ncols(),3);
+                    assert_eq!(res,res2);
+                    for i in 0..3 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(j, i)] as f64, res[(j, i)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/sub.rs
+++ b/crates/argmin-math/src/faer_m/sub.rs
@@ -1,0 +1,99 @@
+use crate::ArgminSub;
+use faer::{
+    mat::AsMatRef,
+    reborrow::{IntoConst, Reborrow, ReborrowMut},
+    unzipped, zipped_rw, Conjugate, Entity, Mat, MatMut, MatRef, SimpleEntity,
+};
+use std::ops::{Sub, SubAssign};
+
+/// MatRef / Scalar -> MatRef
+impl<'a, E> ArgminSub<E, Mat<E>> for MatRef<'a, E>
+where
+    E: Entity + Sub<E, Output = E>,
+{
+    #[inline]
+    fn sub(&self, other: &E) -> Mat<E> {
+        zipped_rw!(self).map(|unzipped!(this)| this.read() - *other)
+    }
+}
+
+/// Mat / Scalar -> Mat
+impl<E> ArgminSub<E, Mat<E>> for Mat<E>
+where
+    E: Entity + Sub<E, Output = E>,
+{
+    #[inline]
+    fn sub(&self, other: &E) -> Mat<E> {
+        //@note(geo-ant) because we are taking self by reference we
+        // cannot mutate the matrix in place, so we can just as well
+        // reuse the reference code
+        <_ as ArgminSub<_, _>>::sub(&self.as_mat_ref(), other)
+    }
+}
+
+/// Scalar / MatRef -> Mat
+impl<'a, E> ArgminSub<MatRef<'a, E>, Mat<E>> for E
+where
+    E: Entity + Sub<E, Output = E>,
+{
+    #[inline]
+    fn sub(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        // does not commute with the expressions above, which is why
+        // we need our own implementations
+        zipped_rw!(other).map(|unzipped!(other_elem)| *self - other_elem.read())
+    }
+}
+
+/// Scalar / Mat -> Mat
+impl<E> ArgminSub<Mat<E>, Mat<E>> for E
+where
+    E: Entity + Sub<E, Output = E>,
+{
+    #[inline]
+    fn sub(&self, other: &Mat<E>) -> Mat<E> {
+        //@note(geo-ant) because we are taking self by reference we
+        // cannot mutate the matrix in place, so we can just as well
+        // reuse the reference code
+        <_ as ArgminSub<_, _>>::sub(self, &other.as_mat_ref())
+    }
+}
+
+/// MatRef / MatRef -> Mat
+impl<'a, 'b, E: Entity + Sub<E, Output = E>> ArgminSub<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+    #[inline]
+    fn sub(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        zipped_rw!(self, other).map(|unzipped!(this, other)| this.read() - other.read())
+    }
+}
+
+/// Mat / MatRef -> Mat
+impl<'a, E: Entity + Sub<E, Output = E>> ArgminSub<MatRef<'a, E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn sub(&self, other: &MatRef<'a, E>) -> Mat<E> {
+        <_ as ArgminSub<_, _>>::sub(&self.as_mat_ref(), other)
+    }
+}
+
+/// MatRef / Mat-> Mat
+impl<'a, E: Entity + Sub<E, Output = E>> ArgminSub<Mat<E>, Mat<E>> for MatRef<'a, E> {
+    #[inline]
+    fn sub(&self, other: &Mat<E>) -> Mat<E> {
+        <_ as ArgminSub<_, _>>::sub(self, &other.as_mat_ref())
+    }
+}
+
+/// Mat / Mat-> Mat
+impl<E: Entity + Sub<E, Output = E>> ArgminSub<Mat<E>, Mat<E>> for Mat<E> {
+    #[inline]
+    fn sub(&self, other: &Mat<E>) -> Mat<E> {
+        <_ as ArgminSub<_, _>>::sub(&self.as_mat_ref(), &other.as_mat_ref())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn more_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/sub.rs
+++ b/crates/argmin-math/src/faer_m/sub.rs
@@ -7,7 +7,7 @@ use faer::{
 use std::ops::{Sub, SubAssign};
 
 /// MatRef / Scalar -> MatRef
-impl<'a, E> ArgminSub<E, Mat<E>> for MatRef<'a, E>
+impl<E> ArgminSub<E, Mat<E>> for MatRef<'_, E>
 where
     E: Entity + Sub<E, Output = E>,
 {
@@ -59,7 +59,7 @@ where
 }
 
 /// MatRef / MatRef -> Mat
-impl<'a, 'b, E: Entity + Sub<E, Output = E>> ArgminSub<MatRef<'a, E>, Mat<E>> for MatRef<'b, E> {
+impl<'a, E: Entity + Sub<E, Output = E>> ArgminSub<MatRef<'a, E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn sub(&self, other: &MatRef<'a, E>) -> Mat<E> {
         zipped_rw!(self, other).map(|unzipped!(this, other)| this.read() - other.read())
@@ -75,7 +75,7 @@ impl<'a, E: Entity + Sub<E, Output = E>> ArgminSub<MatRef<'a, E>, Mat<E>> for Ma
 }
 
 /// MatRef / Mat-> Mat
-impl<'a, E: Entity + Sub<E, Output = E>> ArgminSub<Mat<E>, Mat<E>> for MatRef<'a, E> {
+impl<E: Entity + Sub<E, Output = E>> ArgminSub<Mat<E>, Mat<E>> for MatRef<'_, E> {
     #[inline]
     fn sub(&self, other: &Mat<E>) -> Mat<E> {
         <_ as ArgminSub<_, _>>::sub(self, &other.as_mat_ref())

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -1,18 +1,18 @@
-use faer::{mat::from_column_major_slice_generic, zipped, Conjugate, Mat, SimpleEntity};
+use faer::{mat::from_column_major_slice_generic, zipped, Conjugate, Entity, Mat};
 
 /// create a column vector (in Nx1 matrix form) from a Vec instance
-pub fn column_vector_from_vec<E: SimpleEntity>(vec: Vec<E>) -> Mat<E> {
+pub fn column_vector_from_vec<E: Entity>(vec: Vec<E>) -> Mat<E> {
     column_vector_from_slice(vec.as_slice())
 }
 
 /// create an owning column vector from a slice
-pub fn column_vector_from_slice<E: SimpleEntity>(slice: &[E]) -> Mat<E> {
+pub fn column_vector_from_slice<E: Entity>(slice: &[E]) -> Mat<E> {
     Mat::<E>::from_fn(slice.len(), 1, |ir, _ic| slice[ir])
 }
 
 /// helper method to translate an nalgebra call Vector3::new(a,b,c) to the
 /// equivalent faer matrix constructor
-pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
+pub fn vector3_new<E: Entity>(a: E, b: E, c: E) -> Mat<E> {
     let v = column_vector_from_slice(&[a, b, c]);
     assert_eq!(v.nrows(), 3);
     assert_eq!(v.ncols(), 1);
@@ -21,7 +21,7 @@ pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
 
 /// helper method to translate an nalgebra call RowVector3::new(a,b,c) to the
 /// equivalent faer matrix constructor
-pub fn row_vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
+pub fn row_vector3_new<E: Entity>(a: E, b: E, c: E) -> Mat<E> {
     let v = faer::mat![[a, b, c]];
     assert_eq!(v.nrows(), 1);
     assert_eq!(v.ncols(), 3);
@@ -30,7 +30,7 @@ pub fn row_vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
 
 /// helper method to translate an nalgebra call Vector2::new(a,b) to the
 /// equivalent faer matrix constructor
-pub fn vector2_new<E: SimpleEntity>(a: E, b: E) -> Mat<E> {
+pub fn vector2_new<E: Entity>(a: E, b: E) -> Mat<E> {
     let v = column_vector_from_slice(&[a, b]);
     assert_eq!(v.nrows(), 2);
     assert_eq!(v.ncols(), 1);
@@ -39,7 +39,7 @@ pub fn vector2_new<E: SimpleEntity>(a: E, b: E) -> Mat<E> {
 
 /// helper method to translate an nalgebra call Matrix2x3::new(a,b,c, d,e,f) to the
 /// equivalent faer matrix constructor
-pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {
+pub fn matrix2x3_new<E: Entity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {
     let m = faer::mat![[a, b, c], [d, e, f]];
     assert_eq!(m.nrows(), 2);
     assert_eq!(m.ncols(), 3);
@@ -48,7 +48,7 @@ pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat
 
 /// helper method to translate an nalgebra call Matrix2::new(a,b, c,d) to the
 /// equivalent faer matrix constructor
-pub fn matrix2_new<E: SimpleEntity>(a: E, b: E, c: E, d: E) -> Mat<E> {
+pub fn matrix2_new<E: Entity>(a: E, b: E, c: E, d: E) -> Mat<E> {
     let m = faer::mat![[a, b], [c, d]];
     assert_eq!(m.nrows(), 2);
     assert_eq!(m.ncols(), 2);
@@ -57,17 +57,7 @@ pub fn matrix2_new<E: SimpleEntity>(a: E, b: E, c: E, d: E) -> Mat<E> {
 
 /// helper method to translate an nalgebra call Matrix3::new(a,b,c, d,e,f, g,h,i) to the
 /// equivalent faer matrix constructor
-pub fn matrix3_new<E: SimpleEntity>(
-    a: E,
-    b: E,
-    c: E,
-    d: E,
-    e: E,
-    f: E,
-    g: E,
-    h: E,
-    i: E,
-) -> Mat<E> {
+pub fn matrix3_new<E: Entity>(a: E, b: E, c: E, d: E, e: E, f: E, g: E, h: E, i: E) -> Mat<E> {
     let m = faer::mat![[a, b, c], [d, e, f], [g, h, i]];
     assert_eq!(m.nrows(), 3);
     assert_eq!(m.ncols(), 3);

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -16,6 +16,12 @@ pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
     column_vector_from_slice(&[a, b, c])
 }
 
+/// helper method to translate an nalgebra call Vector2::new(a,b) to the
+/// equivalent faer matrix constructor
+pub fn vector2_new<E: SimpleEntity>(a: E, b: E) -> Mat<E> {
+    column_vector_from_slice(&[a, b])
+}
+
 /// helper method to translate an nalgebra call Matrix2x3::new(a,b,c, d,e,f) to the
 /// equivalent faer matrix constructor
 pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -13,25 +13,46 @@ pub fn column_vector_from_slice<E: SimpleEntity>(slice: &[E]) -> Mat<E> {
 /// helper method to translate an nalgebra call Vector3::new(a,b,c) to the
 /// equivalent faer matrix constructor
 pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
-    column_vector_from_slice(&[a, b, c])
+    let v = column_vector_from_slice(&[a, b, c]);
+    assert_eq!(v.nrows(), 3);
+    assert_eq!(v.ncols(), 1);
+    v
+}
+
+/// helper method to translate an nalgebra call RowVector3::new(a,b,c) to the
+/// equivalent faer matrix constructor
+pub fn row_vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
+    let v = faer::mat![[a, b, c]];
+    assert_eq!(v.nrows(), 1);
+    assert_eq!(v.ncols(), 3);
+    v
 }
 
 /// helper method to translate an nalgebra call Vector2::new(a,b) to the
 /// equivalent faer matrix constructor
 pub fn vector2_new<E: SimpleEntity>(a: E, b: E) -> Mat<E> {
-    column_vector_from_slice(&[a, b])
+    let v = column_vector_from_slice(&[a, b]);
+    assert_eq!(v.nrows(), 2);
+    assert_eq!(v.ncols(), 1);
+    v
 }
 
 /// helper method to translate an nalgebra call Matrix2x3::new(a,b,c, d,e,f) to the
 /// equivalent faer matrix constructor
 pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {
-    faer::mat![[a, b, c], [d, e, f]]
+    let m = faer::mat![[a, b, c], [d, e, f]];
+    assert_eq!(m.nrows(), 2);
+    assert_eq!(m.ncols(), 3);
+    m
 }
 
 /// helper method to translate an nalgebra call Matrix2::new(a,b, c,d) to the
 /// equivalent faer matrix constructor
 pub fn matrix2_new<E: SimpleEntity>(a: E, b: E, c: E, d: E) -> Mat<E> {
-    faer::mat![[a, b], [c, d]]
+    let m = faer::mat![[a, b], [c, d]];
+    assert_eq!(m.nrows(), 2);
+    assert_eq!(m.ncols(), 2);
+    m
 }
 
 /// helper method to translate an nalgebra call Matrix3::new(a,b,c, d,e,f, g,h,i) to the
@@ -47,5 +68,8 @@ pub fn matrix3_new<E: SimpleEntity>(
     h: E,
     i: E,
 ) -> Mat<E> {
-    faer::mat![[a, b, c], [d, e, f], [g, h, i]]
+    let m = faer::mat![[a, b, c], [d, e, f], [g, h, i]];
+    assert_eq!(m.nrows(), 3);
+    assert_eq!(m.ncols(), 3);
+    m
 }

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -33,3 +33,19 @@ pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat
 pub fn matrix2_new<E: SimpleEntity>(a: E, b: E, c: E, d: E) -> Mat<E> {
     faer::mat![[a, b], [c, d]]
 }
+
+/// helper method to translate an nalgebra call Matrix3::new(a,b,c, d,e,f, g,h,i) to the
+/// equivalent faer matrix constructor
+pub fn matrix3_new<E: SimpleEntity>(
+    a: E,
+    b: E,
+    c: E,
+    d: E,
+    e: E,
+    f: E,
+    g: E,
+    h: E,
+    i: E,
+) -> Mat<E> {
+    faer::mat![[a, b, c], [d, e, f], [g, h, i]]
+}

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -1,6 +1,6 @@
-use faer::{mat::from_column_major_slice_generic, Conjugate, Mat, SimpleEntity};
+use faer::{mat::from_column_major_slice_generic, zipped, Conjugate, Mat, SimpleEntity};
 
 /// create a column vector (in Nx1 matrix form) from a Vec instance
-pub fn column_vector_from_vec<E: SimpleEntity + Conjugate<Canonical = E>>(vec: Vec<E>) -> Mat<E> {
-    from_column_major_slice_generic::<E, usize, usize>(vec.as_slice(), vec.len(), 1).to_owned()
+pub fn column_vector_from_vec<E: SimpleEntity>(vec: Vec<E>) -> Mat<E> {
+    Mat::<E>::from_fn(vec.len(), 1, |ir, _ic| vec[ir])
 }

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -1,0 +1,6 @@
+use faer::{mat::from_column_major_slice_generic, Conjugate, Mat, SimpleEntity};
+
+/// create a column vector (in Nx1 matrix form) from a Vec instance
+pub fn column_vector_from_vec<E: SimpleEntity + Conjugate<Canonical = E>>(vec: Vec<E>) -> Mat<E> {
+    from_column_major_slice_generic::<E, usize, usize>(vec.as_slice(), vec.len(), 1).to_owned()
+}

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -15,3 +15,9 @@ pub fn column_vector_from_slice<E: SimpleEntity>(slice: &[E]) -> Mat<E> {
 pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
     column_vector_from_slice(&[a, b, c])
 }
+
+/// helper method to translate an nalgebra call Matrix2x3::new(a,b,c, d,e,f) to the
+/// equivalent faer matrix constructor
+pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {
+    faer::mat![[a, b, c], [d, e, f]]
+}

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -2,5 +2,16 @@ use faer::{mat::from_column_major_slice_generic, zipped, Conjugate, Mat, SimpleE
 
 /// create a column vector (in Nx1 matrix form) from a Vec instance
 pub fn column_vector_from_vec<E: SimpleEntity>(vec: Vec<E>) -> Mat<E> {
-    Mat::<E>::from_fn(vec.len(), 1, |ir, _ic| vec[ir])
+    column_vector_from_slice(vec.as_slice())
+}
+
+/// create an owning column vector from a slice
+pub fn column_vector_from_slice<E: SimpleEntity>(slice: &[E]) -> Mat<E> {
+    Mat::<E>::from_fn(slice.len(), 1, |ir, _ic| slice[ir])
+}
+
+/// helper method to translate an nalgebra call Vector3::new(a,b,c) to the
+/// equivalent faer matrix constructor
+pub fn vector3_new<E: SimpleEntity>(a: E, b: E, c: E) -> Mat<E> {
+    column_vector_from_slice(&[a, b, c])
 }

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -1,6 +1,7 @@
 use faer::{mat::from_column_major_slice_generic, zipped, Conjugate, Entity, Mat};
 
 /// create a column vector (in Nx1 matrix form) from a Vec instance
+/// equivalent to the nalgebra call DVector::from_vec
 pub fn column_vector_from_vec<E: Entity>(vec: Vec<E>) -> Mat<E> {
     column_vector_from_slice(vec.as_slice())
 }

--- a/crates/argmin-math/src/faer_m/test_helper.rs
+++ b/crates/argmin-math/src/faer_m/test_helper.rs
@@ -27,3 +27,9 @@ pub fn vector2_new<E: SimpleEntity>(a: E, b: E) -> Mat<E> {
 pub fn matrix2x3_new<E: SimpleEntity>(a: E, b: E, c: E, d: E, e: E, f: E) -> Mat<E> {
     faer::mat![[a, b, c], [d, e, f]]
 }
+
+/// helper method to translate an nalgebra call Matrix2::new(a,b, c,d) to the
+/// equivalent faer matrix constructor
+pub fn matrix2_new<E: SimpleEntity>(a: E, b: E, c: E, d: E) -> Mat<E> {
+    faer::mat![[a, b], [c, d]]
+}

--- a/crates/argmin-math/src/faer_m/transpose.rs
+++ b/crates/argmin-math/src/faer_m/transpose.rs
@@ -13,7 +13,7 @@ where
     }
 }
 
-impl<'a, E> ArgminTranspose<Mat<E>> for MatRef<'a, E>
+impl<E> ArgminTranspose<Mat<E>> for MatRef<'_, E>
 where
     E: Entity + Conjugate<Canonical = E>,
 {

--- a/crates/argmin-math/src/faer_m/transpose.rs
+++ b/crates/argmin-math/src/faer_m/transpose.rs
@@ -1,0 +1,42 @@
+use crate::ArgminTranspose;
+use faer::{Conjugate, Entity, Mat, MatRef, Shape};
+
+impl<'a, E, R, C> ArgminTranspose<MatRef<'a, E, C, R>> for MatRef<'a, E, R, C>
+where
+    E: Entity,
+    R: Shape,
+    C: Shape,
+{
+    #[inline]
+    fn t(self) -> MatRef<'a, E, C, R> {
+        self.transpose()
+    }
+}
+
+impl<E> ArgminTranspose<Mat<E>> for Mat<E>
+where
+    E: Entity + Conjugate<Canonical = E>,
+{
+    #[inline]
+    fn t(self) -> Mat<E> {
+        self.transpose().to_owned()
+    }
+}
+
+impl<'a, E> ArgminTranspose<MatRef<'a, E>> for &'a Mat<E>
+where
+    E: Entity,
+{
+    #[inline]
+    fn t(self) -> MatRef<'a, E> {
+        self.transpose()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn add_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/transpose.rs
+++ b/crates/argmin-math/src/faer_m/transpose.rs
@@ -13,6 +13,16 @@ where
     }
 }
 
+impl<'a, E> ArgminTranspose<Mat<E>> for MatRef<'a, E>
+where
+    E: Entity + Conjugate<Canonical = E>,
+{
+    #[inline]
+    fn t(self) -> Mat<E> {
+        self.transpose().to_owned()
+    }
+}
+
 impl<E> ArgminTranspose<Mat<E>> for Mat<E>
 where
     E: Entity + Conjugate<Canonical = E>,
@@ -34,9 +44,103 @@ where
 }
 
 #[cfg(test)]
-mod test {
-    #[test]
-    fn add_tests() {
-        todo!()
+mod tests {
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat;
+    use faer::mat::AsMatRef;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_transpose_ $t>]() {
+                    // we make sure that transposition works for both references
+                    // and owned matrices
+                    let a : Mat<$t> = column_vector_from_vec(vec![1 as $t, 4 as $t]);
+                    let a2 = a.clone();
+                    let a3 = a.clone();
+                    assert_eq!(a.nrows(),2);
+                    assert_eq!(a.ncols(),1);
+                    //@note(geo-ant) test all possible implementations
+                    let res =  <_ as ArgminTranspose<Mat<_>>>::t(a);
+                    let res2 = <_ as ArgminTranspose<Mat<_>>>::t(a2.as_mat_ref());
+                    let res3 =  <_ as ArgminTranspose<MatRef<_>>>::t(&a3);
+                    let res4 =  <_ as ArgminTranspose<MatRef<_>>>::t(a3.as_mat_ref());
+                    assert_eq!(res.nrows(),1);
+                    assert_eq!(res.ncols(),2);
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    assert_relative_eq!(res[(0,0)] as f64, 1. as f64, epsilon = f64::EPSILON);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_1_ $t>]() {
+                    let a :Mat<$t> = mat![
+                        [1 as $t, 4 as $t],
+                        [8 as $t, 7 as $t]
+                    ];
+                    let a2 = a.clone();
+                    let a3 = a.clone();
+                    let target = mat![
+                        [1 as $t, 8 as $t],
+                        [4 as $t, 7 as $t]
+                    ];
+                    let res =  <_ as ArgminTranspose<Mat<_>>>::t(a);
+                    let res2 = <_ as ArgminTranspose<Mat<_>>>::t(a2.as_mat_ref());
+                    let res3 =  <_ as ArgminTranspose<MatRef<_>>>::t(&a3);
+                    let res4 =  <_ as ArgminTranspose<MatRef<_>>>::t(a3.as_mat_ref());
+                    assert_eq!(res.nrows(),2);
+                    assert_eq!(res.ncols(),2);
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert_relative_eq!(target[(i, j)] as f64, res[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_transpose_2d_2_ $t>]() {
+                    let a : Mat<$t>= mat![
+                        [1 as $t, 4 as $t],
+                        [8 as $t, 7 as $t],
+                        [3 as $t, 6 as $t]
+                    ];
+                    let a2 = a.clone();
+                    let a3 = a.clone();
+                    let target = mat![
+                        [1 as $t, 8 as $t, 3 as $t],
+                        [4 as $t, 7 as $t, 6 as $t]
+                    ];
+                    let res =  <_ as ArgminTranspose<Mat<_>>>::t(a);
+                    let res2 = <_ as ArgminTranspose<Mat<_>>>::t(a2.as_mat_ref());
+                    let res3 =  <_ as ArgminTranspose<MatRef<_>>>::t(&a3);
+                    let res4 =  <_ as ArgminTranspose<MatRef<_>>>::t(a3.as_mat_ref());
+                    assert_eq!(res.nrows(),target.nrows());
+                    assert_eq!(res.ncols(),target.ncols());
+                    assert_eq!(res,res2);
+                    assert_eq!(res,res3);
+                    assert_eq!(res,res4);
+                    for i in 0..2 {
+                        for j in 0..3 {
+                            assert_relative_eq!(target[(i, j)] as f64, res[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/zero.rs
+++ b/crates/argmin-math/src/faer_m/zero.rs
@@ -1,6 +1,5 @@
-use faer::{Entity, Mat, Shape};
-
 use crate::ArgminZeroLike;
+use faer::{Entity, Mat, Shape};
 
 impl<E, R, C> ArgminZeroLike for Mat<E, R, C>
 where
@@ -15,8 +14,63 @@ where
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn add_tests() {
-        todo!()
+    use super::super::test_helper::*;
+    use super::*;
+    use approx::assert_relative_eq;
+    use faer::mat;
+    use faer::mat::AsMatRef;
+    use paste::item;
+
+    macro_rules! make_test {
+        ($t:ty) => {
+            item! {
+                #[test]
+                fn [<test_zero_like_ $t>]() {
+                    let t: Mat<$t> = column_vector_from_vec::<$t>(vec![]);
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_zero_like_2_ $t>]() {
+                    let a = column_vector_from_vec(vec![42 as $t, 42 as $t, 42 as $t, 42 as $t]).zero_like();
+                    for i in 0..4 {
+                        assert_relative_eq!(0 as f64, a[(i,0)] as f64, epsilon = f64::EPSILON);
+                    }
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_ $t>]() {
+                    let t: Mat<$t> = column_vector_from_vec(vec![0 as $t ,0 as $t]);
+                    let a = t.zero_like();
+                    assert_eq!(t, a);
+                }
+            }
+
+            item! {
+                #[test]
+                fn [<test_2d_zero_like_2_ $t>]() {
+                    let a = mat![
+                      [42 as $t, 42 as $t],
+                      [42 as $t, 42 as $t]
+                    ].zero_like();
+
+                    for i in 0..2 {
+                        for j in 0..2 {
+                            assert_relative_eq!(0 as f64, a[(i, j)] as f64, epsilon = f64::EPSILON);
+                        }
+                    }
+                }
+            }
+        };
     }
+
+    //@note(geo-ant): partial equality does not work for integral types in faer
+    // which is why we implement the tests for floating point numbers only
+    make_test!(f32);
+    make_test!(f64);
 }

--- a/crates/argmin-math/src/faer_m/zero.rs
+++ b/crates/argmin-math/src/faer_m/zero.rs
@@ -1,0 +1,22 @@
+use faer::{Entity, Mat, Shape};
+
+use crate::ArgminZeroLike;
+
+impl<E, R, C> ArgminZeroLike for Mat<E, R, C>
+where
+    E: Entity,
+    R: Shape,
+    C: Shape,
+{
+    fn zero_like(&self) -> Self {
+        Self::zeros(self.nrows(), self.ncols())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn add_tests() {
+        todo!()
+    }
+}

--- a/crates/argmin-math/src/faer_m/zero.rs
+++ b/crates/argmin-math/src/faer_m/zero.rs
@@ -18,7 +18,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use faer::mat;
-    use faer::mat::AsMatRef;
+    use faer::mat::{AsMatRef, MatRef};
     use paste::item;
 
     macro_rules! make_test {

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -237,6 +237,12 @@ mod vec;
 #[allow(unused_imports)]
 pub use crate::vec::*;
 
+//@todo(geo) make this conditional
+extern crate faer_0_20 as faer;
+mod faer_m;
+#[allow(unused_imports)]
+pub use crate::faer_m::*;
+
 // Re-export of types appearing in the api as recommended here: https://www.lurklurk.org/effective-rust/re-export.html
 pub use anyhow::Error;
 pub use rand::Rng;

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -6,9 +6,9 @@
 // copied, modified, or distributed except according to those terms.
 
 //! argmin-math provides mathematics related abstractions needed in argmin. It supports
-//! implementations of these abstractions for basic `Vec`s and for `ndarray` and `nalgebra`.
-//! The traits can of course also be implemented for your own types to make them compatible with
-//! argmin.
+//! implementations of these abstractions for basic `Vec`s and for the `ndarray`, `nalgebra`,
+//! and `faer` linear algebra libraries. The traits can of course also be implemented
+//! for your own types to make them compatible with argmin.
 //!
 //! For an introduction on how to use argmin, please also have a look at the
 //! [book](https://www.argmin-rs.org/book/).

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -239,6 +239,7 @@ pub use crate::vec::*;
 
 //@todo(geo) make this conditional
 extern crate faer_0_20 as faer;
+// extern crate faer_core_0_17 as faer_core;
 mod faer_m;
 #[allow(unused_imports)]
 pub use crate::faer_m::*;

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -219,6 +219,12 @@ cfg_if::cfg_if! {
     }
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(feature = "faer_v0_20")] {
+        extern crate faer_0_20 as faer;
+    }
+}
+
 #[cfg(feature = "primitives")]
 mod primitives;
 #[cfg(feature = "primitives")]
@@ -243,10 +249,9 @@ mod vec;
 #[allow(unused_imports)]
 pub use crate::vec::*;
 
-//@todo(geo) make this conditional
-extern crate faer_0_20 as faer;
-// extern crate faer_core_0_17 as faer_core;
+#[cfg(feature = "faer_all")]
 mod faer_m;
+#[cfg(feature = "faer_all")]
 #[allow(unused_imports)]
 pub use crate::faer_m::*;
 

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -74,6 +74,12 @@
 //! | `nalgebra_v0_30`       | no      | version 0.30                             |
 //! | `nalgebra_v0_29`       | no      | version 0.29                             |
 //!
+//! ### `faer`
+//!
+//! | Feature                | Default | Comment                                  |
+//! |------------------------|---------|------------------------------------------|
+//! | `faer_latest`          | no      | latest supported version                 |
+//! | `faer_v0_20`           | no      | version 0.20                             |
 //!
 //! ## Choosing a backend
 //!

--- a/crates/argmin/src/lib.rs
+++ b/crates/argmin/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! Its goal is to offer a wide range of optimization algorithms with a consistent interface.
 //! It is type-agnostic by design, meaning that any type and/or math backend, such as
-//! `nalgebra` or `ndarray` can be used -- even your own.
+//! `nalgebra` or `ndarray`, can be used -- even your own.
 //!
 //! Observers allow one to track the progress of iterations, either by using one of the provided
 //! ones for logging to screen or disk or by implementing your own.


### PR DESCRIPTION
**Fixes**: https://github.com/argmin-rs/argmin/issues/412 add faer as math backend

This PR adds [`faer`](https://docs.rs/faer/latest/faer/) support to argmin-math. `faer` is a fast and rapidly evolving matrix backend that is gaining popularity in the numeric Rust ecosystem. I'm not associated with the project.

I've closely followed the logic of the `nalgebra` implementation and even manually copied and translated the tests, so that the behavior of the `nalgebra` implementation is kept with the `faer` implementation. The one exception I made is that an `eye_like` identity matrix can also be requested for non-square matrices without panicking. Otherwise I've kept the original behavior.

All implementations are available on the owned `Mat<T>` type and many (but not all) are available on the non-owning reference-type `MatRef<T>`.