### PR TITLE
Support `wasm32-unknown-unknown` without `wasm-bindgen`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,9 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
       - name: Build target wasm32-unknown-unknown
-        run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-unknown-unknown
+        run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-unknown-unknown --no-default-features
+      - name: Build target wasm32-unknown-unknown with feature wasm-bindgen
+        run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-unknown-unknown --features wasm-bindgen
       - name: Build target wasm32-wasip1 with feature wasm-bindgen
         run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-wasip1 --features wasm-bindgen
       - name: Build target wasm32-unknown-emscripten

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh 
       - name: Build target wasm32-unknown-unknown
-        run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-unknown-unknown --features wasm-bindgen
+        run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-unknown-unknown
       - name: Build target wasm32-wasip1 with feature wasm-bindgen
         run: cargo build --workspace --exclude argmin-observer-spectator --exclude spectator --exclude argmin-observer-paramwriter --exclude "example-*" --exclude argmin-testfunctions-py --target wasm32-wasip1 --features wasm-bindgen
       - name: Build target wasm32-unknown-emscripten

--- a/crates/argmin-checkpointing-file/Cargo.toml
+++ b/crates/argmin-checkpointing-file/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science"]
 exclude = []
 
 [dependencies]
-argmin = { version = "0.10.0", path = "../argmin", default-features = false }
+argmin = { version = "0.10.0", path = "../argmin", features = ["rand"], default-features = false }
 bincode = "1.3.3"
 serde = "1.0.195"
 

--- a/crates/argmin-checkpointing-file/Cargo.toml
+++ b/crates/argmin-checkpointing-file/Cargo.toml
@@ -14,9 +14,13 @@ categories = ["science"]
 exclude = []
 
 [dependencies]
-argmin = { version = "0.10.0", path = "../argmin", features = ["rand"], default-features = false }
+argmin = { version = "0.10.0", path = "../argmin", default-features = false }
 bincode = "1.3.3"
 serde = "1.0.195"
 
 [dev-dependencies]
 argmin = { version = "0.10.0", path = "../argmin", features = ["serde1"] }
+
+[features]
+default = ["rand"]
+rand = ["argmin/rand"]

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -61,7 +61,7 @@ latest_all = ["primitives", "vec", "rand", "nalgebra_latest", "ndarray_latest"]
 primitives = ["num-complex_0_4"]
 
 # vec
-vec = ["primitives", "num-complex_0_4"]
+vec = ["rand", "primitives", "num-complex_0_4"]
 
 # nalgebra
 nalgebra_all = ["primitives"]

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -43,7 +43,7 @@ num-complex_0_3 = { package = "num-complex", version = "0.3", optional = true, d
 num-complex_0_2 = { package = "num-complex", version = "0.2", optional = true, default-features = false, features = ["std"] }
 num-traits = { version = "0.2" }
 num-integer = { version = "0.1" }
-rand = { version = "0.8.3" }
+rand = { version = "0.8.3", optional = true }
 anyhow = { version = "1.0" }
 thiserror = { version = "1.0" }
 
@@ -54,8 +54,8 @@ paste = "1"
 approx = "0.5.0"
 
 [features]
-default = ["primitives", "vec"]
-latest_all = ["primitives", "vec", "nalgebra_latest", "ndarray_latest"]
+default = ["primitives", "vec", "rand"]
+latest_all = ["primitives", "vec", "rand", "nalgebra_latest", "ndarray_latest"]
 
 # primitives
 primitives = ["num-complex_0_4"]

--- a/crates/argmin-math/src/faer_m_0_20/mod.rs
+++ b/crates/argmin-math/src/faer_m_0_20/mod.rs
@@ -17,6 +17,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 //@note(geo-ant):
 // scaled addition and subtraction rely on a blanket implementation
@@ -40,6 +41,7 @@ pub use l1norm::*;
 pub use l2norm::*;
 pub use minmax::*;
 pub use mul::*;
+#[cfg(feature = "rand")]
 pub use random::*;
 //@note(geo-ant) see above
 // pub use scaledadd::*;

--- a/crates/argmin-math/src/faer_m_0_21/mod.rs
+++ b/crates/argmin-math/src/faer_m_0_21/mod.rs
@@ -17,6 +17,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 // //@note(geo-ant):
 // // scaled addition and subtraction rely on a blanket implementation
@@ -40,6 +41,7 @@ pub use l1norm::*;
 pub use l2norm::*;
 pub use minmax::*;
 pub use mul::*;
+#[cfg(feature = "rand")]
 pub use random::*;
 //@note(geo-ant) see above
 // pub use scaledadd::*;

--- a/crates/argmin-math/src/faer_tests.rs
+++ b/crates/argmin-math/src/faer_tests.rs
@@ -8,6 +8,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 mod signum;
 mod sub;

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -280,6 +280,7 @@ mod faer_tests;
 // Re-export of types appearing in the api as recommended here: https://www.lurklurk.org/effective-rust/re-export.html
 pub use anyhow::Error;
 use cfg_if::cfg_if;
+#[cfg(feature = "rand")]
 pub use rand::Rng;
 
 /// Dot/scalar product of `T` and `self`
@@ -385,6 +386,7 @@ pub trait ArgminInv<T> {
 }
 
 /// Create a random number
+#[cfg(feature = "rand")]
 pub trait ArgminRandom {
     /// Get a random element between min and max,
     fn rand_from_range<R: Rng>(min: &Self, max: &Self, rng: &mut R) -> Self;

--- a/crates/argmin-math/src/nalgebra_m/mod.rs
+++ b/crates/argmin-math/src/nalgebra_m/mod.rs
@@ -17,6 +17,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 mod scaledadd;
 mod scaledsub;
@@ -35,6 +36,7 @@ pub use l1norm::*;
 pub use l2norm::*;
 pub use minmax::*;
 pub use mul::*;
+#[cfg(feature = "rand")]
 pub use random::*;
 pub use scaledadd::*;
 pub use scaledsub::*;

--- a/crates/argmin-math/src/ndarray_m/mod.rs
+++ b/crates/argmin-math/src/ndarray_m/mod.rs
@@ -18,6 +18,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 mod scaledadd;
 mod scaledsub;

--- a/crates/argmin-math/src/primitives/mod.rs
+++ b/crates/argmin-math/src/primitives/mod.rs
@@ -15,6 +15,7 @@ mod l1norm;
 mod l2norm;
 mod minmax;
 mod mul;
+#[cfg(feature = "rand")]
 mod random;
 mod scaledadd;
 mod scaledsub;
@@ -31,6 +32,7 @@ pub use l1norm::*;
 pub use l2norm::*;
 pub use minmax::*;
 pub use mul::*;
+#[cfg(feature = "rand")]
 pub use random::*;
 pub use scaledadd::*;
 pub use scaledsub::*;

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -18,7 +18,7 @@ exclude = []
 anyhow = "1.0"
 paste = "1"
 num-traits = "0.2"
-rand = "0.8.5"
+rand = { version = "0.8.5", optional = true }
 rand_xoshiro = "0.6.0"
 thiserror = "1.0"
 web-time = "1.1.0"

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -45,6 +45,7 @@ default = ["rand"]
 rand = ["dep:rand", "argmin-math/rand"]
 wasm-bindgen = ["getrandom/js"]
 serde1 = ["serde", "rand_xoshiro/serde1"]
+
 _ndarrayl = ["argmin-math/ndarray_latest"]
 # When adding new features, please consider adding them to either `full` (for users)
 # or `_full_dev` (only for local development, testing and computing test coverage).

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -45,7 +45,6 @@ default = ["rand"]
 rand = ["dep:rand", "argmin-math/rand"]
 wasm-bindgen = ["getrandom/js"]
 serde1 = ["serde", "rand_xoshiro/serde1"]
-
 _ndarrayl = ["argmin-math/ndarray_latest"]
 # When adding new features, please consider adding them to either `full` (for users)
 # or `_full_dev` (only for local development, testing and computing test coverage).

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -42,6 +42,7 @@ argmin-checkpointing-file = { path = "../argmin-checkpointing-file" }
 
 [features]
 default = ["rand"]
+rand = ["dep:rand", "argmin-math/rand"]
 wasm-bindgen = ["getrandom/js"]
 serde1 = ["serde", "rand_xoshiro/serde1"]
 _ndarrayl = ["argmin-math/ndarray_latest"]

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -41,7 +41,7 @@ argmin-observer-paramwriter = { path = "../argmin-observer-paramwriter" }
 argmin-checkpointing-file = { path = "../argmin-checkpointing-file" }
 
 [features]
-default = []
+default = ["rand"]
 wasm-bindgen = ["getrandom/js"]
 serde1 = ["serde", "rand_xoshiro/serde1"]
 _ndarrayl = ["argmin-math/ndarray_latest"]

--- a/crates/argmin/src/core/test_utils.rs
+++ b/crates/argmin/src/core/test_utils.rs
@@ -8,6 +8,7 @@
 use crate::core::{
     CostFunction, Error, Gradient, Hessian, IterState, Jacobian, Operator, Problem, Solver, KV,
 };
+#[cfg(feature = "rand")]
 use crate::solver::simulatedannealing::Anneal;
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -178,6 +179,7 @@ impl Jacobian for TestProblem {
     }
 }
 
+#[cfg(feature = "rand")]
 impl Anneal for TestProblem {
     type Param = Vec<f64>;
     type Output = Vec<f64>;

--- a/crates/argmin/src/solver/mod.rs
+++ b/crates/argmin/src/solver/mod.rs
@@ -14,7 +14,9 @@ pub mod landweber;
 pub mod linesearch;
 pub mod neldermead;
 pub mod newton;
+#[cfg(feature = "rand")]
 pub mod particleswarm;
 pub mod quasinewton;
+#[cfg(feature = "rand")]
 pub mod simulatedannealing;
 pub mod trustregion;

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -24,6 +24,7 @@ use crate::core::{
     ArgminFloat, CostFunction, Error, PopulationState, Problem, Solver, SyncAlias, KV,
 };
 use argmin_math::{ArgminAdd, ArgminMinMax, ArgminMul, ArgminRandom, ArgminSub, ArgminZeroLike};
+#[cfg(feature = "rand")]
 use rand::{Rng, SeedableRng};
 #[cfg(feature = "serde1")]
 use serde::{Deserialize, Serialize};
@@ -106,6 +107,7 @@ where
         }
     }
 }
+
 impl<P, F, R0> ParticleSwarm<P, F, R0>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,

--- a/crates/argmin/src/solver/particleswarm/mod.rs
+++ b/crates/argmin/src/solver/particleswarm/mod.rs
@@ -107,7 +107,6 @@ where
         }
     }
 }
-
 impl<P, F, R0> ParticleSwarm<P, F, R0>
 where
     P: Clone + SyncAlias + ArgminSub<P, P> + ArgminMul<F, P> + ArgminRandom + ArgminZeroLike,


### PR DESCRIPTION
Thank you for making this software available. I think numerical packages in pure Rust are really important. 

This PR allows for succesfully building armin with
```sh
$ cargo build -p argmin --no-default-features --target wasm32-unknown-unknown
```
As a bit of background, the wasm (synonym: WebAssembly) situation is a bit complication right now. As I understand it, most wasm targets assume that Javascript is available too. So that's why `getrandom/js` often works. However, more and more wasm targets are moving away from Javascript. Wasmtime, for example, is a wasm runtime that does not support Javascript. This is useful for example for plugin systems like is used by Typst or Zellij. Both allow developers to write plugins which then can be used by users. But to not compromise the whole system, the plugins are sandboxed by default. So these plugins typically are not allowed to access the filesystem, or other system interfaces; also not via JS bindgen.

But I think it would be very nice if we could argmin in these barebone environments. To do so, this PR suggests to fix the build.