### PR TITLE
Replace crate: paste with pastey

### DIFF
--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -55,7 +55,7 @@ thiserror = { version = "2.0" }
 cfg-if = "1"
 
 [dev-dependencies]
-paste = "1"
+pastey = "0.2.0"
 approx = "0.5.0"
 
 [features]

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
@@ -15,7 +15,7 @@ ndarray-linalg = { version = "0.16", default-features = false, features = ["inte
 num-complex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-paste = "1"
+pastey = "0.2.0"
 approx = "0.5.0"
 rand = "0.9.2"
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
@@ -15,7 +15,7 @@ ndarray-linalg = { version = "0.17", default-features = false, features = ["inte
 num-complex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-paste = "1"
+pastey = "0.2.0"
 approx = "0.5.0"
 rand = "0.9.2"
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
@@ -15,7 +15,7 @@ ndarray-linalg = { version = "0.17", default-features = false, features = ["inte
 num-complex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-paste = "1"
+pastey = "0.2.0"
 approx = "0.5.0"
 rand = "0.9.2"
 

--- a/crates/argmin-math/ndarray-tests-src/add.rs
+++ b/crates/argmin-math/ndarray-tests-src/add.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminAdd;
     use ndarray::array;
     use ndarray::{Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/conj.rs
+++ b/crates/argmin-math/ndarray-tests-src/conj.rs
@@ -14,7 +14,7 @@ mod tests {
     use ndarray::array;
     use ndarray::{Array1, Array2};
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/div.rs
+++ b/crates/argmin-math/ndarray-tests-src/div.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminDiv;
     use ndarray::array;
     use ndarray::{Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/dot.rs
+++ b/crates/argmin-math/ndarray-tests-src/dot.rs
@@ -14,7 +14,7 @@ mod tests {
     use ndarray::array;
     use ndarray::{Array1, Array2};
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/eye.rs
+++ b/crates/argmin-math/ndarray-tests-src/eye.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminEye;
     use ndarray::array;
     use ndarray::Array2;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/inv.rs
+++ b/crates/argmin-math/ndarray-tests-src/inv.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminInv;
     use ndarray::array;
     use ndarray::Array2;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/l1norm.rs
+++ b/crates/argmin-math/ndarray-tests-src/l1norm.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminL1Norm;
     use ndarray::{array, Array1};
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/l2norm.rs
+++ b/crates/argmin-math/ndarray-tests-src/l2norm.rs
@@ -14,7 +14,7 @@ mod tests {
     use ndarray::{array, Array1};
     use num_complex::Complex;
     use num_integer::Roots;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/minmax.rs
+++ b/crates/argmin-math/ndarray-tests-src/minmax.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminMinMax;
     use ndarray::array;
     use ndarray::{Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/mul.rs
+++ b/crates/argmin-math/ndarray-tests-src/mul.rs
@@ -14,7 +14,7 @@ mod tests {
     use ndarray::array;
     use ndarray::{Array1, Array2};
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/random.rs
+++ b/crates/argmin-math/ndarray-tests-src/random.rs
@@ -11,7 +11,7 @@ mod tests {
     use super::*;
     use argmin_math::ArgminRandom;
     use ndarray::{array, Array1, Array2};
-    use paste::item;
+    use pastey::item;
     use rand::SeedableRng;
 
     macro_rules! make_test {

--- a/crates/argmin-math/ndarray-tests-src/scaledadd.rs
+++ b/crates/argmin-math/ndarray-tests-src/scaledadd.rs
@@ -12,7 +12,7 @@ mod tests {
     use approx::assert_relative_eq;
     use argmin_math::ArgminScaledAdd;
     use ndarray::{array, Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/scaledsub.rs
+++ b/crates/argmin-math/ndarray-tests-src/scaledsub.rs
@@ -12,7 +12,7 @@ mod tests {
     use approx::assert_relative_eq;
     use argmin_math::ArgminScaledSub;
     use ndarray::{array, Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/signum.rs
+++ b/crates/argmin-math/ndarray-tests-src/signum.rs
@@ -13,7 +13,7 @@ mod tests {
     use ndarray::array;
     use ndarray::{Array1, Array2};
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/sub.rs
+++ b/crates/argmin-math/ndarray-tests-src/sub.rs
@@ -13,7 +13,7 @@ mod tests {
     use argmin_math::ArgminSub;
     use ndarray::array;
     use ndarray::{Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/transpose.rs
+++ b/crates/argmin-math/ndarray-tests-src/transpose.rs
@@ -17,7 +17,7 @@ mod tests {
     use ndarray::{Array1, Array2};
 
     use ndarray::array;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/ndarray-tests-src/zero.rs
+++ b/crates/argmin-math/ndarray-tests-src/zero.rs
@@ -12,7 +12,7 @@ mod tests {
     use approx::assert_relative_eq;
     use argmin_math::ArgminZeroLike;
     use ndarray::{array, Array1, Array2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/add.rs
+++ b/crates/argmin-math/src/faer_tests/add.rs
@@ -2,7 +2,7 @@ use crate::faer_tests::test_helper::*;
 use crate::ArgminAdd;
 use approx::assert_relative_eq;
 use faer::mat::AsMatRef;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/conj.rs
+++ b/crates/argmin-math/src/faer_tests/conj.rs
@@ -4,7 +4,7 @@ use approx::assert_relative_eq;
 use faer::Mat;
 use num_complex::Complex;
 use num_complex::ComplexFloat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/div.rs
+++ b/crates/argmin-math/src/faer_tests/div.rs
@@ -3,7 +3,7 @@ use crate::ArgminDiv;
 use approx::assert_relative_eq;
 use faer::mat::AsMatRef;
 use faer::Mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/dot.rs
+++ b/crates/argmin-math/src/faer_tests/dot.rs
@@ -3,7 +3,7 @@ use crate::ArgminDot;
 use approx::assert_relative_eq;
 use faer::mat::AsMatRef;
 use faer::Mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/eye.rs
+++ b/crates/argmin-math/src/faer_tests/eye.rs
@@ -2,7 +2,7 @@ use crate::faer_tests::test_helper::*;
 use crate::ArgminEye;
 use approx::assert_relative_eq;
 use faer::Mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/inv.rs
+++ b/crates/argmin-math/src/faer_tests/inv.rs
@@ -2,7 +2,7 @@ use crate::faer_tests::test_helper::*;
 use crate::ArgminInv;
 use approx::assert_relative_eq;
 use faer::mat::AsMatRef;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/l1norm.rs
+++ b/crates/argmin-math/src/faer_tests/l1norm.rs
@@ -1,7 +1,7 @@
 use crate::faer_tests::test_helper::*;
 use crate::ArgminL1Norm;
 use approx::assert_relative_eq;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/l2norm.rs
+++ b/crates/argmin-math/src/faer_tests/l2norm.rs
@@ -1,7 +1,7 @@
 use crate::faer_tests::test_helper::*;
 use crate::ArgminL2Norm;
 use approx::assert_relative_eq;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/minmax.rs
+++ b/crates/argmin-math/src/faer_tests/minmax.rs
@@ -1,7 +1,7 @@
 use crate::faer_tests::test_helper::*;
 use crate::ArgminMinMax;
 use approx::assert_relative_eq;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/mul.rs
+++ b/crates/argmin-math/src/faer_tests/mul.rs
@@ -2,7 +2,7 @@ use crate::faer_tests::test_helper::*;
 use crate::ArgminMul;
 use approx::assert_relative_eq;
 use faer::mat::AsMatRef;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/random.rs
+++ b/crates/argmin-math/src/faer_tests/random.rs
@@ -1,7 +1,7 @@
 use crate::faer_tests::test_helper::*;
 use crate::ArgminRandom;
 use faer::mat;
-use paste::item;
+use pastey::item;
 use rand::SeedableRng;
 
 macro_rules! make_test {

--- a/crates/argmin-math/src/faer_tests/signum.rs
+++ b/crates/argmin-math/src/faer_tests/signum.rs
@@ -2,7 +2,7 @@ use crate::faer_tests::test_helper::*;
 use crate::ArgminSignum;
 use approx::assert_relative_eq;
 use faer::mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/sub.rs
+++ b/crates/argmin-math/src/faer_tests/sub.rs
@@ -4,7 +4,7 @@ use approx::assert_relative_eq;
 use faer::mat;
 use faer::mat::AsMatRef;
 use faer::Mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/transpose.rs
+++ b/crates/argmin-math/src/faer_tests/transpose.rs
@@ -4,7 +4,7 @@ use approx::assert_relative_eq;
 use faer::mat;
 use faer::mat::AsMatRef;
 use faer::{Mat, MatRef};
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/faer_tests/zero.rs
+++ b/crates/argmin-math/src/faer_tests/zero.rs
@@ -3,7 +3,7 @@ use crate::ArgminZeroLike;
 use approx::assert_relative_eq;
 use faer::mat;
 use faer::Mat;
-use paste::item;
+use pastey::item;
 
 macro_rules! make_test {
     ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/add.rs
+++ b/crates/argmin-math/src/nalgebra_m/add.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{DMatrix, DVector, Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/conj.rs
+++ b/crates/argmin-math/src/nalgebra_m/conj.rs
@@ -28,7 +28,7 @@ mod tests {
     use approx::assert_relative_eq;
     use nalgebra::Vector3;
     use num_complex::Complex;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/div.rs
+++ b/crates/argmin-math/src/nalgebra_m/div.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{DMatrix, DVector, Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/dot.rs
+++ b/crates/argmin-math/src/nalgebra_m/dot.rs
@@ -90,7 +90,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix3, RowVector3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/eye.rs
+++ b/crates/argmin-math/src/nalgebra_m/eye.rs
@@ -35,7 +35,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2x3, Matrix3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/inv.rs
+++ b/crates/argmin-math/src/nalgebra_m/inv.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::Matrix2;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/l1norm.rs
+++ b/crates/argmin-math/src/nalgebra_m/l1norm.rs
@@ -30,7 +30,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::Vector2;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/l2norm.rs
+++ b/crates/argmin-math/src/nalgebra_m/l2norm.rs
@@ -30,7 +30,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::Vector2;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/minmax.rs
+++ b/crates/argmin-math/src/nalgebra_m/minmax.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/mul.rs
+++ b/crates/argmin-math/src/nalgebra_m/mul.rs
@@ -70,7 +70,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/random.rs
+++ b/crates/argmin-math/src/nalgebra_m/random.rs
@@ -50,7 +50,7 @@ where
 mod tests {
     use super::*;
     use nalgebra::{Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
     use rand::SeedableRng;
 
     macro_rules! make_test {

--- a/crates/argmin-math/src/nalgebra_m/scaledadd.rs
+++ b/crates/argmin-math/src/nalgebra_m/scaledadd.rs
@@ -10,7 +10,7 @@ mod tests {
     use crate::ArgminScaledAdd;
     use approx::assert_relative_eq;
     use nalgebra::{DVector, Matrix2, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/scaledsub.rs
+++ b/crates/argmin-math/src/nalgebra_m/scaledsub.rs
@@ -10,7 +10,7 @@ mod tests {
     use crate::ArgminScaledSub;
     use approx::assert_relative_eq;
     use nalgebra::{DVector, Matrix2, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/signum.rs
+++ b/crates/argmin-math/src/nalgebra_m/signum.rs
@@ -27,7 +27,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/sub.rs
+++ b/crates/argmin-math/src/nalgebra_m/sub.rs
@@ -62,7 +62,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2x3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/transpose.rs
+++ b/crates/argmin-math/src/nalgebra_m/transpose.rs
@@ -34,7 +34,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{Matrix2, Matrix2x3, Matrix3x2, RowVector2, Vector2};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/nalgebra_m/zero.rs
+++ b/crates/argmin-math/src/nalgebra_m/zero.rs
@@ -29,7 +29,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use nalgebra::{DVector, Matrix2, Vector2, Vector4};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/add.rs
+++ b/crates/argmin-math/src/primitives/add.rs
@@ -44,7 +44,7 @@ make_add!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/conj.rs
+++ b/crates/argmin-math/src/primitives/conj.rs
@@ -51,7 +51,7 @@ make_complex_conj!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test_complex {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/div.rs
+++ b/crates/argmin-math/src/primitives/div.rs
@@ -44,7 +44,7 @@ make_div!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/dot.rs
+++ b/crates/argmin-math/src/primitives/dot.rs
@@ -44,7 +44,7 @@ make_dot_vec!(Complex<u64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/l1norm.rs
+++ b/crates/argmin-math/src/primitives/l1norm.rs
@@ -77,7 +77,7 @@ make_l1norm_complex_unsigned!(u64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/l2norm.rs
+++ b/crates/argmin-math/src/primitives/l2norm.rs
@@ -59,7 +59,7 @@ make_norm_complex!(f64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/minmax.rs
+++ b/crates/argmin-math/src/primitives/minmax.rs
@@ -44,7 +44,7 @@ make_minmax!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/mul.rs
+++ b/crates/argmin-math/src/primitives/mul.rs
@@ -44,7 +44,7 @@ make_mul!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/random.rs
+++ b/crates/argmin-math/src/primitives/random.rs
@@ -33,7 +33,7 @@ make_random!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
+    use pastey::item;
     use rand::SeedableRng;
 
     macro_rules! make_test {

--- a/crates/argmin-math/src/primitives/scaledadd.rs
+++ b/crates/argmin-math/src/primitives/scaledadd.rs
@@ -24,7 +24,7 @@ where
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/scaledsub.rs
+++ b/crates/argmin-math/src/primitives/scaledsub.rs
@@ -24,7 +24,7 @@ where
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/sub.rs
+++ b/crates/argmin-math/src/primitives/sub.rs
@@ -44,7 +44,7 @@ make_sub!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/transpose.rs
+++ b/crates/argmin-math/src/primitives/transpose.rs
@@ -44,7 +44,7 @@ make_transpose!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/weighteddot.rs
+++ b/crates/argmin-math/src/primitives/weighteddot.rs
@@ -24,7 +24,7 @@ where
 mod tests_vec {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -62,7 +62,7 @@ mod tests_vec {
 mod tests_ndarray {
     use super::*;
     use ndarray::array;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {
@@ -100,7 +100,7 @@ mod tests_ndarray {
 mod tests_nalgebra {
     use super::*;
     use nalgebra::{Matrix3, Vector3};
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/primitives/zero.rs
+++ b/crates/argmin-math/src/primitives/zero.rs
@@ -71,7 +71,7 @@ make_complex_zero!(u64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/add.rs
+++ b/crates/argmin-math/src/vec/add.rs
@@ -87,7 +87,7 @@ make_add!(f64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/conj.rs
+++ b/crates/argmin-math/src/vec/conj.rs
@@ -44,7 +44,7 @@ make_conj!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/div.rs
+++ b/crates/argmin-math/src/vec/div.rs
@@ -82,7 +82,7 @@ make_div!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/dot.rs
+++ b/crates/argmin-math/src/vec/dot.rs
@@ -119,7 +119,7 @@ make_dot_vec!(Complex<u64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/eye.rs
+++ b/crates/argmin-math/src/vec/eye.rs
@@ -49,7 +49,7 @@ make_eye!(u64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/l1norm.rs
+++ b/crates/argmin-math/src/vec/l1norm.rs
@@ -66,7 +66,7 @@ make_l1norm_complex!(Complex<f64>, f64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/l2norm.rs
+++ b/crates/argmin-math/src/vec/l2norm.rs
@@ -78,7 +78,7 @@ make_norm_complex!(Complex<f64>, f64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/minmax.rs
+++ b/crates/argmin-math/src/vec/minmax.rs
@@ -70,7 +70,7 @@ make_minmax!(f64);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/mul.rs
+++ b/crates/argmin-math/src/vec/mul.rs
@@ -97,7 +97,7 @@ make_mul!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/random.rs
+++ b/crates/argmin-math/src/vec/random.rs
@@ -61,7 +61,7 @@ make_random!(u64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
+    use pastey::item;
     use rand::SeedableRng;
 
     macro_rules! make_test {

--- a/crates/argmin-math/src/vec/scaledadd.rs
+++ b/crates/argmin-math/src/vec/scaledadd.rs
@@ -9,7 +9,7 @@
 mod tests {
     use crate::ArgminScaledAdd;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/scaledsub.rs
+++ b/crates/argmin-math/src/vec/scaledsub.rs
@@ -9,7 +9,7 @@
 mod tests {
     use crate::ArgminScaledSub;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/signum.rs
+++ b/crates/argmin-math/src/vec/signum.rs
@@ -51,7 +51,7 @@ make_signum_complex!(Complex<f64>);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/sub.rs
+++ b/crates/argmin-math/src/vec/sub.rs
@@ -97,7 +97,7 @@ make_sub!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/transpose.rs
+++ b/crates/argmin-math/src/vec/transpose.rs
@@ -55,7 +55,7 @@ make_transpose!(Complex<f64>);
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-math/src/vec/zero.rs
+++ b/crates/argmin-math/src/vec/zero.rs
@@ -25,7 +25,7 @@ where
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use paste::item;
+    use pastey::item;
 
     macro_rules! make_test {
         ($t:ty) => {

--- a/crates/argmin-testfunctions/Cargo.toml
+++ b/crates/argmin-testfunctions/Cargo.toml
@@ -22,7 +22,7 @@ num = "0.4"
 approx = "0.5"
 criterion = "0.7.0"
 finitediff = "0.1.4"
-paste = "1.0"
+pastey = "0.2.0"
 proptest = "1.4.0"
 
 [badges]

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -16,7 +16,7 @@ exclude = []
 [dependencies]
 # Required
 anyhow = "1.0"
-paste = "1"
+pastey = "0.2.0"
 num-traits = "0.2"
 rand = { version = "0.9.2", optional = true }
 rand_xoshiro = "0.7.0"

--- a/crates/argmin/src/core/macros.rs
+++ b/crates/argmin/src/core/macros.rs
@@ -86,7 +86,7 @@ macro_rules! float {
 #[macro_export]
 macro_rules! bulk {
     ($method_name:tt, $input:ty, $output:ty) => {
-        paste::item! {
+        pastey::item! {
             #[doc = concat!(
                 "Compute `",
                 stringify!($method_name),
@@ -145,7 +145,7 @@ macro_rules! bulk {
 #[cfg(test)]
 macro_rules! send_sync_test {
     ($n:ident, $t:ty) => {
-        paste::item! {
+        pastey::item! {
             #[test]
             #[allow(non_snake_case)]
             fn [<test_send_ $n>]() {
@@ -154,7 +154,7 @@ macro_rules! send_sync_test {
             }
         }
 
-        paste::item! {
+        pastey::item! {
             #[test]
             #[allow(non_snake_case)]
             fn [<test_sync_ $n>]() {
@@ -170,7 +170,7 @@ macro_rules! send_sync_test {
 #[macro_export]
 macro_rules! test_trait_impl {
     ($n:ident, $t:ty) => {
-        paste::item! {
+        pastey::item! {
             #[test]
             #[allow(non_snake_case)]
             fn [<test_send_ $n>]() {
@@ -179,7 +179,7 @@ macro_rules! test_trait_impl {
             }
         }
 
-        paste::item! {
+        pastey::item! {
             #[test]
             #[allow(non_snake_case)]
             fn [<test_sync_ $n>]() {
@@ -188,7 +188,7 @@ macro_rules! test_trait_impl {
             }
         }
 
-        paste::item! {
+        pastey::item! {
             #[test]
             #[allow(non_snake_case)]
             fn [<test_clone_ $n>]() {

--- a/python/argmin-testfunctions-py/Cargo.toml
+++ b/python/argmin-testfunctions-py/Cargo.toml
@@ -19,5 +19,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 argmin_testfunctions = { version = "0.3.0", path = "../../crates/argmin-testfunctions" }
-paste = "1"
+pastey = "0.2.0"
 pyo3 = "0.26"

--- a/python/argmin-testfunctions-py/src/lib.rs
+++ b/python/argmin-testfunctions-py/src/lib.rs
@@ -1,5 +1,5 @@
 use argmin_testfunctions::*;
-use paste::paste;
+use pastey::paste;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::stringify;


### PR DESCRIPTION
`paste` is no longer maintained and thus triggers some advisory warnings. `pastey`is a drop-in replacement with the same API.

Unfortunately that alone is not enough to get rid of the advisory as various other libraries have a transitive dependency, such as:
- `simba`
- `rmp`
- `egui_dock`

But maybe a small step in the right direction.