### PR TITLE
cargo deny: ignore unmaintained paste

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,8 @@ ignore = [
     "RUSTSEC-2024-0370",
     "RUSTSEC-2024-0384",
     "RUSTSEC-2024-0388",
+    # ignore unmaintained `paste`
+    "RUSTSEC-2024-0436",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Ignores `paste` being unmaintained. Quick fix until a replacement for paste exists.

Related to #574 

