### PR TITLE
argmin-math: add ArgminAdd, ArgminSub and ArgminMul traits for primitive arrays

### DIFF
--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -32,10 +32,10 @@
 //!
 //! ### Default features
 //!
-//! | Feature                | Default | Comment                                               |
-//! |------------------------|---------|-------------------------------------------------------|
-//! | `primitives`           | yes     | basic integer and floating point types                |
-//! | `vec`                  | yes     | `Vec`s (basic functionality)                          |
+//! | Feature                | Default | Comment                                                                |
+//! |------------------------|---------|------------------------------------------------------------------------|
+//! | `primitives`           | yes     | basic integer and floating point types, and fixed-sized arrays thereof |
+//! | `vec`                  | yes     | `Vec`s (basic functionality)                                           |
 //!
 //! ### `ndarray`
 //!

--- a/crates/argmin-math/src/primitives/add.rs
+++ b/crates/argmin-math/src/primitives/add.rs
@@ -41,6 +41,7 @@ make_add!(Complex<f32>);
 make_add!(Complex<f64>);
 
 impl<T, const N : usize> ArgminAdd<[T; N], [T; N]> for [T; N] where T : ArgminAdd<T, T> {
+    #[inline]
     fn add(&self, other: &Self) -> Self {
         std::array::from_fn(|idx| ArgminAdd::add(&self[idx], &other[idx]))
     }

--- a/crates/argmin-math/src/primitives/add.rs
+++ b/crates/argmin-math/src/primitives/add.rs
@@ -40,6 +40,12 @@ make_add!(Complex<u64>);
 make_add!(Complex<f32>);
 make_add!(Complex<f64>);
 
+impl<T, const N : usize> ArgminAdd<[T; N], [T; N]> for [T; N] where T : ArgminAdd<T, T> {
+    fn add(&self, other: &Self) -> Self {
+        std::array::from_fn(|idx| ArgminAdd::add(&self[idx], &other[idx]))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,6 +61,15 @@ mod tests {
                     let b = 34 as $t;
                     let res = <$t as ArgminAdd<$t, $t>>::add(&a, &b);
                     assert_relative_eq!(42 as f64, res as f64, epsilon = f64::EPSILON);
+                }
+
+                #[test]
+                fn [<test_add_arr_ $t>]() {
+                    let a = [8 as $t, 9 as $t];
+                    let b = [34 as $t, 14 as $t];
+                    let res = ArgminAdd::add(&a, &b);
+                    assert_relative_eq!(42 as f64, res[0] as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(23 as f64, res[1] as f64, epsilon = f64::EPSILON);
                 }
             }
         };

--- a/crates/argmin-math/src/primitives/mul.rs
+++ b/crates/argmin-math/src/primitives/mul.rs
@@ -40,6 +40,12 @@ make_mul!(Complex<u64>);
 make_mul!(Complex<f32>);
 make_mul!(Complex<f64>);
 
+impl<T, const N : usize> ArgminMul<T, [T; N]> for [T; N] where T : ArgminMul<T, T> {
+    fn mul(&self, other: &T) -> Self {
+        std::array::from_fn(|idx| ArgminMul::mul(&self[idx], &other))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,6 +61,15 @@ mod tests {
                     let b = 21 as $t;
                     let res = <$t as ArgminMul<$t, $t>>::mul(&a, &b);
                     assert_relative_eq!(42 as f64, res as f64, epsilon = f64::EPSILON);
+                }
+                
+                #[test]
+                fn [<test_mul_arr_ $t>]() {
+                    let a = [21 as $t, 10 as $t];
+                    let b = 2 as $t;
+                    let res = ArgminMul::mul(&a, &b);
+                    assert_relative_eq!(42 as f64, res[0] as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(20 as f64, res[1] as f64, epsilon = f64::EPSILON);
                 }
             }
         };

--- a/crates/argmin-math/src/primitives/mul.rs
+++ b/crates/argmin-math/src/primitives/mul.rs
@@ -41,8 +41,16 @@ make_mul!(Complex<f32>);
 make_mul!(Complex<f64>);
 
 impl<T, const N : usize> ArgminMul<T, [T; N]> for [T; N] where T : ArgminMul<T, T> {
+    #[inline]
     fn mul(&self, other: &T) -> Self {
         std::array::from_fn(|idx| ArgminMul::mul(&self[idx], &other))
+    }
+}
+
+impl<T, const N : usize> ArgminMul<[T; N], [T; N]> for [T; N] where T : ArgminMul<T, T> {
+    #[inline]
+    fn mul(&self, other: &[T; N]) -> [T; N] {
+        std::array::from_fn(|idx| ArgminMul::mul(&self[idx], &other[idx]))
     }
 }
 
@@ -70,6 +78,17 @@ mod tests {
                     let res = ArgminMul::mul(&a, &b);
                     assert_relative_eq!(42 as f64, res[0] as f64, epsilon = f64::EPSILON);
                     assert_relative_eq!(20 as f64, res[1] as f64, epsilon = f64::EPSILON);
+                }
+
+                #[test]
+                fn [<test_mul_arr_arr_ $t>]() {
+                    let a = [1 as $t, 4 as $t, 8 as $t];
+                    let b = [2 as $t, 3 as $t, 4 as $t];
+                    let target = [2 as $t, 12 as $t, 32 as $t];
+                    let res = ArgminMul::mul(&a, &b);
+                    for i in 0..3 {
+                        assert_relative_eq!(target[i] as f64, res[i] as f64, epsilon = f64::EPSILON);
+                    }
                 }
             }
         };

--- a/crates/argmin-math/src/primitives/sub.rs
+++ b/crates/argmin-math/src/primitives/sub.rs
@@ -41,6 +41,7 @@ make_sub!(Complex<f32>);
 make_sub!(Complex<f64>);
 
 impl<T, const N : usize> ArgminSub<[T; N], [T; N]> for [T; N] where T : ArgminSub<T, T> {
+    #[inline]
     fn sub(&self, other: &Self) -> Self {
         std::array::from_fn(|idx| ArgminSub::sub(&self[idx], &other[idx]))
     }

--- a/crates/argmin-math/src/primitives/sub.rs
+++ b/crates/argmin-math/src/primitives/sub.rs
@@ -40,6 +40,12 @@ make_sub!(Complex<u64>);
 make_sub!(Complex<f32>);
 make_sub!(Complex<f64>);
 
+impl<T, const N : usize> ArgminSub<[T; N], [T; N]> for [T; N] where T : ArgminSub<T, T> {
+    fn sub(&self, other: &Self) -> Self {
+        std::array::from_fn(|idx| ArgminSub::sub(&self[idx], &other[idx]))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -55,6 +61,15 @@ mod tests {
                     let b = 8 as $t;
                     let res = <$t as ArgminSub<$t, $t>>::sub(&a, &b);
                     assert_relative_eq!(42 as f64, res as f64, epsilon = f64::EPSILON);
+                }
+
+                #[test]
+                fn [<test_sub_arr_ $t>]() {
+                    let a = [50 as $t, 25 as $t];
+                    let b = [8 as $t, 2 as $t];
+                    let res = ArgminSub::sub(&a, &b);
+                    assert_relative_eq!(42 as f64, res[0] as f64, epsilon = f64::EPSILON);
+                    assert_relative_eq!(23 as f64, res[1] as f64, epsilon = f64::EPSILON);
                 }
             }
         };


### PR DESCRIPTION
I wanted to implement `CostFunction` with `type Param = [f32; 6]` for an optimization problem and found that fixed-sized arrays were unsupported. Since you're already supporting `Vec`s anyway, and since ergonomics for primitive arrays have gotten better by now, I figured there's nothing wrong with adding these traits for them.