### PR TITLE
propagate rand 0.9 xoshiro 0.7 deps

### DIFF
--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -43,7 +43,7 @@ num-complex_0_3 = { package = "num-complex", version = "0.3", optional = true, d
 num-complex_0_2 = { package = "num-complex", version = "0.2", optional = true, default-features = false, features = ["std"] }
 num-traits = { version = "0.2" }
 num-integer = { version = "0.1" }
-rand = { version = "0.8.3" }
+rand = { version = "0.9" }
 anyhow = { version = "1.0" }
 thiserror = { version = "1.0" }
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "0.8"
+rand = "0.9"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "0.8"
+rand = "0.9"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "0.8"
+rand = "0.9"
 
 [features]
 

--- a/crates/argmin-math/src/faer_m_0_21/random.rs
+++ b/crates/argmin-math/src/faer_m_0_21/random.rs
@@ -1,6 +1,6 @@
 use crate::ArgminRandom;
 use faer::Mat;
-use rand::distributions::uniform::SampleUniform;
+use rand::distr::uniform::SampleUniform;
 
 impl<E: PartialOrd + SampleUniform + Copy> ArgminRandom for Mat<E> {
     fn rand_from_range<R: rand::Rng>(min: &Self, max: &Self, rng: &mut R) -> Self {

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -387,7 +387,7 @@ pub trait ArgminInv<T> {
 /// Create a random number
 pub trait ArgminRandom {
     /// Get a random element between min and max,
-    fn rand_from_range<R: rand::RngCore>(min: &Self, max: &Self, rng: &mut R) -> Self;
+    fn rand_from_range<R: rand::Rng>(min: &Self, max: &Self, rng: &mut R) -> Self;
 }
 
 /// Minimum and Maximum of type `T`

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -387,7 +387,7 @@ pub trait ArgminInv<T> {
 /// Create a random number
 pub trait ArgminRandom {
     /// Get a random element between min and max,
-    fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> Self;
+    fn rand_from_range<R: rand::RngCore>(min: &Self, max: &Self, rng: &mut R) -> Self;
 }
 
 /// Minimum and Maximum of type `T`

--- a/crates/argmin-math/src/nalgebra_m/random.rs
+++ b/crates/argmin-math/src/nalgebra_m/random.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use rand::{distributions::uniform::SampleUniform, Rng};
+use rand::{distr::uniform::SampleUniform, Rng};
 
 use crate::{Allocator, ArgminRandom};
 
@@ -37,9 +37,9 @@ where
                 if a == b {
                     a.clone()
                 } else if a < b {
-                    rng.gen_range(a.clone()..b.clone())
+                    rng.random_range(a.clone()..b.clone())
                 } else {
-                    rng.gen_range(b.clone()..a.clone())
+                    rng.random_range(b.clone()..a.clone())
                 }
             }),
         )

--- a/crates/argmin-math/src/ndarray_m/random.rs
+++ b/crates/argmin-math/src/ndarray_m/random.rs
@@ -24,9 +24,9 @@ macro_rules! make_random {
                     if a == b {
                         a.clone()
                     } else if a < b {
-                        rng.gen_range(a.clone()..b.clone())
+                        rng.random_range(a.clone()..b.clone())
                     } else {
-                        rng.gen_range(b.clone()..a.clone())
+                        rng.random_range(b.clone()..a.clone())
                     }
                 }))
             }
@@ -46,9 +46,9 @@ macro_rules! make_random {
                     if a == b {
                         a.clone()
                     } else if a < b {
-                        rng.gen_range(a.clone()..b.clone())
+                        rng.random_range(a.clone()..b.clone())
                     } else {
-                        rng.gen_range(b.clone()..a.clone())
+                        rng.random_range(b.clone()..a.clone())
                     }
                 })
             }

--- a/crates/argmin-math/src/primitives/random.rs
+++ b/crates/argmin-math/src/primitives/random.rs
@@ -13,7 +13,7 @@ macro_rules! make_random {
         impl ArgminRandom for $t {
             #[inline]
             fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> $t {
-                rng.gen_range(*min..*max)
+                rng.random_range(*min..*max)
             }
         }
     };

--- a/crates/argmin-math/src/vec/random.rs
+++ b/crates/argmin-math/src/vec/random.rs
@@ -25,9 +25,9 @@ macro_rules! make_random {
                         if a == b {
                             a.clone()
                         } else if a < b {
-                            rng.gen_range(a.clone()..b.clone())
+                            rng.random_range(a.clone()..b.clone())
                         } else {
-                            rng.gen_range(b.clone()..a.clone())
+                            rng.random_range(b.clone()..a.clone())
                         }
                     })
                     .collect()

--- a/crates/argmin-observer-spectator/Cargo.toml
+++ b/crates/argmin-observer-spectator/Cargo.toml
@@ -25,5 +25,5 @@ uuid = { version = "1.3.0", features = ["v4"] }
 
 [dev-dependencies]
 argmin_testfunctions = { version = "*", path = "../argmin-testfunctions" }
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -43,7 +43,7 @@ argmin-checkpointing-file = { path = "../argmin-checkpointing-file" }
 [features]
 default = []
 wasm-bindgen = ["getrandom/js"]
-serde1 = ["serde"]
+serde1 = ["serde", "rand_xoshiro/serde"]
 _ndarrayl = ["argmin-math/ndarray_latest"]
 # When adding new features, please consider adding them to either `full` (for users)
 # or `_full_dev` (only for local development, testing and computing test coverage).

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -18,8 +18,8 @@ exclude = []
 anyhow = "1.0"
 paste = "1"
 num-traits = "0.2"
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"
 thiserror = "1.0"
 web-time = "1.1.0"
 argmin-math = { path = "../argmin-math", version = "0.4", default-features = false, features = ["primitives"] }
@@ -43,7 +43,7 @@ argmin-checkpointing-file = { path = "../argmin-checkpointing-file" }
 [features]
 default = []
 wasm-bindgen = ["getrandom/js"]
-serde1 = ["serde", "rand_xoshiro/serde1"]
+serde1 = ["serde"]
 _ndarrayl = ["argmin-math/ndarray_latest"]
 # When adding new features, please consider adding them to either `full` (for users)
 # or `_full_dev` (only for local development, testing and computing test coverage).
@@ -55,4 +55,4 @@ maintenance = { status = "actively-developed" }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-features = ["serde1"]
+features = []

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -24,7 +24,7 @@ use crate::core::{
     ArgminFloat, CostFunction, Error, PopulationState, Problem, Solver, SyncAlias, KV,
 };
 use argmin_math::{ArgminAdd, ArgminMinMax, ArgminMul, ArgminRandom, ArgminSub, ArgminZeroLike};
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngCore, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -102,7 +102,7 @@ where
             weight_social: float!(0.5 + 2.0f64.ln()),
             bounds,
             num_particles,
-            rng_generator: rand::rngs::StdRng::from_entropy(),
+            rng_generator: rand::rngs::StdRng::from_os_rng(),
         }
     }
 }
@@ -146,7 +146,7 @@ impl<P, F, R> ParticleSwarm<P, F, R>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,
     F: ArgminFloat,
-    R: Rng,
+    R: Rng + RngCore,
 {
     /// Set inertia factor on particle velocity
     ///

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -24,7 +24,7 @@ use crate::core::{
     ArgminFloat, CostFunction, Error, PopulationState, Problem, Solver, SyncAlias, KV,
 };
 use argmin_math::{ArgminAdd, ArgminMinMax, ArgminMul, ArgminRandom, ArgminSub, ArgminZeroLike};
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
 
@@ -146,7 +146,7 @@ impl<P, F, R> ParticleSwarm<P, F, R>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,
     F: ArgminFloat,
-    R: Rng + RngCore,
+    R: Rng,
 {
     /// Set inertia factor on particle velocity
     ///

--- a/crates/argmin/src/solver/simulatedannealing/mod.rs
+++ b/crates/argmin/src/solver/simulatedannealing/mod.rs
@@ -199,7 +199,7 @@ where
     /// # }
     /// ```
     pub fn new(initial_temperature: F) -> Result<Self, Error> {
-        SimulatedAnnealing::new_with_rng(initial_temperature, Xoshiro256PlusPlus::from_entropy())
+        SimulatedAnnealing::new_with_rng(initial_temperature, Xoshiro256PlusPlus::from_os_rng())
     }
 }
 
@@ -511,7 +511,7 @@ where
         // `1 / (1 + exp((next_cost - prev_cost) / current_temperature))`,
         //
         // which will always be between 0 and 0.5.
-        let prob: f64 = self.rng.gen();
+        let prob: f64 = self.rng.random();
         let prob = float!(prob);
         let accepted = (new_cost < prev_cost)
             || (float!(1.0) / (float!(1.0) + ((new_cost - prev_cost) / self.cur_temp).exp())

--- a/examples/simulatedannealing/Cargo.toml
+++ b/examples/simulatedannealing/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["vec"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"

--- a/examples/simulatedannealing/src/main.rs
+++ b/examples/simulatedannealing/src/main.rs
@@ -11,7 +11,7 @@ use argmin::{
 };
 use argmin_observer_slog::SlogLogger;
 use argmin_testfunctions::rosenbrock;
-use rand::{distributions::Uniform, prelude::*};
+use rand::{distr::Uniform, prelude::*};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::sync::{Arc, Mutex};
 
@@ -32,7 +32,7 @@ impl Rosenbrock {
         Rosenbrock {
             lower_bound,
             upper_bound,
-            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_os_rng())),
         }
     }
 }
@@ -55,7 +55,7 @@ impl Anneal for Rosenbrock {
     fn anneal(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
         let mut param_n = param.clone();
         let mut rng = self.rng.lock().unwrap();
-        let distr = Uniform::from(0..param.len());
+        let distr = Uniform::try_from(0..param.len()).unwrap();
         // Perform modifications to a degree proportional to the current temperature `temp`.
         for _ in 0..(temp.floor() as u64 + 1) {
             // Compute random index of the parameter vector using the supplied random number
@@ -63,7 +63,7 @@ impl Anneal for Rosenbrock {
             let idx = rng.sample(distr);
 
             // Compute random number in [0.1, 0.1].
-            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1));
+            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1).unwrap());
 
             // modify previous parameter value at random position `idx` by `val`
             param_n[idx] += val;

--- a/examples/spectator_basic/Cargo.toml
+++ b/examples/spectator_basic/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["vec"], path = "../../crates/argmin-math" }
 argmin-observer-spectator = { version = "*", path = "../../crates/argmin-observer-spectator" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"

--- a/examples/spectator_basic/src/main.rs
+++ b/examples/spectator_basic/src/main.rs
@@ -11,7 +11,7 @@ use argmin::{
 };
 use argmin_observer_spectator::SpectatorBuilder;
 use argmin_testfunctions::rosenbrock;
-use rand::{distributions::Uniform, prelude::*};
+use rand::{distr::Uniform, prelude::*};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::sync::{Arc, Mutex};
 
@@ -32,7 +32,7 @@ impl Rosenbrock {
         Rosenbrock {
             lower_bound,
             upper_bound,
-            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_os_rng())),
         }
     }
 }
@@ -55,10 +55,10 @@ impl Anneal for Rosenbrock {
     fn anneal(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
         let mut param_n = param.clone();
         let mut rng = self.rng.lock().unwrap();
-        let distr = Uniform::from(0..param.len());
+        let distr = Uniform::try_from(0..param.len()).unwrap();
         for _ in 0..(temp.floor() as u64 + 1) {
             let idx = rng.sample(distr);
-            let val = rng.sample(Uniform::new_inclusive(-0.0001, 0.0001));
+            let val = rng.sample(Uniform::new_inclusive(-0.0001, 0.0001).unwrap());
             param_n[idx] += val;
             param_n[idx] = param_n[idx].clamp(self.lower_bound[idx], self.upper_bound[idx]);
         }

--- a/examples/spectator_multiple/Cargo.toml
+++ b/examples/spectator_multiple/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["vec"], path = "../../crates/argmin-math" }
 argmin-observer-spectator = { version = "*", path = "../../crates/argmin-observer-spectator" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"

--- a/examples/spectator_multiple/src/main.rs
+++ b/examples/spectator_multiple/src/main.rs
@@ -11,7 +11,7 @@ use argmin::{
 };
 use argmin_observer_spectator::SpectatorBuilder;
 use argmin_testfunctions::rosenbrock;
-use rand::{distributions::Uniform, prelude::*};
+use rand::{distr::Uniform, prelude::*};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::sync::{Arc, Mutex};
 
@@ -33,7 +33,7 @@ impl Rosenbrock {
         Rosenbrock {
             lower_bound,
             upper_bound,
-            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_os_rng())),
         }
     }
 }
@@ -58,10 +58,10 @@ impl Anneal for Rosenbrock {
     fn anneal(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
         let mut param_n = param.clone();
         let mut rng = self.rng.lock().unwrap();
-        let distr = Uniform::from(0..param.len());
+        let distr = Uniform::try_from(0..param.len()).unwrap();
         for _ in 0..(temp.floor() as u64 + 1) {
             let idx = rng.sample(distr);
-            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1));
+            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1).unwrap());
             param_n[idx] += val;
             param_n[idx] = param_n[idx].clamp(self.lower_bound[idx], self.upper_bound[idx]);
         }

--- a/examples/timeout/Cargo.toml
+++ b/examples/timeout/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["vec"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-rand = "0.8.5"
-rand_xoshiro = "0.6.0"
+rand = "0.9"
+rand_xoshiro = "0.7"

--- a/examples/timeout/src/main.rs
+++ b/examples/timeout/src/main.rs
@@ -14,7 +14,7 @@ use argmin::{
 };
 use argmin_observer_slog::SlogLogger;
 use argmin_testfunctions::rosenbrock;
-use rand::{distributions::Uniform, prelude::*};
+use rand::{distr::Uniform, prelude::*};
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::sync::{Arc, Mutex};
 
@@ -29,7 +29,7 @@ impl Rosenbrock {
         Rosenbrock {
             lower_bound,
             upper_bound,
-            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_entropy())),
+            rng: Arc::new(Mutex::new(Xoshiro256PlusPlus::from_os_rng())),
         }
     }
 }
@@ -51,10 +51,10 @@ impl Anneal for Rosenbrock {
     fn anneal(&self, param: &Vec<f64>, temp: f64) -> Result<Vec<f64>, Error> {
         let mut param_n = param.clone();
         let mut rng = self.rng.lock().unwrap();
-        let distr = Uniform::from(0..param.len());
+        let distr = Uniform::try_from(0..param.len()).unwrap();
         for _ in 0..(temp.floor() as u64 + 1) {
             let idx = rng.sample(distr);
-            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1));
+            let val = rng.sample(Uniform::new_inclusive(-0.1, 0.1).unwrap());
             param_n[idx] += val;
             param_n[idx] = param_n[idx].clamp(self.lower_bound[idx], self.upper_bound[idx]);
         }


### PR DESCRIPTION
updates deps.
from_entropy replaces by from_os_rng  (rand docs recommans chacha for portability...)
The rest should be ok. all tests passed.