### PR TITLE
Add comments translating exceptions for unmaintained crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,8 +44,11 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    # ignore unmaintained `proc-macro-error`
     "RUSTSEC-2024-0370",
+    # ignore unmaintained `instant`
     "RUSTSEC-2024-0384",
+    # ignore unmaintained `derivative`
     "RUSTSEC-2024-0388",
     # ignore unmaintained `paste`
     "RUSTSEC-2024-0436",


### PR DESCRIPTION
I liked the transparency from the `paste` comment and replicated it for the other ignored advisories. 

I had intended to accompany this with removing allowances for dependencies (such as [instant](https://github.com/argmin-rs/argmin/pull/539)) which have already been removed. Unfortunately they all still have at least indirect dependencies, primarily via eframe/egui. I'll have a go at getting those updated this evening.