### PR TITLE
update faer to 0.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
       # faer
       - name: argmin-math (faer_latest)
         run: cargo test -p argmin-math --no-default-features --features "faer_latest"
+      - name: argmin-math (faer_v0_23)
+        run: cargo test -p argmin-math --no-default-features --features "faer_v0_23"
+      - name: argmin-math (faer_v0_22)
+        run: cargo test -p argmin-math --no-default-features --features "faer_v0_22"
       - name: argmin-math (faer_v0_21)
         run: cargo test -p argmin-math --no-default-features --features "faer_v0_21"
       - name: argmin-math (faer_v0_20)

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -36,7 +36,9 @@ ndarray_0_13 = { package = "ndarray", version = "0.13", optional = true }
 #faer
 faer_0_20 = { package = "faer", version = "0.20", optional = true}
 faer_0_21 = { package = "faer", version = "0.21", optional = true}
+faer_0_23 = { package = "faer", version = "0.23", optional = true}
 faer_traits_0_21 = {package = "faer-traits", version = "0.21", optional = true}
+faer_traits_0_23 = {package = "faer-traits", version = "0.23", optional = true}
 
 # general
 num-complex_0_4 = { package = "num-complex", version = "0.4", optional = true, default-features = false, features = ["std"] }
@@ -80,9 +82,10 @@ ndarray_latest = ["ndarray_v0_16"]
 
 #faer
 faer_all = ["primitives"]
-faer_latest = ["faer_v0_21"]
+faer_latest = ["faer_v0_23"]
 faer_v0_20  = ["faer_0_20", "num-complex_0_4", "faer_all"]
 faer_v0_21  = ["faer_0_21", "num-complex_0_4", "faer_traits_0_21", "faer_all"]
+faer_v0_23  = ["faer_0_23", "num-complex_0_4", "faer_traits_0_23", "faer_all"]
 
 ## With `ndarray-linalg`
 ndarray_v0_16 = ["ndarray_0_16", "ndarray-linalg_0_17", "num-complex_0_4", "ndarray_all"]

--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -36,8 +36,10 @@ ndarray_0_13 = { package = "ndarray", version = "0.13", optional = true }
 #faer
 faer_0_20 = { package = "faer", version = "0.20", optional = true}
 faer_0_21 = { package = "faer", version = "0.21", optional = true}
+faer_0_22 = { package = "faer", version = "0.22", optional = true}
 faer_0_23 = { package = "faer", version = "0.23", optional = true}
 faer_traits_0_21 = {package = "faer-traits", version = "0.21", optional = true}
+faer_traits_0_22 = {package = "faer-traits", version = "0.22", optional = true}
 faer_traits_0_23 = {package = "faer-traits", version = "0.23", optional = true}
 
 # general
@@ -85,6 +87,7 @@ faer_all = ["primitives"]
 faer_latest = ["faer_v0_23"]
 faer_v0_20  = ["faer_0_20", "num-complex_0_4", "faer_all"]
 faer_v0_21  = ["faer_0_21", "num-complex_0_4", "faer_traits_0_21", "faer_all"]
+faer_v0_22  = ["faer_0_22", "num-complex_0_4", "faer_traits_0_22", "faer_all"]
 faer_v0_23  = ["faer_0_23", "num-complex_0_4", "faer_traits_0_23", "faer_all"]
 
 ## With `ndarray-linalg`

--- a/crates/argmin-math/src/faer_tests/test_helper.rs
+++ b/crates/argmin-math/src/faer_tests/test_helper.rs
@@ -5,6 +5,8 @@ cfg_if::cfg_if! {
         use faer::ComplexField;
     } else if #[cfg(feature = "faer_v0_21")] {
         use faer_traits::ComplexField;
+    } else if #[cfg(feature = "faer_v0_22")] {
+        use faer_traits::ComplexField;
     } else if #[cfg(feature = "faer_v0_23")] {
         use faer_traits::ComplexField;
     }

--- a/crates/argmin-math/src/faer_tests/test_helper.rs
+++ b/crates/argmin-math/src/faer_tests/test_helper.rs
@@ -5,6 +5,8 @@ cfg_if::cfg_if! {
         use faer::ComplexField;
     } else if #[cfg(feature = "faer_v0_21")] {
         use faer_traits::ComplexField;
+    } else if #[cfg(feature = "faer_v0_23")] {
+        use faer_traits::ComplexField;
     }
 }
 

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -266,6 +266,8 @@ cfg_if::cfg_if! {
         extern crate faer_0_20 as faer;
     } else if #[cfg(feature = "faer_v0_21")] {
         extern crate faer_0_21 as faer;
+    } else if #[cfg(feature = "faer_v0_23")] {
+        extern crate faer_0_23 as faer;
     }
 }
 
@@ -301,6 +303,10 @@ cfg_if! {
         use faer_m_0_20 as faer_m;
     } else if #[cfg(feature = "faer_v0_21")] {
         extern crate faer_traits_0_21 as faer_traits;
+        mod faer_m_0_21;
+        use faer_m_0_21 as faer_m;
+    } else if #[cfg(feature = "faer_v0_23")] {
+        extern crate faer_traits_0_23 as faer_traits;
         mod faer_m_0_21;
         use faer_m_0_21 as faer_m;
     }

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -266,6 +266,8 @@ cfg_if::cfg_if! {
         extern crate faer_0_20 as faer;
     } else if #[cfg(feature = "faer_v0_21")] {
         extern crate faer_0_21 as faer;
+    } else if #[cfg(feature = "faer_v0_22")] {
+        extern crate faer_0_22 as faer;
     } else if #[cfg(feature = "faer_v0_23")] {
         extern crate faer_0_23 as faer;
     }
@@ -303,6 +305,10 @@ cfg_if! {
         use faer_m_0_20 as faer_m;
     } else if #[cfg(feature = "faer_v0_21")] {
         extern crate faer_traits_0_21 as faer_traits;
+        mod faer_m_0_21;
+        use faer_m_0_21 as faer_m;
+    } else if #[cfg(feature = "faer_v0_22")] {
+        extern crate faer_traits_0_22 as faer_traits;
         mod faer_m_0_21;
         use faer_m_0_21 as faer_m;
     } else if #[cfg(feature = "faer_v0_23")] {


### PR DESCRIPTION
This is fortunately much shorter than #575 thanks to the infrastructure introduced there; we can just use the 0.21 backend with the new release.

(too bad I missed the release of 0.11.0)