### PR TITLE
Fixed link checking in CI

### DIFF
--- a/media/website/config.toml
+++ b/media/website/config.toml
@@ -138,3 +138,8 @@ weight = 10
 # name = "Code of Conduct"
 # url = "/docs/contributing/code-of-conduct/"
 # weight = 20
+
+[link_checker]
+skip_prefixes = [
+    "https://lib.rs/",
+]

--- a/media/website/content/blog/version-v0.6.0.md
+++ b/media/website/content/blog/version-v0.6.0.md
@@ -24,7 +24,7 @@ For users of the optimization algorithms, adapting your code to the new version 
 If you are using argmin to implement your own algorithms, the changes you will have to make are more severe. 
 I suggest having a look at the source code of argmin to get a sense of how you may have to adapt your own code.
 
-In either case, feel free to get in touch if you run into trouble, either on [Gitter](https://gitter.im/argmin-rs/community) or by opening an [issue](https://github.com/argmin-rs/argmin/issues). 
+In either case, feel free to get in touch if you run into trouble, either on [Discord](https://discord.gg/fYB8AwxxMW) or by opening an [issue](https://github.com/argmin-rs/argmin/issues). 
 
 
 ## argmin-math


### PR DESCRIPTION
I intended to fix all seemingly broken links on the website, but I'm afraid some of the failing link checks in the CI are due to lib.rs not accepting connections from Github Actions for some reason.