### PR TITLE
Bump remaining dependencies

### DIFF
--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -45,7 +45,7 @@ num-traits = { version = "0.2" }
 num-integer = { version = "0.1" }
 rand = { version = "0.9.2", optional = true }
 anyhow = { version = "1.0" }
-thiserror = { version = "1.0" }
+thiserror = { version = "2.0" }
 
 cfg-if = "1"
 

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -20,7 +20,7 @@ paste = "1"
 num-traits = "0.2"
 rand = { version = "0.9.2", optional = true }
 rand_xoshiro = "0.7.0"
-thiserror = "1.0"
+thiserror = "2.0"
 web-time = "1.1.0"
 argmin-math = { path = "../argmin-math", version = "0.4", default-features = false, features = ["primitives"] }
 # optional

--- a/crates/spectator/Cargo.toml
+++ b/crates/spectator/Cargo.toml
@@ -24,7 +24,7 @@ eframe = { version = "0.32", features = ["ron", "persistence"], optional = true 
 egui_dock = { version = "0.17", optional = true }
 egui_extras = { version = "0.32", optional = true }
 egui_plot = { version = "0.33", optional = true }
-itertools = { version = "0.13", optional = true }
+itertools = { version = "0.14", optional = true }
 rmp-serde = "1.1.1"
 serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3", features = ["serde"] }

--- a/examples/observer/Cargo.toml
+++ b/examples/observer/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["vec"], path = "../../crates/argmin-math" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-gnuplot = "0.0.43"
+gnuplot = "0.0.46"
 web-time = "1.1.0"

--- a/examples/observer/src/main.rs
+++ b/examples/observer/src/main.rs
@@ -9,7 +9,7 @@ use argmin::core::observers::{Observe, ObserverMode};
 use argmin::core::{ArgminFloat, CostFunction, Error, Executor, PopulationState, State, KV};
 use argmin::solver::particleswarm::{Particle, ParticleSwarm};
 use argmin_testfunctions::himmelblau;
-use gnuplot::{Color, PointSize};
+use gnuplot::{Color, PointSize, RGBString};
 use std::sync::Mutex;
 use web_time::Duration;
 
@@ -76,8 +76,8 @@ impl Visualizer3d {
 
         figure.clear_axes();
 
-        let options_optima = [Color("#ffff00"), PointSize(2.0)];
-        let options_particles = [Color("#ff0000"), PointSize(2.0)];
+        let options_optima = [Color(RGBString("#ffff00")), PointSize(2.0)];
+        let options_particles = [Color(RGBString("#ff0000")), PointSize(2.0)];
         let axes3d = figure.axes3d();
 
         // Draw surface before points


### PR DESCRIPTION
Dependabot seems to be struggling with the rebases, so this should just clear the rest of the set (https://github.com/argmin-rs/argmin/pull/555 https://github.com/argmin-rs/argmin/pull/589 https://github.com/argmin-rs/argmin/pull/535). 

The ndarray one (https://github.com/argmin-rs/argmin/pull/513) is a false alarm since (outside of explicit compatibility code) you're already on v16.