### PR TITLE
Update syntax for finitediff calls in benchmark code

### DIFF
--- a/crates/finitediff/benches/bench.rs
+++ b/crates/finitediff/benches/bench.rs
@@ -170,7 +170,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::vec::forward_jacobian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -182,7 +182,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::ndarr::forward_jacobian_vec_prod(
                 &cost_multi_ndarray_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -193,7 +193,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::vec::central_jacobian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -205,7 +205,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::ndarr::central_jacobian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -348,7 +348,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::vec::forward_hessian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -360,7 +360,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::ndarr::forward_hessian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -371,7 +371,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::vec::central_hessian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 
@@ -383,7 +383,7 @@ mod tests {
         b.iter(|| {
             black_box(finitediff::ndarr::central_hessian_vec_prod(
                 &cost_multi_vec_f64,
-            )(&p, &x));
+            )(&x, &p));
         });
     }
 

--- a/crates/finitediff/benches/bench.rs
+++ b/crates/finitediff/benches/bench.rs
@@ -8,27 +8,29 @@
 //! Benches
 
 #![feature(test)]
+
+use anyhow::Error;
 extern crate finitediff;
 extern crate test;
 
 const MASSIVENESS: usize = 256;
 
-fn cost_vec_f64(x: &Vec<f64>) -> f64 {
-    x.iter().fold(0.0, |a, acc| a + acc)
+fn cost_vec_f64(x: &Vec<f64>) -> Result<f64, Error> {
+    Ok(x.iter().fold(0.0, |a, acc| a + acc))
 }
 
 #[cfg(feature = "ndarray")]
-fn cost_ndarray_f64(x: &ndarray::Array1<f64>) -> f64 {
-    x.iter().fold(0.0, |a, acc| a + acc)
+fn cost_ndarray_f64(x: &ndarray::Array1<f64>) -> Result<f64, Error> {
+    Ok(x.iter().fold(0.0, |a, acc| a + acc))
 }
 
-fn cost_multi_vec_f64(x: &Vec<f64>) -> Vec<f64> {
-    x.clone()
+fn cost_multi_vec_f64(x: &Vec<f64>) -> Result<Vec<f64>, Error> {
+    Ok(x.clone())
 }
 
 #[cfg(feature = "ndarray")]
-fn cost_multi_ndarray_f64(x: &ndarray::Array1<f64>) -> ndarray::Array1<f64> {
-    x.clone()
+fn cost_multi_ndarray_f64(x: &ndarray::Array1<f64>) -> Result<ndarray::Array1<f64>, Error> {
+    Ok(x.clone())
 }
 
 #[cfg(test)]
@@ -97,7 +99,7 @@ mod tests {
     fn forward_diff_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_diff(&cost_vec_f64));
+            black_box(finitediff::vec::forward_diff(&cost_vec_f64)(&x));
         });
     }
 
@@ -106,7 +108,7 @@ mod tests {
     fn forward_diff_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_diff(&cost_ndarray_f64));
+            black_box(finitediff::ndarr::forward_diff(&cost_ndarray_f64)(&x));
         });
     }
 
@@ -114,7 +116,7 @@ mod tests {
     fn central_diff_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.central_diff(&cost_vec_f64));
+            black_box(finitediff::vec::central_diff(&cost_vec_f64)(&x));
         });
     }
 
@@ -123,7 +125,7 @@ mod tests {
     fn central_diff_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.central_diff(&cost_ndarray_f64));
+            black_box(finitediff::ndarr::central_diff(&cost_ndarray_f64)(&x));
         });
     }
 
@@ -131,7 +133,7 @@ mod tests {
     fn forward_jacobian_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_jacobian(&cost_multi_vec_f64));
+            black_box(finitediff::vec::forward_jacobian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -140,7 +142,7 @@ mod tests {
     fn forward_jacobian_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_jacobian(&cost_multi_ndarray_f64));
+            black_box(finitediff::ndarr::forward_jacobian(&cost_multi_ndarray_f64)(&x));
         });
     }
 
@@ -148,7 +150,7 @@ mod tests {
     fn central_jacobian_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.central_jacobian(&cost_multi_vec_f64));
+            black_box(finitediff::vec::central_jacobian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -157,7 +159,7 @@ mod tests {
     fn central_jacobian_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.central_jacobian(&cost_multi_ndarray_f64));
+            black_box(finitediff::ndarr::central_jacobian(&cost_multi_ndarray_f64)(&x));
         });
     }
 
@@ -166,7 +168,7 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_jacobian_vec_prod(&cost_multi_vec_f64, &p));
+            black_box(finitediff::vec::forward_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -176,7 +178,7 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_jacobian_vec_prod(&cost_multi_ndarray_f64, &p));
+            black_box(finitediff::ndarr::forward_jacobian_vec_prod(&cost_multi_ndarray_f64)(&p, &x));
         });
     }
 
@@ -185,7 +187,7 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_jacobian_vec_prod(&cost_multi_vec_f64, &p));
+            black_box(finitediff::vec::central_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -195,7 +197,7 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_jacobian_vec_prod(&cost_multi_ndarray_f64, &p));
+            black_box(finitediff::ndarr::central_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -217,7 +219,7 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(x.forward_jacobian_pert(&cost_multi_vec_f64, &p2));
+            black_box(finitediff::vec::forward_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
         });
     }
 
@@ -240,7 +242,7 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(x.forward_jacobian_pert(&cost_multi_ndarray_f64, &p2));
+            black_box(finitediff::ndarr::forward_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
         });
     }
 
@@ -262,7 +264,7 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(x.central_jacobian_pert(&cost_multi_vec_f64, &p2));
+            black_box(finitediff::vec::central_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
         });
     }
 
@@ -285,7 +287,7 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(x.central_jacobian_pert(&cost_multi_ndarray_f64, &p2));
+            black_box(finitediff::ndarr::central_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
         });
     }
 
@@ -293,7 +295,7 @@ mod tests {
     fn forward_hessian_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_hessian(&cost_multi_vec_f64));
+            black_box(finitediff::vec::forward_hessian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -302,7 +304,7 @@ mod tests {
     fn forward_hessian_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_hessian(&cost_multi_ndarray_f64));
+            black_box(finitediff::ndarr::forward_hessian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -310,7 +312,7 @@ mod tests {
     fn central_hessian_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.central_hessian(&cost_multi_vec_f64));
+            black_box(finitediff::vec::central_hessian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -319,7 +321,7 @@ mod tests {
     fn central_hessian_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.central_hessian(&cost_multi_ndarray_f64));
+            black_box(finitediff::ndarr::central_hessian(&cost_multi_vec_f64)(&x));
         });
     }
 
@@ -328,7 +330,7 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_hessian_vec_prod(&cost_multi_vec_f64, &p));
+            black_box(finitediff::vec::forward_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -338,7 +340,7 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_hessian_vec_prod(&cost_multi_ndarray_f64, &p));
+            black_box(finitediff::ndarr::forward_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -347,7 +349,7 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.central_hessian_vec_prod(&cost_multi_vec_f64, &p));
+            black_box(finitediff::vec::central_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -357,7 +359,7 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.central_hessian_vec_prod(&cost_multi_ndarray_f64, &p));
+            black_box(finitediff::ndarr::central_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
         });
     }
 
@@ -365,7 +367,7 @@ mod tests {
     fn forward_hessian_nograd_vec_f64(b: &mut Bencher) {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(x.forward_hessian_nograd(&cost_vec_f64));
+            black_box(finitediff::vec::forward_hessian_nograd(&cost_vec_f64)(&x));
         });
     }
 
@@ -374,7 +376,7 @@ mod tests {
     fn forward_hessian_nograd_ndarray_f64(b: &mut Bencher) {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(x.forward_hessian_nograd(&cost_ndarray_f64));
+            black_box(finitediff::ndarr::forward_hessian_nograd(&cost_vec_f64)(&x));
         });
     }
 
@@ -383,7 +385,7 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
             let indices = vec![[1, 2], [23, 23], [128, 8]];
-            black_box(x.forward_hessian_nograd_sparse(&cost_vec_f64, indices));
+            black_box(finitediff::vec::forward_hessian_nograd_sparse(&cost_vec_f64)(&x, indices));
         });
     }
 
@@ -393,7 +395,7 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
             let indices = vec![[1, 2], [23, 23], [128, 8]];
-            black_box(x.forward_hessian_nograd_sparse(&cost_ndarray_f64, indices));
+            black_box(finitediff::ndarr::forward_hessian_nograd_sparse(&cost_vec_f64)(&x, indices));
         });
     }
 }

--- a/crates/finitediff/benches/bench.rs
+++ b/crates/finitediff/benches/bench.rs
@@ -168,7 +168,9 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(finitediff::vec::forward_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::vec::forward_jacobian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -178,7 +180,9 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(finitediff::ndarr::forward_jacobian_vec_prod(&cost_multi_ndarray_f64)(&p, &x));
+            black_box(finitediff::ndarr::forward_jacobian_vec_prod(
+                &cost_multi_ndarray_f64,
+            )(&p, &x));
         });
     }
 
@@ -187,7 +191,9 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(finitediff::vec::central_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::vec::central_jacobian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -197,7 +203,9 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(finitediff::ndarr::central_jacobian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::ndarr::central_jacobian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -219,7 +227,9 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(finitediff::vec::forward_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
+            black_box(finitediff::vec::forward_jacobian_pert(&cost_multi_vec_f64)(
+                &x, &p2,
+            ));
         });
     }
 
@@ -242,7 +252,9 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(finitediff::ndarr::forward_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
+            black_box(finitediff::ndarr::forward_jacobian_pert(
+                &cost_multi_vec_f64,
+            )(&x, &p2));
         });
     }
 
@@ -264,7 +276,9 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(finitediff::vec::central_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
+            black_box(finitediff::vec::central_jacobian_pert(&cost_multi_vec_f64)(
+                &x, &p2,
+            ));
         });
     }
 
@@ -287,7 +301,9 @@ mod tests {
 
         b.iter(|| {
             let p2 = pert.clone();
-            black_box(finitediff::ndarr::central_jacobian_pert(&cost_multi_vec_f64)(&x, &p2));
+            black_box(finitediff::ndarr::central_jacobian_pert(
+                &cost_multi_vec_f64,
+            )(&x, &p2));
         });
     }
 
@@ -330,7 +346,9 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(finitediff::vec::forward_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::vec::forward_hessian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -340,7 +358,9 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(finitediff::ndarr::forward_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::ndarr::forward_hessian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -349,7 +369,9 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         let p = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
-            black_box(finitediff::vec::central_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::vec::central_hessian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -359,7 +381,9 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         let p = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
-            black_box(finitediff::ndarr::central_hessian_vec_prod(&cost_multi_vec_f64)(&p, &x));
+            black_box(finitediff::ndarr::central_hessian_vec_prod(
+                &cost_multi_vec_f64,
+            )(&p, &x));
         });
     }
 
@@ -385,7 +409,9 @@ mod tests {
         let x = vec![1.0f64; MASSIVENESS];
         b.iter(|| {
             let indices = vec![[1, 2], [23, 23], [128, 8]];
-            black_box(finitediff::vec::forward_hessian_nograd_sparse(&cost_vec_f64)(&x, indices));
+            black_box(finitediff::vec::forward_hessian_nograd_sparse(
+                &cost_vec_f64,
+            )(&x, indices));
         });
     }
 
@@ -395,7 +421,9 @@ mod tests {
         let x = ndarray::Array1::from(vec![1.0f64; MASSIVENESS]);
         b.iter(|| {
             let indices = vec![[1, 2], [23, 23], [128, 8]];
-            black_box(finitediff::ndarr::forward_hessian_nograd_sparse(&cost_vec_f64)(&x, indices));
+            black_box(finitediff::ndarr::forward_hessian_nograd_sparse(
+                &cost_vec_f64,
+            )(&x, indices));
         });
     }
 }


### PR DESCRIPTION
I think this benchmark file got left behind when finitediff changed, presumably to better handle error propagation. 

This is just the minimal set of changes to mollify the compiler. 