### PR TITLE
Fix: Update and repair broken badges in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@
       src="https://img.shields.io/crates/d/argmin?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+  <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
     <img
       src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"

--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@
       alt="Crates.io downloads"
   /></a>
   <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
-  <img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
-      alt="GitHub Actions workflow status"
-    />
-  </a>
-  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
     <img
       src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@
       src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
       alt="GitHub Actions workflow status"
   /></a>
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
+      alt="GitHub Actions workflow status"
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin?style=flat-square"
     alt="License"
@@ -121,8 +127,8 @@ argmin is designed to simplify the implementation of optimization algorithms and
 
 ### External solvers compatible with argmin
 
-External solvers which implement the `Solver` trait are compatible with argmin's `Executor`, 
-and as such can leverage features like checkpointing and observers. 
+External solvers which implement the `Solver` trait are compatible with argmin's `Executor`,
+and as such can leverage features like checkpointing and observers.
 
 - [egobox](https://crates.io/crates/egobox-ego)
 - [cobyla](https://crates.io/crates/cobyla)

--- a/crates/argmin-checkpointing-file/README.md
+++ b/crates/argmin-checkpointing-file/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/argmin-checkpointing-file?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin-checkpointing-file?style=flat-square"
     alt="License"

--- a/crates/argmin-math/README.md
+++ b/crates/argmin-math/README.md
@@ -29,11 +29,12 @@
       src="https://img.shields.io/crates/d/argmin-math?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin-math?style=flat-square"
     alt="License"

--- a/crates/argmin-observer-paramwriter/README.md
+++ b/crates/argmin-observer-paramwriter/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/argmin-observer-paramwriter?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin-observer-paramwriter?style=flat-square"
     alt="License"
@@ -44,9 +45,9 @@
 </p>
 
 This argmin observer writes serialized parameter vectors to files during optimization.
-Details can be found in the documentation ([latest release](https://docs.rs/argmin-observer-paramwriter) or 
+Details can be found in the documentation ([latest release](https://docs.rs/argmin-observer-paramwriter) or
 [current main](https://argmin-rs.github.io/argmin/argmin_observer_paramwriter/index.html))
-or the [argmin book](https://argmin-rs.org/book/). 
+or the [argmin book](https://argmin-rs.org/book/).
 There is also an [example](https://github.com/argmin-rs/argmin/tree/main/examples/paramwriter)
 which illustrates how to use the observer.
 

--- a/crates/argmin-observer-slog/README.md
+++ b/crates/argmin-observer-slog/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/argmin-observer-slog?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin-observer-slog?style=flat-square"
     alt="License"
@@ -44,9 +45,9 @@
 </p>
 
 This argmin observer logs the progress of the optimization to the terminal or to disk.
-Details can be found in the documentation ([latest release](https://docs.rs/argmin-observer-slog) or 
+Details can be found in the documentation ([latest release](https://docs.rs/argmin-observer-slog) or
 [current main](https://argmin-rs.github.io/argmin/argmin_observer_slog/index.html))
-or the [argmin book](https://argmin-rs.org/book/). 
+or the [argmin book](https://argmin-rs.org/book/).
 
 ## License
 

--- a/crates/argmin-observer-spectator/README.md
+++ b/crates/argmin-observer-spectator/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/argmin-observer-spectator?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin-observer-spectator?style=flat-square"
     alt="License"

--- a/crates/argmin-testfunctions/README.md
+++ b/crates/argmin-testfunctions/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/argmin_testfunctions?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/python.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin?style=flat-square"
     alt="License"
@@ -43,9 +44,9 @@
   /></a>
 </p>
 
-A collection of two- and multidimensional test functions (and their derivatives and Hessians) for optimization algorithms. 
+A collection of two- and multidimensional test functions (and their derivatives and Hessians) for optimization algorithms.
 For two-dimensional test functions, the derivate and Hessian calculation does not allocate. For multi-dimensional tes functions,
-the derivative and Hessian calculation comes in two variants. One variant returns `Vec`s and hence does allocate. This is 
+the derivative and Hessian calculation comes in two variants. One variant returns `Vec`s and hence does allocate. This is
 needed for cases, where the number of parameters is only known at run time. In case the number of parameters are known at
 compile-time, the `_const` variants can be used, which return fixed size arrays and hence do not allocate.
 
@@ -54,7 +55,7 @@ The derivative and Hessian calculation is always named `<test function name>_der
 `<test function name>_derivative_const` and `<test function name>_hessian_const`.
 
 Some functions, such as `ackley`, `rosenbrock` and `rastrigin` come with additional optional parameters which change
-the shape of the functions. These additional parameters are exposed in `ackley_abc`, `rosenbrock_ab` and `rastrigin_a`. 
+the shape of the functions. These additional parameters are exposed in `ackley_abc`, `rosenbrock_ab` and `rastrigin_a`.
 
 All functions are generic over their inputs and work with `[f64]` and `[f32]`.
 
@@ -74,7 +75,7 @@ cargo test
 ```
 
 The test functions derivatives and Hessians are tested against [finitediff](https://crates.io/crates/finitediff) using
-[proptest](https://crates.io/crates/proptest) to sample the functions at various points. 
+[proptest](https://crates.io/crates/proptest) to sample the functions at various points.
 
 All functions are benchmarked using [criterion.rs](https://crates.io/crates/criterion). Run the benchmarks with
 

--- a/crates/finitediff/README.md
+++ b/crates/finitediff/README.md
@@ -1,5 +1,10 @@
-[![Build Status](https://travis-ci.org/argmin-rs/finitediff.svg?branch=master)](https://travis-ci.org/argmin-rs/finitediff)
-[![Gitter chat](https://badges.gitter.im/argmin-rs/community.png)](https://gitter.im/argmin-rs/community)
+<!-- [![Build Status](https://travis-ci.org/argmin-rs/finitediff.svg?branch=master)](https://travis-ci.org/argmin-rs/finitediff) -->
+<a href="https://discord.gg/fYB8AwxxMW">
+  <img
+    src="https://img.shields.io/discord/1189119565335109683?style=flat-square&label=argmin%20Discord"
+    alt="argmin Discord"
+  />
+</a>
 
 # finitediff: Finite Differentiation
 

--- a/crates/spectator/README.md
+++ b/crates/spectator/README.md
@@ -27,11 +27,12 @@
       src="https://img.shields.io/crates/d/spectator?style=flat-square"
       alt="Crates.io downloads"
   /></a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/spectator?style=flat-square"
     alt="License"
@@ -43,7 +44,7 @@
   /></a>
 </p>
 
-Spectator is a GUI tool to observe the progress of argmin optimization runs. 
+Spectator is a GUI tool to observe the progress of argmin optimization runs.
 
 ## Installation
 
@@ -80,7 +81,7 @@ spectator --host 127.0.0.1 --port 5498
 The optional options `--host` and `--port` indicate the host and port spectator binds to.
 By default, spectator will bind to `0.0.0.0:5498`.
 
-The argmin optimization run which should be observed needs to use the spectator observer which 
+The argmin optimization run which should be observed needs to use the spectator observer which
 can be found [in the `argmin-observer-spectator` crate](https://crates.io/crates/argmin-observer-spectator).
 
 ## License

--- a/media/website/sass/bootstrap/README.md
+++ b/media/website/sass/bootstrap/README.md
@@ -58,21 +58,17 @@ Read the [Getting started page](https://getbootstrap.com/docs/5.0/getting-starte
 
 ## Status
 
-[![Slack](https://bootstrap-slack.herokuapp.com/badge.svg)](https://bootstrap-slack.herokuapp.com/)
 [![Build Status](https://img.shields.io/github/workflow/status/twbs/bootstrap/JS%20Tests/main?label=JS%20Tests&logo=github)](https://github.com/twbs/bootstrap/actions?query=workflow%3AJS+Tests+branch%3Amain)
 [![npm version](https://img.shields.io/npm/v/bootstrap)](https://www.npmjs.com/package/bootstrap)
 [![Gem version](https://img.shields.io/gem/v/bootstrap)](https://rubygems.org/gems/bootstrap)
 [![Meteor Atmosphere](https://img.shields.io/badge/meteor-twbs%3Abootstrap-blue)](https://atmospherejs.com/twbs/bootstrap)
 [![Packagist Prerelease](https://img.shields.io/packagist/vpre/twbs/bootstrap)](https://packagist.org/packages/twbs/bootstrap)
 [![NuGet](https://img.shields.io/nuget/vpre/bootstrap)](https://www.nuget.org/packages/bootstrap/absoluteLatest)
-[![peerDependencies Status](https://img.shields.io/david/peer/twbs/bootstrap)](https://david-dm.org/twbs/bootstrap?type=peer)
-[![devDependency Status](https://img.shields.io/david/dev/twbs/bootstrap)](https://david-dm.org/twbs/bootstrap?type=dev)
 [![Coverage Status](https://img.shields.io/coveralls/github/twbs/bootstrap/main)](https://coveralls.io/github/twbs/bootstrap?branch=main)
 [![CSS gzip size](https://img.badgesize.io/twbs/bootstrap/main/dist/css/bootstrap.min.css?compression=gzip&label=CSS%20gzip%20size)](https://github.com/twbs/bootstrap/blob/main/dist/css/bootstrap.min.css)
 [![CSS Brotli size](https://img.badgesize.io/twbs/bootstrap/main/dist/css/bootstrap.min.css?compression=brotli&label=CSS%20Brotli%20size)](https://github.com/twbs/bootstrap/blob/main/dist/css/bootstrap.min.css)
 [![JS gzip size](https://img.badgesize.io/twbs/bootstrap/main/dist/js/bootstrap.min.js?compression=gzip&label=JS%20gzip%20size)](https://github.com/twbs/bootstrap/blob/main/dist/js/bootstrap.min.js)
 [![JS Brotli size](https://img.badgesize.io/twbs/bootstrap/main/dist/js/bootstrap.min.js?compression=brotli&label=JS%20Brotli%20size)](https://github.com/twbs/bootstrap/blob/main/dist/js/bootstrap.min.js)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=SkxZcStBeExEdVJqQ2hWYnlWckpkNmNEY213SFp6WHFETWk2bGFuY3pCbz0tLXhqbHJsVlZhQnRBdEpod3NLSDMzaHc9PQ==--3d0b75245708616eb93113221beece33e680b229)](https://www.browserstack.com/automate/public-build/SkxZcStBeExEdVJqQ2hWYnlWckpkNmNEY213SFp6WHFETWk2bGFuY3pCbz0tLXhqbHJsVlZhQnRBdEpod3NLSDMzaHc9PQ==--3d0b75245708616eb93113221beece33e680b229)
 [![Backers on Open Collective](https://img.shields.io/opencollective/backers/bootstrap)](#backers)
 [![Sponsors on Open Collective](https://img.shields.io/opencollective/sponsors/bootstrap)](#sponsors)
 

--- a/python/argmin-testfunctions-py/README.md
+++ b/python/argmin-testfunctions-py/README.md
@@ -20,11 +20,12 @@
   <a href="https://pypi.org/project/argmin-testfunctions-py/">
     <img alt="PyPI" src="https://img.shields.io/pypi/v/argmin-testfunctions-py?style=flat-square">
   </a>
-  <a href="https://github.com/argmin-rs/argmin/actions"
-    ><img
-      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/python.yml?branch=main&label=argmin CI&style=flat-square"
+  <a href="https://github.com/argmin-rs/argmin/actions/workflows/ci.yml">
+    <img
+      src="https://img.shields.io/github/actions/workflow/status/argmin-rs/argmin/ci.yml?branch=main&label=CI&style=flat-square"
       alt="GitHub Actions workflow status"
-  /></a>
+    />
+  </a>
   <img
     src="https://img.shields.io/crates/l/argmin?style=flat-square"
     alt="License"
@@ -36,8 +37,8 @@
   /></a>
 </p>
 
-This Python module makes the test functions of the `argmin_testfunctions` Rust crate available in Python. 
-For each test function the derivative and Hessian are available as well. 
+This Python module makes the test functions of the `argmin_testfunctions` Rust crate available in Python.
+For each test function the derivative and Hessian are available as well.
 While most functions are two-dimensional, some allow an arbitrary number of parameters.
 For some functions additional optional parameters are accessible, which can be used to modify the shape of the test function.
 For details on the individual test functions please consult the docs of the Rust library, either for the


### PR DESCRIPTION
**Fixes #623**

### Description

This PR addresses issue #623 by updating and fixing the badges across all relevant README files in the project. The goal is to ensure all badges are rendering correctly and linking to the correct, up-to-date resources. Additionally, some of the outdated links that weren't working are also removed.

### Changes Made

* **Fixed broken badges**: Badges linked to the ci.yml were not rendering and were fixed
* **Removal of certain badges**: Badges that were not relevant anymore were removed or optionally commented out
* **Gitter <-> Discord**: Replaced all the links to Gitter with Discord links