### PR TITLE
Change default time to None in IterState

### DIFF
--- a/crates/argmin/src/core/state/iterstate.rs
+++ b/crates/argmin/src/core/state/iterstate.rs
@@ -1028,7 +1028,7 @@ where
     /// # assert_eq!(state.last_best_iter, 0);
     /// # assert_eq!(state.max_iters, u64::MAX);
     /// # assert_eq!(state.counts.len(), 0);
-    /// # assert_eq!(state.time.unwrap(), Duration::ZERO);
+    /// # assert!(state.time.is_none());
     /// # assert_eq!(state.termination_status, TerminationStatus::NotTerminated);
     /// ```
     fn new() -> Self {
@@ -1057,7 +1057,7 @@ where
             max_iters: u64::MAX,
             counts: HashMap::new(),
             counting_enabled: false,
-            time: Some(Duration::ZERO),
+            time: None,
             termination_status: TerminationStatus::NotTerminated,
         }
     }
@@ -1330,7 +1330,7 @@ where
     /// # use argmin::core::{IterState, State, ArgminFloat};
     /// # let mut state: IterState<Vec<f64>, (), (), (), (), f64> = IterState::new();
     /// let time = state.get_time();
-    /// # assert_eq!(time.unwrap(), Duration::ZERO);
+    /// # assert!(time.is_none());
     /// ```
     fn get_time(&self) -> Option<Duration> {
         self.time

--- a/media/book/src/running_solver.md
+++ b/media/book/src/running_solver.md
@@ -112,8 +112,8 @@ let termination_status = res.state().get_termination_status();
 // Optionally, check why the optimizer terminated (if status is terminated) 
 let termination_reason = res.state().get_termination_reason();
 
-// Time needed for optimization
-let time_needed = res.state().get_time().unwrap();
+// Time needed for optimization (only available if timer was enabled)
+let time_needed = res.state().get_time();
 
 // Total number of iterations needed
 let num_iterations = res.state().get_iter();


### PR DESCRIPTION
## 📝 Description

Updated the `IterState` struct to initialize the time field as `None` instead of `Some(Duration::ZERO)`. This should fix the timer showing as 0 ns, which was introduced in commit https://github.com/argmin-rs/argmin/commit/6492020c5510c0aa4a99955a55207dbbfdee8a64.

## 🔨 Changes Made

- Updated the `IterState` struct to initialize the time field as `None` instead of `Some(Duration::ZERO)`.
- Modified tests to take into account this implementation

## 🔗 Related Issues

Closes https://github.com/argmin-rs/argmin/issues/640
