### PR TITLE
Render math in argmin-testfunctions with KaTeX (part 2)

### DIFF
--- a/crates/argmin-testfunctions/src/eggholder.rs
+++ b/crates/argmin-testfunctions/src/eggholder.rs
@@ -5,29 +5,33 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # Eggholder test function
+//! # Eggholder test function.
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = -(x_2 + 47) * sin( sqrt( abs( x_2 + x_1/2 + 47 ) ) ) -
-//!                x_1 * sin( sqrt( abs( x_1 - (x_2 + 47) ) ) )`
+//! $$
+//! f(x_1, x_2) = -(x_2 + 47) \cdot \sin\left( \sqrt{\left| x_2 + \frac{x_1}{2} + 47 \right|} \right) -
+//!                x_1 \cdot \sin\left(\sqrt{\left|x_1 - (x_2 + 47)\right|}\right)
+//! $$
 //!
-//! where `x_i \in [-512, 512]`.
+//! where $x_i \in [-512,\\,512]$.
 //!
-//! The global minimum is at * `f(x_1, x_2) = f(512, 404.2319) = -959.6407`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(512,\\,404.2319) = -959.6407$.
 
 use num::{Float, FromPrimitive};
 
-/// Eggholder test function
+/// Eggholder test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = -(x_2 + 47) * sin( sqrt( abs( x_2 + x_1/2 + 47 ) ) ) -
-///                x_1 * sin( sqrt( abs( x_1 - (x_2 + 47) ) ) )`
+/// $$
+/// f(x_1, x_2) = -(x_2 + 47) \cdot \sin\left( \sqrt{\left| x_2 + \frac{x_1}{2} + 47 \right|} \right) -
+///                x_1 \cdot \sin\left(\sqrt{\left|x_1 - (x_2 + 47)\right|}\right)
+/// $$
 ///
-/// where `x_i \in [-512, 512]`.
+/// where $x_i \in [-512,\\,512]$.
 ///
-/// The global minimum is at * `f(x_1, x_2) = f(512, 404.2319) = -959.6407`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(512,\\,404.2319) = -959.6407$.
 pub fn eggholder<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -42,7 +46,7 @@ where
         - x1 * (x1 - (x2 + n47)).abs().sqrt().sin()
 }
 
-/// Derivative of Eggholder test function
+/// Derivative of Eggholder test function.
 pub fn eggholder_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -96,13 +100,15 @@ where
     ]
 }
 
-/// Hessian of Eggholder test function
+/// Hessian of Eggholder test function.
 ///
-/// This function can return NaN elements under the following conditions:
+/// This function can return [`NaN`](num::Float::nan)-valued elements under the following conditions:
 ///
-/// * |x1 - x2 - 47| <= EPS && x1 != 0
-/// * |x2 - x1 + 47| <= EPS && x1 != 0
-/// * |x1/2 + x2 + 47| <= EPS && |x2 + 47| != 0
+/// * $|x_1 - x_2 - 47| <= \epsilon$ and $x_1 \neq 0$
+/// * $|x_2 - x_1 + 47| <= \epsilon$ and $x_1 \neq 0$
+/// * $\left|\frac{x_1}{2} + x_2 + 47\right| <= \epsilon$ and $|x_2 + 47| \neq 0$
+///
+/// where $\epsilon$ is `T`'s [epsilon](num::Float::epsilon).
 pub fn eggholder_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/goldsteinprice.rs
+++ b/crates/argmin-testfunctions/src/goldsteinprice.rs
@@ -5,31 +5,39 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # Goldstein-Price test function
+//! # Goldstein-Price test function.
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = [1 + (x_1 + x_2 + 1)^2 * (19 - 14*x_1 + 3*x_1^2 - 14*x_2 + 6*x_1*x_2 + 3*x_2^2)]
-//!                * [30 + (2*x_1 - 3*x_2)^2(18 - 32 * x_1 + 12* x_1^2 + 48 * x_2 -
-//!                   36 * x_1 * x_2 + 27 * x_2^2) ]`
+//! $$
+//! \begin{aligned}
+//! f(x_1,\\,x_2) &= [1 + (x_1 + x_2 + 1)^2(19 - 14 x_1 + 3 x_1^2 - 14 x_2 + 6 x_1 x_2 + 3 x_2^2)] \\\\
+//!                &\times [30 + (2 x_1 - 3 x_2)^2(18 - 32 x_1 + 12 x_1^2 + 48 x_2 -
+//!                   36x_1 x_2 + 27 x_2^2) ]
+//! \end{aligned}
+//! $$
 //!
-//! where `x_i \in [-2, 2]`.
+//! where $x_i \in [-2,\\,2]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0, -1) = 3`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(0,\\,-1) = 3$.
 
 use num::{Float, FromPrimitive};
 
-/// Goldstein-Price test function
+/// Goldstein-Price test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = [1 + (x_1 + x_2 + 1)^2 * (19 - 14*x_1 + 3*x_1^2 - 14*x_2 + 6*x_1*x_2 + 3*x_2^2)]
-///                * [30 + (2*x_1 - 3*x_2)^2(18 - 32 * x_1 + 12* x_1^2 + 48 * x_2 -
-///                   36 * x_1 * x_2 + 27 * x_2^2) ]`
+/// $$
+/// \begin{aligned}
+/// f(x_1,\\,x_2) &= [1 + (x_1 + x_2 + 1)^2(19 - 14 x_1 + 3 x_1^2 - 14 x_2 + 6 x_1 x_2 + 3 x_2^2)] \\\\
+///                &\times [30 + (2 x_1 - 3 x_2)^2(18 - 32 x_1 + 12 x_1^2 + 48 x_2 -
+///                   36x_1 x_2 + 27 x_2^2) ]
+/// \end{aligned}
+/// $$
 ///
-/// where `x_i \in [-2, 2]`.
+/// where $x_i \in [-2,\\,2]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0, -1) = 3`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0,\\,-1) = 3$.
 pub fn goldsteinprice<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -55,7 +63,7 @@ where
                 * (n18 - n32 * x1 + n12 * x1.powi(2) + n48 * x2 - n36 * x1 * x2 + n27 * x2.powi(2)))
 }
 
-/// Derivative of Goldstein-Price test function
+/// Derivative of Goldstein-Price test function.
 pub fn goldsteinprice_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -110,7 +118,7 @@ where
     ]
 }
 
-/// Hessian of Goldstein-Price test function
+/// Hessian of Goldstein-Price test function.
 pub fn goldsteinprice_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/himmelblau.rs
+++ b/crates/argmin-testfunctions/src/himmelblau.rs
@@ -5,35 +5,39 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # Himmelblau test function
+//! # Himmelblau's test function.
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = (x_1^2 + x_2 - 11)^2 + (x_1 + x_2^2 - 7)^2`
+//! $$
+//! f(x_1,\\,x_2) = (x_1^2 + x_2 - 11)^2 + (x_1 + x_2^2 - 7)^2
+//! $$
 //!
-//! where `x_i \in [-5, 5]`.
+//! where $x_i \in [-5,\\,5]$.
 //!
 //! The global minima are at
-//!  * `f(x_1, x_2) = f(3, 2) = 0`.
-//!  * `f(x_1, x_2) = f(-2.805118, 3.131312) = 0`.
-//!  * `f(x_1, x_2) = f(-3.779310, -3.283186) = 0`.
-//!  * `f(x_1, x_2) = f(3.584428, -1.848126) = 0`.
+//!  * $f(x_1,\\,x_2) = f(3,\\,2) = 0$.
+//!  * $f(x_1,\\,x_2) = f(-2.805118,\\,3.131312) = 0$.
+//!  * $f(x_1,\\,x_2) = f(-3.779310,\\,-3.283186) = 0$.
+//!  * $f(x_1,\\,x_2) = f(3.584428,\\,-1.848126) = 0$.
 
 use num::{Float, FromPrimitive};
 
-/// Himmelblau test function
+/// Himmelblau's test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = (x_1^2 + x_2 - 11)^2 + (x_1 + x_2^2 - 7)^2`
+/// $$
+/// f(x_1,\\,x_2) = (x_1^2 + x_2 - 11)^2 + (x_1 + x_2^2 - 7)^2
+/// $$
 ///
-/// where `x_i \in [-5, 5]`.
+/// where $x_i \in [-5,\\,5]$.
 ///
 /// The global minima are at
-///  * `f(x_1, x_2) = f(3, 2) = 0`.
-///  * `f(x_1, x_2) = f(-2.805118, 3.131312) = 0`.
-///  * `f(x_1, x_2) = f(-3.779310, -3.283186) = 0`.
-///  * `f(x_1, x_2) = f(3.584428, -1.848126) = 0`.
+///  * $f(x_1,\\,x_2) = f(3,\\,2) = 0$.
+///  * $f(x_1,\\,x_2) = f(-2.805118,\\,3.131312) = 0$.
+///  * $f(x_1,\\,x_2) = f(-3.779310,\\,-3.283186) = 0$.
+///  * $f(x_1,\\,x_2) = f(3.584428,\\,-1.848126) = 0$.
 pub fn himmelblau<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -44,7 +48,7 @@ where
     (x1.powi(2) + x2 - n11).powi(2) + (x1 + x2.powi(2) - n7).powi(2)
 }
 
-/// Derivative of Himmelblau test function
+/// Derivative of Himmelblau's test function.
 pub fn himmelblau_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -62,7 +66,7 @@ where
     ]
 }
 
-/// Hessian of Himmelblau test function
+/// Hessian of Himmelblau's test function.
 pub fn himmelblau_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/holdertable.rs
+++ b/crates/argmin-testfunctions/src/holdertable.rs
@@ -9,32 +9,36 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = -abs(sin(x_1)*cos(x_2)*exp(abs(1- sqrt(x_1^2+x_2^2)/pi)))`
+//! $$
+//! f(x_1,\\,x_2) = -\left|\sin(x_1)\cos(x_2)\exp\left(\left|1- \frac{\sqrt{x_1^2+x_2^2}}{\pi}\right|\right)\right|
+//! $$
 //!
-//! where `x_i \in [-10, 10]`.
+//! where $x_i \in [-10,\\,10]$.
 //!
 //! The global minima are at
-//!  * `f(x_1, x_2) = f(8.05502, 9.66459) = -19.2085`.
-//!  * `f(x_1, x_2) = f(8.05502, -9.66459) = -19.2085`.
-//!  * `f(x_1, x_2) = f(-8.05502, 9.66459) = -19.2085`.
-//!  * `f(x_1, x_2) = f(-8.05502, -9.66459) = -19.2085`.
+//!  * $f(x_1,\\,x_2) = f(8.05502,\\,9.66459) = -19.2085$.
+//!  * $f(x_1,\\,x_2) = f(8.05502,\\,-9.66459) = -19.2085$.
+//!  * $f(x_1,\\,x_2) = f(-8.05502,\\,9.66459) = -19.2085$.
+//!  * $f(x_1,\\,x_2) = f(-8.05502,\\,-9.66459) = -19.2085$.
 
 use num::{Float, FromPrimitive};
 use std::f64::consts::PI;
 
-/// Holder table test function
+/// Holder table test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = -abs(sin(x_1)*cos(x_2)*exp(abs(1- sqrt(x_1^2+x_2^2)/pi)))`
+/// $$
+/// f(x_1,\\,x_2) = -\left|\sin(x_1)\cos(x_2)\exp\left(\left|1- \frac{\sqrt{x_1^2+x_2^2}}{\pi}\right|\right)\right|
+/// $$
 ///
-/// where `x_i \in [-10, 10]`.
+/// where $x_i \in [-10,\\,10]$.
 ///
 /// The global minima are at
-///  * `f(x_1, x_2) = f(8.05502, 9.66459) = -19.2085`.
-///  * `f(x_1, x_2) = f(8.05502, -9.66459) = -19.2085`.
-///  * `f(x_1, x_2) = f(-8.05502, 9.66459) = -19.2085`.
-///  * `f(x_1, x_2) = f(-8.05502, -9.66459) = -19.2085`.
+///  * $f(x_1,\\,x_2) = f(8.05502,\\,9.66459) = -19.2085$.
+///  * $f(x_1,\\,x_2) = f(8.05502,\\,-9.66459) = -19.2085$.
+///  * $f(x_1,\\,x_2) = f(-8.05502,\\,9.66459) = -19.2085$.
+///  * $f(x_1,\\,x_2) = f(-8.05502,\\,-9.66459) = -19.2085$.
 pub fn holder_table<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -45,9 +49,10 @@ where
     -(x1.sin() * x2.cos() * (n1 - (x1.powi(2) + x2.powi(2)).sqrt() / pi).abs().exp()).abs()
 }
 
-/// Derivative of the Holder table test function
+/// Derivative of the Holder table test function.
 ///
-/// This function has a discontinuity at `sqrt(x_1^2+x_2^2) = PI`, and hence can return `NaN`.
+/// The test function has a discontinuity at $\sqrt{x_1^2+x_2^2} = \pi$,
+/// hence the derivative can be [NaN](num::Float::nan)-valued.
 pub fn holder_table_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -90,9 +95,10 @@ where
     }
 }
 
-/// Hessian of the Holder table test function
+/// Hessian of the Holder table test function.
 ///
-/// This function has a discontinuity at `sqrt(x_1^2+x_2^2) = PI`, and hence can return `NaN`.
+/// The test function has a discontinuity at $\sqrt{x_1^2+x_2^2} = \pi$,
+/// hence the Hessian can be [NaN](num::Float::nan)-valued.
 pub fn holder_table_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/levy.rs
+++ b/crates/argmin-testfunctions/src/levy.rs
@@ -9,38 +9,44 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2, ..., x_n) = sin^2(pi * w1) + \sum_{i=1}^{d-1}(w_i -1)^2 * (1+10*sin^2(pi*wi+1)) +
-//! (w_d - 1)^2 * (1 + sin^2(2*pi*w_d))`
+//! $$
+//! f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sin^2(\pi w_1) + \sum_{i=1}^{d-1}(w_i -1)^2 \left[1+10\sin^2(\pi w_i+1)\right] +
+//! (w_d - 1)^2\left[1 + \sin^2(2\pi w_d)\right]
+//! $$
 //!
-//! where `w_i = 1 + (x_i - 1)/4` and `x_i \in [-10, 10]`.
+//! where $w_i = 1 + \frac{x_i - 1}{4}$ and $x_i \in [-10, 10]$.
 //!
-//! The global minimum is at `f(x_1, x_2, ..., x_n) = f(1, 1, ..., 1) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(1,\\,1,\\,\ldots,\\,1) = 0$.
 //!
 //! # Levy test function No. 13
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = sin^2(3 * pi * x_1) + (x_1 - 1)^2 * (1 + sin^2(3 * pi * x_2)) + (x_2 - 1)^2 *
-//! (1 + sin^2(2 * pi * x_2))`
+//! $$
+//! f(x_1,\\,x_2) = \sin^2(3\pi x_1) + (x_1 - 1)^2\left[1 + \sin^2(3\pi x_2)\right] + (x_2 - 1)^2
+//! \left[1 + \sin^2(2\pi x_2)\right]
+//! $$
 //!
-//! where `x_i \in [-10, 10]`.
+//! where $x_i \in [-10, 10]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(1, 1) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(1,\\,1) = 0$.
 
 use num::{Float, FromPrimitive};
 use std::f64::consts::PI;
 use std::iter::Sum;
 
-/// Levy test function
+/// Levy test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = sin^2(pi * w1) + \sum_{i=1}^{d-1}(w_i -1)^2 * (1+10*sin^2(pi*wi+1)) +
-/// (w_d - 1)^2 * (1 + sin^2(2*pi*w_d))`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sin^2(\pi w_1) + \sum_{i=1}^{d-1}(w_i -1)^2 \left[1+10\sin^2(\pi w_i+1)\right] +
+/// (w_d - 1)^2\left[1 + \sin^2(2\pi w_d)\right]
+/// $$
 ///
-/// where `w_i = 1 + (x_i - 1)/4` and `x_i \in [-10, 10]`.
+/// where $w_i = 1 + \frac{x_i - 1}{4}$ and $x_i \in [-10, 10]$.
 ///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(1, 1, ..., 1) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(1,\\,1,\\,\ldots,\\,1) = 0$.
 pub fn levy<T>(param: &[T]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -65,7 +71,7 @@ where
         + (w(param[plen - 1]) - n1).powi(2) * (n1 + (n2 * pi * w(param[plen - 1])).sin().powi(2))
 }
 
-/// Derivative of Levy test function
+/// Derivative of Levy test function.
 pub fn levy_derivative<T>(param: &[T]) -> Vec<T>
 where
     T: Float + FromPrimitive + Sum,
@@ -100,7 +106,7 @@ where
         .collect()
 }
 
-/// Derivative of Levy test function
+/// Derivative of Levy test function.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -142,7 +148,7 @@ where
     out
 }
 
-/// Hessian of Levy test function
+/// Hessian of Levy test function.
 pub fn levy_hessian<T>(param: &[T]) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive + Sum,
@@ -188,7 +194,7 @@ where
     out
 }
 
-/// Hessian of Levy test function
+/// Hessian of Levy test function.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -236,16 +242,18 @@ where
     out
 }
 
-/// Levy test function No. 13
+/// Levy test function No. 13.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = sin^2(3 * pi * x_1) + (x_1 - 1)^2 * (1 + sin^2(3 * pi * x_2)) + (x_2 - 1)^2 *
-/// (1 + sin^2(2 * pi * x_2))`
+/// $$
+/// f(x_1,\\,x_2) = \sin^2(3\pi x_1) + (x_1 - 1)^2\left[1 + \sin^2(3\pi x_2)\right] + (x_2 - 1)^2
+/// \left[1 + \sin^2(2\pi x_2)\right]
+/// $$
 ///
-/// where `x_i \in [-10, 10]`.
+/// where $x_i \in [-10, 10]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(1, 1) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(1,\\,1) = 0$.
 pub fn levy_n13<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -262,7 +270,7 @@ where
         + (x2 - n1).powi(2) * (n1 + (n2 * pi * x2).sin().powi(2))
 }
 
-/// Derivative of Levy test function No. 13
+/// Derivative of Levy test function No. 13.
 pub fn levy_n13_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive + Sum,
@@ -296,7 +304,7 @@ where
     ]
 }
 
-/// Hessian of Levy test function No. 13
+/// Hessian of Levy test function No. 13.
 pub fn levy_n13_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive + Sum,

--- a/crates/argmin-testfunctions/src/matyas.rs
+++ b/crates/argmin-testfunctions/src/matyas.rs
@@ -9,23 +9,27 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = 0.26 * (x_1^2 + x_2^2) - 0.48 * x_1 * x_2`
+//! $$
+//! f(x_1,\\,x_2) = 0.26 (x_1^2 + x_2^2) - 0.48 x_1 x_2
+//! $$
 //!
-//! where `x_i \in [-10, 10]`.
+//! where $x_i \in [-10,\\,10]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 
 use num::{Float, FromPrimitive};
 
-/// Matyas test function
+/// Matyas test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = 0.26 * (x_1^2 + x_2^2) - 0.48 * x_1 * x_2`
+/// $$
+/// f(x_1,\\,x_2) = 0.26 (x_1^2 + x_2^2) - 0.48 x_1 x_2
+/// $$
 ///
-/// where `x_i \in [-10, 10]`.
+/// where $x_i \in [-10,\\,10]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 pub fn matyas<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -38,7 +42,7 @@ where
     n026 * (x1.powi(2) + x2.powi(2)) - n048 * x1 * x2
 }
 
-/// Derivative of Matyas test function
+/// Derivative of Matyas test function.
 pub fn matyas_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -51,9 +55,18 @@ where
     [n0_52 * x1 - n0_48 * x2, n0_52 * x2 - n0_48 * x1]
 }
 
-/// Hessian of Matyas test function
+/// Hessian of Matyas test function.
 ///
-/// Returns [[0.52, -0.48], [-0.48, 0.52]] for any input.
+/// Returns
+/// $$
+/// \left(
+/// \begin{matrix}
+/// 0.52 & -0.48 \\\\
+/// -0.48 & 0.52
+/// \end{matrix}
+/// \right)
+/// $$
+/// for any input.
 pub fn matyas_hessian<T>(_param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/mccorminck.rs
+++ b/crates/argmin-testfunctions/src/mccorminck.rs
@@ -5,27 +5,31 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-//! # McCorminck test function
+//! # McCormick test function
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = sin(x_1 + x_2) + (x_1 - x_2)^2 - 1.5*x_1 + 2.5*x_2 + 1`
+//! $$
+//! f(x_1,\\,x_2) = \sin(x_1 + x_2) + (x_1 - x_2)^2 - 1.5x_1 + 2.5x_2 + 1
+//! $$
 //!
-//! where `x_1 \in [-1.5, 4]` and `x_2 \in [-3, 4]`.
+//! where $x_1 \in [-1.5,\\,4]$ and $x_2 \in [-3,\\,4]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(-0.54719, -1.54719) = -1.913228`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(-0.54719,\\,-1.54719) = -1.913228$.
 
 use num::{Float, FromPrimitive};
 
-/// McCorminck test function
+/// McCormick test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = sin(x_1 + x_2) + (x_1 - x_2)^2 - 1.5*x_1 + 2.5*x_2 + 1`
+/// $$
+/// f(x_1,\\,x_2) = \sin(x_1 + x_2) + (x_1 - x_2)^2 - 1.5x_1 + 2.5x_2 + 1
+/// $$
 ///
-/// where `x_1 \in [-1.5, 4]` and `x_2 \in [-3, 4]`.
+/// where $x_1 \in [-1.5,\\,4]$ and $x_2 \in [-3,\\,4]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(-0.54719, -1.54719) = -1.913228`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(-0.54719,\\,-1.54719) = -1.913228$.
 pub fn mccorminck<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -36,7 +40,7 @@ where
         + T::from_f64(1.0).unwrap()
 }
 
-/// Derivative of McCorminck test function
+/// Derivative of McCormick test function.
 pub fn mccorminck_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -53,7 +57,7 @@ where
     ]
 }
 
-/// Hessian of McCorminck test function
+/// Hessian of McCormick test function.
 pub fn mccorminck_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/picheny.rs
+++ b/crates/argmin-testfunctions/src/picheny.rs
@@ -11,33 +11,39 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = (1/2.427) * log([1 + (\bar{x}_1 + \bar{x}_2 + 1)^2 * (19 - 14*\bar{x}_2 +
-//!                3*\bar{x}_1^2 - 14*\bar{x}_2 + 6*\bar{x}_1*\bar{x}_2 + 3*\bar{x}_2^2)]
-//!                * [30 + (2*\bar{x}_1 - 3*\bar{x}_2)^2(18 - 32 * \bar{x}_1 + 12* \bar{x}_1^2 +
-//!                48 * \bar{x}_2 - 36 * \bar{x}_1 * \bar{x}_2 + 27 * \bar{x}_2^2) ] - 8.693)`
+//! $$
+//! f(x_1,\\,x_2) = \frac{1}{2.427}\biggl[
+//!                    \log\Bigl[\bigl(1 + (\bar{x}_1 + \bar{x}_2 + 1)^2(19 - 14\bar{x}_1 +
+//!                    3\bar{x}_1^2 - 14\bar{x}_2 + 6\bar{x}_1\bar{x}_2 + 3\bar{x}_2^2)\bigr) \\\\
+//!                    \times\bigl(30 + (2\bar{x}_1 - 3\bar{x}_2)^2(18 - 32\bar{x}_1 + 12\bar{x}_1^2 +
+//!                    48\bar{x}_2 - 36\bar{x}_1\bar{x}_2 + 27\bar{x}_2^2)\bigr)\Bigr]
+//!                 - 8.693\biggr]
+//! $$
 //!
-//! where `\bar{x}_i = 4*x_i - 2` and `x_i \in [0, 1]`.
+//! where $\bar{x}_i = 4x_i - 2$ and $x_i \in [0, 1]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0.5, 0.25) = 3.3851993182036826`.
-
-//  (1/2.427) * (log_10([1 + ((4*x_1-2) + (4*x_2-2) + 1)^2 * (19 - 14*(4*x_1-2) + 3*(4*x_1-2)^2 - 14*(4*x_2-2) + 6*(4*x_1-2)*(4*x_2-2) + 3*(4*x_2-2)^2)]    * [30 + (2*(4*x_1-2) - 3*(4*x_2-2))^2*(18 - 32 * (4*x_1-2) + 12* (4*x_1-2)^2 +   48 * (4*x_2-2) - 36 * (4*x_1-2) * (4*x_2-2) + 27 * (4*x_2-2)^2) ]) - 8.693)
+//! The global minimum is at $f(x_1,\\,x_2) = f(0.5,\\,0.25) = 3.3851993182036826$.
 
 use num::{Float, FromPrimitive};
 
-/// Picheny test function
+/// Picheny test function.
 ///
-/// Variation of the Goldstein-Price test function.
+/// Variation on the [Goldstein-Price test function](crate::goldsteinprice::goldsteinprice) introduced by [Picheny et al. (2012)](https://hal.science/hal-00658212).
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = (1/2.427) * log([1 + (\bar{x}_1 + \bar{x}_2 + 1)^2 * (19 - 14*\bar{x}_2 +
-///                3*\bar{x}_1^2 - 14*\bar{x}_2 6*\bar{x}_1*\bar{x}_2 + 3*\bar{x}_2^2)]
-///                * [30 + (2*\bar{x}_1 - 3*\bar{x}_2)^2(18 - 32 * \bar{x}_1 + 12* \bar{x}_1^2 +
-///                48 * \bar{x}_2 - 36 * \bar{x}_1 * \bar{x}_2 + 27 * \bar{x}_2^2) ] - 8.693)`
+/// $$
+/// f(x_1,\\,x_2) = \frac{1}{2.427}\biggl[
+///                    \log\Bigl[\bigl(1 + (\bar{x}_1 + \bar{x}_2 + 1)^2(19 - 14\bar{x}_1 +
+///                    3\bar{x}_1^2 - 14\bar{x}_2 + 6\bar{x}_1\bar{x}_2 + 3\bar{x}_2^2)\bigr) \\\\
+///                    \times\bigl(30 + (2\bar{x}_1 - 3\bar{x}_2)^2(18 - 32\bar{x}_1 + 12\bar{x}_1^2 +
+///                    48\bar{x}_2 - 36\bar{x}_1\bar{x}_2 + 27\bar{x}_2^2)\bigr)\Bigr]
+///                 - 8.693\biggr]
+/// $$
 ///
-/// where `\bar{x}_i = 4*x_i - 2` and `x_i \in [0, 1]`.
+/// where $\bar{x}_i = 4x_i - 2$ and $x_i \in [0, 1]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0.5, 0.25) = 3.3851993182036826`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0.5,\\,0.25) = 3.3851993182036826$.
 pub fn picheny<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -70,7 +76,7 @@ where
         .log10()
             - T::from_f64(8.693).unwrap())
 }
-/// Derivative of Picheny test function
+/// Derivative of Picheny test function.
 pub fn picheny_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -207,7 +213,7 @@ where
     [a, b]
 }
 
-/// Hessian of Picheny test function
+/// Hessian of Picheny test function.
 pub fn picheny_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/rastrigin.rs
+++ b/crates/argmin-testfunctions/src/rastrigin.rs
@@ -9,25 +9,31 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2, ..., x_n) = a * n + \sum_{i=1}^{n} \left[ x_i^2 - a * cos(2 * pi * x_i) \right]`
+//! $$
+//! f(x_1,\\,x_2,\\,\ldots,\\,x_d) = a\cdot d + \sum_{i=1}^{d} \left[ x_i^2 - a\cos(2\pi x_i) \right]
+//! $$
 //!
-//! where `x_i \in [-5.12, 5.12]` and `a = 10`
+//! where $x_i \in [-5.12,\\,5.12]$ and $a = 10$.
 //!
-//! The global minimum is at `f(x_1, x_2, ..., x_n) = f(0, 0, ..., 0) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(0,\\,0,\\,\ldots,\\,0) = 0$.
 
 use num::{Float, FromPrimitive};
 use std::f64::consts::PI;
 use std::iter::Sum;
 
-/// Rastrigin test function
+/// Rastrigin test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = a * n + \sum_{i=1}^{n} \left[ x_i^2 - a * cos(2 * pi * x_i) \right]`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = a\cdot d + \sum_{i=1}^{d} \left[ x_i^2 - a\cos(2\pi x_i) \right]
+/// $$
 ///
-/// where `x_i \in [-5.12, 5.12]` and `a = 10`
+/// where $x_i \in [-5.12,\\,5.12]$ and $a = 10$.
 ///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(0, 0, ..., 0) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(0,\\,0,\\,\ldots,\\,0) = 0$.
+///
+/// See [`rastrigin_a`] for a variant where the parameter `a` can be chosen freely.
 pub fn rastrigin<T>(param: &[T]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -35,9 +41,9 @@ where
     rastrigin_a(param, T::from_f64(10.0).unwrap())
 }
 
-/// Rastrigin test function
+/// Rastrigin test function.
 ///
-/// The same as `rastrigin`; however, it allows to set the parameter a.
+/// The same as [`rastrigin`]; however, it allows to set the parameter a.
 pub fn rastrigin_a<T>(param: &[T], a: T) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -49,7 +55,7 @@ where
             .sum()
 }
 
-/// Derivative of Rastrigin test function where `a` can be chosen freely
+/// Derivative of Rastrigin test function where the parameter `a` can be chosen freely.
 pub fn rastrigin_a_derivative<T>(param: &[T], a: T) -> Vec<T>
 where
     T: Float + FromPrimitive + Sum + Into<f64>,
@@ -62,7 +68,7 @@ where
         .collect()
 }
 
-/// Derivative of Rastrigin test function
+/// Derivative of Rastrigin test function with `a = 10`.
 pub fn rastrigin_derivative<T>(param: &[T]) -> Vec<T>
 where
     T: Float + FromPrimitive + Sum + Into<f64>,
@@ -70,7 +76,7 @@ where
     rastrigin_a_derivative(param, T::from_f64(10.0).unwrap())
 }
 
-/// Derivative of Rastrigin test function where `a` can be chosen freely
+/// Derivative of Rastrigin test function where the parameter `a` can be chosen freely.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -88,7 +94,7 @@ where
     result
 }
 
-/// Derivative of Rastrigin test function
+/// Derivative of Rastrigin test function with `a = 10`.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -99,7 +105,7 @@ where
     rastrigin_a_derivative_const(param, T::from_f64(10.0).unwrap())
 }
 
-/// Hessian of Rastrigin test function where `a` can be chosen freely
+/// Hessian of Rastrigin test function where the parameter `a` can be chosen freely.
 pub fn rastrigin_a_hessian<T>(param: &[T], a: T) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive + Sum + Into<f64>,
@@ -118,7 +124,7 @@ where
     hessian
 }
 
-/// Hessian of Rastrigin test function
+/// Hessian of Rastrigin test function with `a = 10`.
 pub fn rastrigin_hessian<T>(param: &[T]) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive + Sum + Into<f64>,
@@ -126,7 +132,7 @@ where
     rastrigin_a_hessian(param, T::from_f64(10.0).unwrap())
 }
 
-/// Hessian of Rastrigin test function where `a` can be chosen freely
+/// Hessian of Rastrigin test function where `a` can be chosen freely.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -147,7 +153,7 @@ where
     hessian
 }
 
-/// Hessian of Rastrigin test function
+/// Hessian of Rastrigin test function with `a = 10`.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.

--- a/crates/argmin-testfunctions/src/rosenbrock.rs
+++ b/crates/argmin-testfunctions/src/rosenbrock.rs
@@ -7,30 +7,32 @@
 
 //! # Rosenbrock function
 //!
-//! In 2D, it is defined as
+//! Defined as
 //!
-//! `f(x_1, x_2) = (a - x_1)^2 + b * (x_2 - x_1^2)^2`
+//! $$
+//! f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sum_{i=1}^{d-1} \left[ (a - x_i)^2 + b(x_{i+1} - x_i^2)^2 \right]
+//! $$
 //!
-//! where `x_i \in (-\infty, \infty)`. The parameters a and b usually are: `a = 1` and `b = 100`.
+//! where $x_i \in (-\infty, \infty)$. Typically, $a = 1$ and $b = 100$.
 //!
-//! The multidimensional Rosenbrock function is defined as:
-//!
-//! `f(x_1, x_2, ..., x_n) = \sum_{i=1}^{n-1} \left[ (a - x_i)^2 + b * (x_{i+1} - x_i^2)^2 \right]`
-//!
-//! The minimum is at `f(x_1, x_2, ..., x_n) = f(1, 1, ..., 1) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\, x_d) = f(1,\\,1,\\,\ldots,\\,1) = 0$.
 
 use num::{Float, FromPrimitive};
 use std::{iter::Sum, ops::AddAssign};
 
-/// Multidimensional Rosenbrock test function
+/// Multidimensional Rosenbrock test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = \sum_{i=1}^{n-1} \left[ (a - x_i)^2 + b * (x_{i+1} - x_i^2)^2 \right]`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sum_{i=1}^{d-1} \left[ (a - x_i)^2 + b(x_{i+1} - x_i^2)^2 \right]
+/// $$
 ///
-/// where `x_i \in (-\infty, \infty)`. The parameters a and b are: `a = 1` and `b = 100`.
+/// where $x_i \in (-\infty, \infty)$, $a = 1$, and $b = 100$.
 ///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(1, 1, ..., 1) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\, x_d) = f(1,\\,1,\\,\ldots,\\,1) = 0$.
+///
+/// See [`rosenbrock_ab`] for a variant that allows choosing `a` and `b` freely.
 pub fn rosenbrock<T>(param: &[T]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -42,15 +44,9 @@ where
     )
 }
 
-/// Multidimensional Rosenbrock test function
+/// Multidimensional Rosenbrock test function.
 ///
-/// Defined as
-///
-/// `f(x_1, x_2, ..., x_n) = \sum_{i=1}^{n-1} \left[ (a - x_i)^2 + b * (x_{i+1} - x_i^2)^2 \right]`
-///
-/// where `x_i \in (-\infty, \infty)`. The parameters a and b can be chosen freely.
-///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(1, 1, ..., 1) = 0`.
+/// Same as [`rosenbrock`] but with free choice of the parameters `a` and `b`.
 pub fn rosenbrock_ab<T>(param: &[T], a: T, b: T) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -61,7 +57,7 @@ where
         .map(|(&xi, &xi1)| (a - xi).powi(2) + b * (xi1 - xi.powi(2)).powi(2))
         .sum()
 }
-/// Derivative of the multidimensional Rosenbrock test function
+/// Derivative of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` are set to `1.0` and `100.0`, respectively.
 pub fn rosenbrock_derivative<T>(param: &[T]) -> Vec<T>
@@ -75,7 +71,7 @@ where
     )
 }
 
-/// Derivative of the multidimensional Rosenbrock test function
+/// Derivative of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` can be chosen freely.
 pub fn rosenbrock_ab_derivative<T>(param: &[T], a: T, b: T) -> Vec<T>
@@ -103,7 +99,7 @@ where
     result
 }
 
-/// Hessian of the multidimensional Rosenbrock test function
+/// Hessian of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` are set to `1.0` and `100.0`, respectively.
 pub fn rosenbrock_hessian<T>(param: &[T]) -> Vec<Vec<T>>
@@ -117,7 +113,7 @@ where
     )
 }
 
-/// Hessian of the multidimensional Rosenbrock test function
+/// Hessian of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` can be chosen freely.
 pub fn rosenbrock_ab_hessian<T>(param: &[T], a: T, b: T) -> Vec<Vec<T>>
@@ -144,7 +140,7 @@ where
     hessian
 }
 
-/// Derivative of the multidimensional Rosenbrock test function
+/// Derivative of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` are set to `1.0` and `100.0`, respectively.
 ///
@@ -161,7 +157,7 @@ where
     )
 }
 
-/// Derivative of the multidimensional Rosenbrock test function
+/// Derivative of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` can be chosen freely.
 ///
@@ -190,7 +186,7 @@ where
     result
 }
 
-/// Hessian of the multidimensional Rosenbrock test function
+/// Hessian of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` are set to `1.0` and `100.0`, respectively.
 ///
@@ -207,7 +203,7 @@ where
     )
 }
 
-/// Hessian of the multidimensional Rosenbrock test function
+/// Hessian of the multidimensional Rosenbrock test function.
 ///
 /// The parameters `a` and `b` can be chosen freely.
 ///

--- a/crates/argmin-testfunctions/src/schaffer.rs
+++ b/crates/argmin-testfunctions/src/schaffer.rs
@@ -9,33 +9,40 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = 0.5 + (sin^2(x_1^2 - x_2^2) - 0.5) / (1 + 0.001*(x_1^2 + x_2^2))^2`
+//! $$
+//! f(x_1,\\,x_2) = 0.5 + \frac{\sin^2(x_1^2 - x_2^2) - 0.5}{\left[1 + 0.001(x_1^2 + x_2^2)\right]^2}
+//! $$
 //!
-//! where `x_i \in [-100, 100]`.
+//! where $x_i \in [-100, 100]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 //!
 //! # Schaffer test function No. 4
 //!
+
 //! Defined as
 //!
-//! `f(x_1, x_2) = 0.5 + (cos(sin(abs(x_1^2 - x_2^2)))^2 - 0.5) / (1 + 0.001*(x_1^2 + x_2^2))^2`
+//! $$
+//! f(x_1,\\,x_2) = 0.5 + \frac{\cos^2(\sin(\left|x_1^2 - x_2^2\right|)) - 0.5}{\left[1 + 0.001(x_1^2 + x_2^2)\right]^2}
+//! $$
 //!
-//! where `x_i \in [-100, 100]`.
+//! where $x_i \in [-100, 100]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0, 1.25313) = 0.291992`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(0,\\,1.25313) = 0.291992$.
 
 use num::{Float, FromPrimitive};
 
-/// Schaffer test function No. 2
+/// Schaffer test function No. 2.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = 0.5 + (sin^2(x_1^2 - x_2^2) - 0.5) / (1 + 0.001*(x_1^2 + x_2^2))^2`
+/// $$
+/// f(x_1,\\,x_2) = 0.5 + \frac{\sin^2(x_1^2 - x_2^2) - 0.5}{\left[1 + 0.001(x_1^2 + x_2^2)\right]^2}
+/// $$
 ///
-/// where `x_i \in [-100, 100]`.
+/// where $x_i \in [-100, 100]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 pub fn schaffer_n2<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -135,11 +142,13 @@ where
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = 0.5 + (cos(sin(abs(x_1^2 - x_2^2)))^2 - 0.5) / (1 + 0.001*(x_1^2 + x_2^2))^2`
+/// $$
+/// f(x_1,\\,x_2) = 0.5 + \frac{\cos^2(\sin(\left|x_1^2 - x_2^2\right|)) - 0.5}{\left[1 + 0.001(x_1^2 + x_2^2)\right]^2}
+/// $$
 ///
-/// where `x_i \in [-100, 100]`.
+/// where $x_i \in [-100, 100]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0, 1.25313) = 0.291992`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0,\\,1.25313) = 0.291992$.
 pub fn schaffer_n4<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/sphere.rs
+++ b/crates/argmin-testfunctions/src/sphere.rs
@@ -9,24 +9,28 @@
 //!
 //! Defined as
 //!
-//! `f(x) = \sum_{i=1}^n x_i^2`
+//! $$
+//! f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sum_{i=1}^d x_i^2
+//! $$
 //!
-//! where `x_i \in (-\infty, \infty)`
+//! where $x_i \in (-\infty, \infty)$ and $d > 0$.
 //!
-//! The minimum is at `f(x_1, x_2, ..., x_n) = f(0, 0, ..., 0) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(0,\\,0,\\,\ldots,\\,0) = 0$.
 
 use num::{Float, FromPrimitive};
 use std::iter::Sum;
 
-/// Sphere test function
+/// Sphere test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = \sum_{i=1}^n x_i^2
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \sum_{i=1}^d x_i^2
+/// $$
 ///
-/// where `x_i \in (-\infty, \infty)` and `n > 0`.
+/// where $x_i \in (-\infty, \infty)$ and $d > 0$.
 ///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(0, 0, ..., 0) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2,\\,\ldots,\\,x_d) = f(0,\\,0,\\,\ldots,\\,0) = 0$.
 pub fn sphere<T>(param: &[T]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -34,13 +38,15 @@ where
     param.iter().map(|x| x.powi(2)).sum()
 }
 
-/// Derivative of sphere test function
+/// Derivative of sphere test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = (2 * x_1, 2 * x_2, ... 2 * x_n)`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = (2x_1,\\,2x_2,\\,\ldots,\\,2x_d)
+/// $$
 ///
-/// where `x_i \in (-\infty, \infty)` and `n > 0`.
+/// where $x_i \in (-\infty, \infty)$ and $d > 0$.
 pub fn sphere_derivative<T>(param: &[T]) -> Vec<T>
 where
     T: Float + FromPrimitive,
@@ -49,13 +55,15 @@ where
     param.iter().map(|x| num2 * *x).collect()
 }
 
-/// Derivative of sphere test function
+/// Derivative of sphere test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = (2 * x_1, 2 * x_2, ... 2 * x_n)`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = (2x_1,\\,2x_2,\\,\ldots,\\,2x_d)
+/// $$
 ///
-/// where `x_i \in (-\infty, \infty)` and `n > 0`.
+/// where $x_i \in (-\infty, \infty)$ and $d > 0$.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -71,7 +79,7 @@ where
     deriv
 }
 
-/// Hessian of sphere test function
+/// Hessian of sphere test function.
 pub fn sphere_hessian<T>(param: &[T]) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive,
@@ -84,7 +92,7 @@ where
     hessian
 }
 
-/// Hessian of sphere test function
+/// Hessian of sphere test function.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.

--- a/crates/argmin-testfunctions/src/styblinskitang.rs
+++ b/crates/argmin-testfunctions/src/styblinskitang.rs
@@ -9,26 +9,30 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2, ..., x_n) = 1/2 * \sum_{i=1}^{n} \left[ x_i^4 - 16 * x_i^2 + 5 * x_i \right]`
+//! $$
+//! f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \frac{1}{2}\sum_{i=1}^{d} \left(x_i^4 - 16x_i^2 + 5x_i\right)
+//! $$
 //!
-//! where `x_i \in [-5, 5]`.
+//! where $x_i \in [-5, 5]$.
 //!
-//! The global minimum is at `f(x_1, x_2, ..., x_n) = f(-2.903534, -2.903534, ..., -2.903534) =
-//! -39.16616*n`.
+//! The global minimum is at $f(x_1, x_2, ..., x_d) = f(-2.903534,\\,-2.903534,\\,\ldots,\\,-2.903534) =
+//! -39.16616d$.
 
 use num::{Float, FromPrimitive};
 use std::iter::Sum;
 
-/// Styblinski-Tang test function
+/// Styblinski-Tang test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2, ..., x_n) = 1/2 * \sum_{i=1}^{n} \left[ x_i^4 - 16 * x_i^2 + 5 * x_i \right]`
+/// $$
+/// f(x_1,\\,x_2,\\,\ldots,\\,x_d) = \frac{1}{2}\sum_{i=1}^{d} \left(x_i^4 - 16x_i^2 + 5x_i\right)
+/// $$
 ///
-/// where `x_i \in [-5, 5]`.
+/// where $x_i \in [-5, 5]$.
 ///
-/// The global minimum is at `f(x_1, x_2, ..., x_n) = f(-2.903534, -2.903534, ..., -2.903534) =
-/// -39.16616*n`.
+/// The global minimum is at $f(x_1, x_2, ..., x_d) = f(-2.903534,\\,-2.903534,\\,\ldots,\\,-2.903534) =
+/// -39.16616d$.
 pub fn styblinski_tang<T>(param: &[T]) -> T
 where
     T: Float + FromPrimitive + Sum,
@@ -42,7 +46,7 @@ where
             .sum()
 }
 
-/// Derivative of Styblinski-Tang test function
+/// Derivative of Styblinski-Tang test function.
 pub fn styblinski_tang_derivative<T>(param: &[T]) -> Vec<T>
 where
     T: Float + FromPrimitive + Sum,
@@ -57,7 +61,7 @@ where
         .collect()
 }
 
-/// Derivative of Styblinski-Tang test function
+/// Derivative of Styblinski-Tang test function.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.
@@ -81,7 +85,7 @@ where
     out
 }
 
-/// Hessian of Styblinski-Tang test function
+/// Hessian of Styblinski-Tang test function.
 pub fn styblinski_tang_hessian<T>(param: &[T]) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive + Sum,
@@ -102,7 +106,7 @@ where
     out
 }
 
-/// Hessian of Styblinski-Tang test function
+/// Hessian of Styblinski-Tang test function.
 ///
 /// This is the const generics version, which requires the number of parameters to be known
 /// at compile time.

--- a/crates/argmin-testfunctions/src/threehumpcamel.rs
+++ b/crates/argmin-testfunctions/src/threehumpcamel.rs
@@ -9,23 +9,27 @@
 //!
 //! Defined as
 //!
-//! `f(x_1, x_2) = 2*x_1^2 - 1.05*x_1^4 + x_1^6/6 + x_1*x_2 + x_2^2`
+//! $$
+//! f(x_1,\\,x_2) = 2x_1^2 - 1.05x_1^4 + \frac{x_1^6}{6} + x_1x_2 + x_2^2
+//! $$
 //!
-//! where `x_i \in [-5, 5]`.
+//! where $x_i \in [-5, 5]$.
 //!
-//! The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+//! The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 
 use num::{Float, FromPrimitive};
 
-/// Three-hump camel test function
+/// Three-hump camel test function.
 ///
 /// Defined as
 ///
-/// `f(x_1, x_2) = 2*x_1^2 - 1.05*x_1^4 + x_1^6/6 + x_1*x_2 + x_2^2`
+/// $$
+/// f(x_1,\\,x_2) = 2x_1^2 - 1.05x_1^4 + \frac{x_1^6}{6} + x_1x_2 + x_2^2
+/// $$
 ///
-/// where `x_i \in [-5, 5]`.
+/// where $x_i \in [-5, 5]$.
 ///
-/// The global minimum is at `f(x_1, x_2) = f(0, 0) = 0`.
+/// The global minimum is at $f(x_1,\\,x_2) = f(0,\\,0) = 0$.
 pub fn threehumpcamel<T>(param: &[T; 2]) -> T
 where
     T: Float + FromPrimitive,
@@ -38,7 +42,7 @@ where
         + x2.powi(2)
 }
 
-/// Derivative of Three-hump camel test function
+/// Derivative of Three-hump camel test function.
 pub fn threehumpcamel_derivative<T>(param: &[T; 2]) -> [T; 2]
 where
     T: Float + FromPrimitive,
@@ -52,7 +56,7 @@ where
     [x1.powi(5) - n4_2 * x1.powi(3) + n4 * x1 + x2, n2 * x2 + x1]
 }
 
-/// Hessian of Three-hump camel test function
+/// Hessian of Three-hump camel test function.
 pub fn threehumpcamel_hessian<T>(param: &[T; 2]) -> [[T; 2]; 2]
 where
     T: Float + FromPrimitive,

--- a/crates/argmin-testfunctions/src/zero.rs
+++ b/crates/argmin-testfunctions/src/zero.rs
@@ -11,7 +11,7 @@
 
 use num::{Float, FromPrimitive};
 
-/// Zero test function
+/// Zero test function.
 ///
 /// Always returns `0.0`. This is only for performance tests.
 pub fn zero<T>(_param: &[T]) -> T
@@ -21,7 +21,7 @@ where
     T::from_f64(0.0).unwrap()
 }
 
-/// Derivative of zero test function
+/// Derivative of zero test function.
 ///
 /// Always returns a vector with the length of param, full of `0.0`. This is only for performance
 /// tests.
@@ -32,7 +32,7 @@ where
     vec![T::from_f64(0.0).unwrap(); param.len()]
 }
 
-/// Derivative of zero test function (const version)
+/// Derivative of zero test function (const version).
 ///
 /// Always returns an array with the length of param, full of `0.0`. This is only for performance
 /// tests.
@@ -43,9 +43,9 @@ where
     [T::from_f64(0.0).unwrap(); N]
 }
 
-/// Hessian of zero test function
+/// Hessian of zero test function.
 ///
-/// Always returns a matrix with size NxN, full of `0.0`. This is only for performance tests.
+/// Always returns a matrix with size `N` by `N`, full of `0.0`. This is only for performance tests.
 pub fn zero_hessian<T>(param: &[T]) -> Vec<Vec<T>>
 where
     T: Float + FromPrimitive,
@@ -53,9 +53,9 @@ where
     vec![vec![T::from_f64(0.0).unwrap(); param.len()]; param.len()]
 }
 
-/// Hessian of zero test function (const version)
+/// Hessian of zero test function (const version).
 ///
-/// Always returns a matrix with size NxN, full of `0.0`. This is only for performance tests.
+/// Always returns a matrix with size `N` by `N`, full of `0.0`. This is only for performance tests.
 pub fn zero_hessian_const<const N: usize, T>(_param: &[T; N]) -> [[T; N]; N]
 where
     T: Float + FromPrimitive,


### PR DESCRIPTION
Follow-up to #530.

Render the math in `argmin-testfunctions` with KaTeX for the documentation that had not been converted yet. No code changes.

The function in `mccorminck.rs` seems to be call "McCormick" (without the `n`) on the Internet. See e.g. [wikipedia](https://en.wikipedia.org/wiki/Test_functions_for_optimization#:~:text=McCormick) and [here](https://www.sfu.ca/~ssurjano/mccorm.html). I used this spelling in the documentation, but didn't change the function or module name, to not introduce a breaking change in this documentation-only PR. @stefan-k Would you consider a PR changing the function and module names?