### PR TITLE
Fix clippy complaint about manual implementations of is_multiple_of

### DIFF
--- a/crates/argmin/src/core/checkpointing/mod.rs
+++ b/crates/argmin/src/core/checkpointing/mod.rs
@@ -172,7 +172,9 @@ pub trait Checkpoint<S, I> {
     fn save_cond(&self, solver: &S, state: &I, iter: u64) -> Result<(), Error> {
         match self.frequency() {
             CheckpointingFrequency::Always => self.save(solver, state)?,
-            CheckpointingFrequency::Every(it) if iter % it == 0 => self.save(solver, state)?,
+            CheckpointingFrequency::Every(it) if iter.is_multiple_of(it) => {
+                self.save(solver, state)?
+            }
             CheckpointingFrequency::Never | CheckpointingFrequency::Every(_) => {}
         };
         Ok(())

--- a/crates/argmin/src/core/observers/mod.rs
+++ b/crates/argmin/src/core/observers/mod.rs
@@ -264,7 +264,9 @@ impl<I: State> Observe<I> for Observers<I> {
             let observer = &mut l.0.lock().unwrap();
             match l.1 {
                 ObserverMode::Always => observer.observe_iter(state, kv),
-                ObserverMode::Every(i) if iter % i == 0 => observer.observe_iter(state, kv),
+                ObserverMode::Every(i) if iter.is_multiple_of(i) => {
+                    observer.observe_iter(state, kv)
+                }
                 ObserverMode::NewBest if state.is_best() => observer.observe_iter(state, kv),
                 ObserverMode::Never | ObserverMode::Every(_) | ObserverMode::NewBest => Ok(()),
             }?

--- a/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
+++ b/crates/argmin/src/solver/conjugategradient/nonlinear_cg.rs
@@ -205,7 +205,7 @@ where
         };
 
         let restart_iter: bool =
-            (state.get_iter() % self.restart_iter == 0) && state.get_iter() != 0;
+            (state.get_iter().is_multiple_of(self.restart_iter)) && state.get_iter() != 0;
 
         if restart_iter || restart_orthogonality {
             self.beta = float!(0.0);


### PR DESCRIPTION
This is pretty obvious. 
The newest Clippy believes, correctly, that it is easier to read `x.is_multiple_of(y)` than `x % y ==0`.

The only downside I can see is that with this change the msrv in argmin proper (rather than merely via sometimes-optional dependencies) is now [actually 1.87.0](https://doc.rust-lang.org/std/primitive.u32.html#method.is_multiple_of). You've already indicated that's not something you particularly care about, so this is definitely the cleanest way to resolve the clippy failure.