### PR TITLE
Add README to pyproject.toml

### DIFF
--- a/python/argmin-testfunctions-py/pyproject.toml
+++ b/python/argmin-testfunctions-py/pyproject.toml
@@ -19,6 +19,8 @@ dynamic = ["version"]
 authors = [
     { name = "Stefan Kroboth", email = "stefan.kroboth@gmail.com" }
 ]
+readme = "README.md"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
+exclude = [{ path = "/README.md", format = "sdist" }]


### PR DESCRIPTION
Set the README file for the project and update the maturin configuration to exclude README.md from the source distribution (stdist, since it uses issues because of duplicate entries README.md from parent folder and README.md from argmin-testfunctions-py). This should add the README to PyPi

Closes https://github.com/argmin-rs/argmin/issues/622