### PR TITLE
Update ndarray to 0.17 and ndarray-linalg to 0.18

### DIFF
--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "argmin-math"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Stefan Kroboth <stefan.kroboth@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -23,6 +23,9 @@ nalgebra_0_30 = { package = "nalgebra", version = "0.30", optional = true }
 nalgebra_0_29 = { package = "nalgebra", version = "0.29", optional = true }
 
 # ndarray
+ndarray_0_17 = { package = "ndarray", version = "0.17", optional = true }
+ndarray-linalg_0_18 = { package = "ndarray-linalg", version = "0.18", optional = true }
+## v0.16
 ndarray_0_16 = { package = "ndarray", version = "0.16", optional = true }
 ndarray-linalg_0_17 = { package = "ndarray-linalg", version = "0.17", optional = true }
 ## v0.15
@@ -80,7 +83,7 @@ nalgebra_v0_29 = ["nalgebra_0_29", "num-complex_0_4", "nalgebra_all"]
 
 # ndarray
 ndarray_all = ["primitives"]
-ndarray_latest = ["ndarray_v0_16"]
+ndarray_latest = ["ndarray_v0_17"]
 
 #faer
 faer_all = ["primitives"]
@@ -91,11 +94,13 @@ faer_v0_22  = ["faer_0_22", "num-complex_0_4", "faer_traits_0_22", "faer_all"]
 faer_v0_23  = ["faer_0_23", "num-complex_0_4", "faer_traits_0_23", "faer_all"]
 
 ## With `ndarray-linalg`
+ndarray_v0_17 = ["ndarray_0_17", "ndarray-linalg_0_18", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_16 = ["ndarray_0_16", "ndarray-linalg_0_17", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_15 = ["ndarray_0_15", "ndarray-linalg_0_16", "num-complex_0_4", "ndarray_all"]
 
 ## Without `ndarray-linalg`
-ndarray_latest-nolinalg = ["ndarray_v0_16-nolinalg"]
+ndarray_latest-nolinalg = ["ndarray_v0_17-nolinalg"]
+ndarray_v0_17-nolinalg = ["ndarray_0_17", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_16-nolinalg = ["ndarray_0_16", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_15-nolinalg = ["ndarray_0_15", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_14-nolinalg = ["ndarray_0_14", "num-complex_0_3", "ndarray_all"]

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_17/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_17/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dev-dependencies]
 argmin-math = { path = "../../", version = "*", features = [
-    "ndarray_latest",
+    "ndarray_v0_17",
 ] }
 ndarray = { version = "0.17", default-features = false }
 ndarray-linalg = { version = "0.18", default-features = false, features = ["intel-mkl-static"] }

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_17/src/lib.rs
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_17/src/lib.rs
@@ -1,0 +1,102 @@
+mod add {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/add.rs"
+    ));
+}
+mod conj {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/conj.rs"
+    ));
+}
+mod div {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/div.rs"
+    ));
+}
+mod dot {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/dot.rs"
+    ));
+}
+mod eye {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/eye.rs"
+    ));
+}
+mod inv {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/inv.rs"
+    ));
+}
+mod l1norm {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/l1norm.rs"
+    ));
+}
+mod l2norm {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/l2norm.rs"
+    ));
+}
+mod minmax {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/minmax.rs"
+    ));
+}
+mod mul {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/mul.rs"
+    ));
+}
+mod random {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/random.rs"
+    ));
+}
+mod scaledadd {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/scaledadd.rs"
+    ));
+}
+mod scaledsub {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/scaledsub.rs"
+    ));
+}
+mod signum {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/signum.rs"
+    ));
+}
+mod sub {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/sub.rs"
+    ));
+}
+mod transpose {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/transpose.rs"
+    ));
+}
+mod zero {
+    include!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../ndarray-tests-src/zero.rs"
+    ));
+}

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -43,7 +43,11 @@
 //! |---------------------------------|---------|--------------------------------------------------------------------|
 //! | `ndarray_latest`                | no      | latest supported version                                           |
 //! | `ndarray_latest-nolinalg`       | no      | latest supported version without `ndarray-linalg`                  |
+//! | `ndarray_v0_17`                 | no      | version 0.17 with ndarray-linalg 0.18                              |
+//! | `ndarray_v0_16`                 | no      | version 0.16 with ndarray-linalg 0.17                              |
 //! | `ndarray_v0_15`                 | no      | version 0.15 with ndarray-linalg 0.16                              |
+//! | `ndarray_v0_17-nolinalg`        | no      | version 0.17 without `ndarray-linalg`                              |
+//! | `ndarray_v0_16-nolinalg`        | no      | version 0.16 without `ndarray-linalg`                              |
 //! | `ndarray_v0_15-nolinalg`        | no      | version 0.15 without `ndarray-linalg`                              |
 //! | `ndarray_v0_14-nolinalg`        | no      | version 0.14 without `ndarray-linalg`                              |
 //! | `ndarray_v0_13-nolinalg`        | no      | version 0.13 without `ndarray-linalg`                              |
@@ -232,7 +236,9 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "ndarray_0_16")] {
+    if #[cfg(feature = "ndarray_0_17")] {
+        extern crate ndarray_0_17 as ndarray;
+    } else if #[cfg(feature = "ndarray_0_16")] {
         extern crate ndarray_0_16 as ndarray;
     } else if #[cfg(feature = "ndarray_0_15")] {
         extern crate ndarray_0_15 as ndarray;
@@ -244,7 +250,9 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "ndarray-linalg_0_17")] {
+    if #[cfg(feature = "ndarray-linalg_0_18")] {
+        extern crate ndarray_linalg_0_18 as ndarray_linalg;
+    } else if #[cfg(feature = "ndarray-linalg_0_17")] {
         extern crate ndarray_linalg_0_17 as ndarray_linalg;
     } else if #[cfg(feature = "ndarray-linalg_0_16")] {
         extern crate ndarray_linalg_0_16 as ndarray_linalg;

--- a/crates/argmin-math/src/ndarray_m/dot.rs
+++ b/crates/argmin-math/src/ndarray_m/dot.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::ArgminDot;
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, linalg::Dot};
 use num_complex::Complex;
 
 macro_rules! make_dot_ndarray {
@@ -14,7 +14,7 @@ macro_rules! make_dot_ndarray {
         impl ArgminDot<Array1<$t>, $t> for Array1<$t> {
             #[inline]
             fn dot(&self, other: &Array1<$t>) -> $t {
-                ndarray::Array1::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 
@@ -42,14 +42,14 @@ macro_rules! make_dot_ndarray {
         impl ArgminDot<Array1<$t>, Array1<$t>> for Array2<$t> {
             #[inline]
             fn dot(&self, other: &Array1<$t>) -> Array1<$t> {
-                ndarray::Array2::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 
         impl ArgminDot<Array2<$t>, Array2<$t>> for Array2<$t> {
             #[inline]
             fn dot(&self, other: &Array2<$t>) -> Array2<$t> {
-                ndarray::Array2::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 
@@ -72,7 +72,7 @@ macro_rules! make_dot_ndarray {
         impl ArgminDot<Array1<Complex<$t>>, Complex<$t>> for Array1<Complex<$t>> {
             #[inline]
             fn dot(&self, other: &Array1<Complex<$t>>) -> Complex<$t> {
-                ndarray::Array1::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 
@@ -100,14 +100,14 @@ macro_rules! make_dot_ndarray {
         impl ArgminDot<Array1<Complex<$t>>, Array1<Complex<$t>>> for Array2<Complex<$t>> {
             #[inline]
             fn dot(&self, other: &Array1<Complex<$t>>) -> Array1<Complex<$t>> {
-                ndarray::Array2::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 
         impl ArgminDot<Array2<Complex<$t>>, Array2<Complex<$t>>> for Array2<Complex<$t>> {
             #[inline]
             fn dot(&self, other: &Array2<Complex<$t>>) -> Array2<Complex<$t>> {
-                ndarray::Array2::dot(self, other)
+                Dot::dot(self, other)
             }
         }
 

--- a/crates/argmin-math/src/ndarray_m/inv.rs
+++ b/crates/argmin-math/src/ndarray_m/inv.rs
@@ -7,10 +7,12 @@
 
 use crate::ArgminInv;
 use crate::Error;
-use ndarray::Array2;
 use ndarray_linalg::Inverse;
 use num_complex::Complex;
 
+#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17"))]
+use ndarray::Array2;
+#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17"))]
 macro_rules! make_inv {
     ($t:ty) => {
         impl ArgminInv<Array2<$t>> for Array2<$t>
@@ -20,6 +22,31 @@ macro_rules! make_inv {
             #[inline]
             fn inv(&self) -> Result<Array2<$t>, Error> {
                 Ok(<Self as Inverse>::inv(&self)?)
+            }
+        }
+
+        // inverse for scalars (1d solvers)
+        impl ArgminInv<$t> for $t {
+            #[inline]
+            fn inv(&self) -> Result<$t, Error> {
+                Ok(1.0 / self)
+            }
+        }
+    };
+}
+
+#[cfg(feature = "ndarray-linalg_0_18")]
+use ndarray::{Array2, ArrayRef2};
+#[cfg(feature = "ndarray-linalg_0_18")]
+macro_rules! make_inv {
+    ($t:ty) => {
+        impl ArgminInv<Array2<$t>> for Array2<$t>
+        where
+            ArrayRef2<$t>: Inverse,
+        {
+            #[inline]
+            fn inv(&self) -> Result<Array2<$t>, Error> {
+                Ok(<ArrayRef2<$t> as Inverse>::inv(&self)?)
             }
         }
 

--- a/crates/argmin-math/src/ndarray_m/mod.rs
+++ b/crates/argmin-math/src/ndarray_m/mod.rs
@@ -12,7 +12,7 @@ mod conj;
 mod div;
 mod dot;
 mod eye;
-#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17",))]
+#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17", feature = "ndarray-linalg_0_18"))]
 mod inv;
 mod l1norm;
 mod l2norm;
@@ -32,7 +32,7 @@ pub use conj::*;
 pub use div::*;
 pub use dot::*;
 pub use eye::*;
-#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17",))]
+#[cfg(any(feature = "ndarray-linalg_0_16", feature = "ndarray-linalg_0_17", feature = "ndarray-linalg_0_18"))]
 pub use inv::*;
 pub use l1norm::*;
 pub use l2norm::*;

--- a/examples/bfgs/Cargo.toml
+++ b/examples/bfgs/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "*", path = "../../crates/finitediff", features = ["ndarray"] }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/dfp/Cargo.toml
+++ b/examples/dfp/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "*", path = "../../crates/finitediff", features = ["ndarray"] }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/gaussnewton/Cargo.toml
+++ b/examples/gaussnewton/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
-ndarray = "0.16"
-ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }
+ndarray = "0.17"
+ndarray-linalg = { version = "0.18.0", features = ["openblas-static"] }

--- a/examples/gaussnewton_linesearch/Cargo.toml
+++ b/examples/gaussnewton_linesearch/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
-ndarray = "0.16"
-ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }
+ndarray = "0.17"
+ndarray-linalg = { version = "0.18.0", features = ["intel-mkl"] }

--- a/examples/lbfgs/Cargo.toml
+++ b/examples/lbfgs/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "*", path = "../../crates/finitediff", features = ["ndarray"] }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/neldermead/Cargo.toml
+++ b/examples/neldermead/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/newton/Cargo.toml
+++ b/examples/newton/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.16"
-ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }
+ndarray = "0.17"
+ndarray-linalg = { version = "0.18.0", features = ["intel-mkl"] }

--- a/examples/newton_cg/Cargo.toml
+++ b/examples/newton_cg/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/owl_qn/Cargo.toml
+++ b/examples/owl_qn/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/sr1/Cargo.toml
+++ b/examples/sr1/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "*", path = "../../crates/finitediff", features = ["ndarray"] }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/sr1_trustregion/Cargo.toml
+++ b/examples/sr1_trustregion/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "*", path = "../../crates/finitediff", features = ["ndarray"] }
-ndarray = "0.16"
+ndarray = "0.17"

--- a/examples/trustregion/Cargo.toml
+++ b/examples/trustregion/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.16"
-ndarray-linalg = { version = "0.17.0", features = ["intel-mkl-static"] }
+ndarray = "0.17"
+ndarray-linalg = { version = "0.18.0", features = ["intel-mkl-static"] }


### PR DESCRIPTION
Awesome project, my personal gratitude to the maintainers and contributors. 

I needed to use it with the latest `ndarray` crates (0.17, `linalg` 0.18) so I went ahead and patched them in. I haven't tested every possible combination of features, or done any in-depth QA, this is an as-is patch that seems to work for me.

I have done some quick `cargo test`ing with older versions of `ndarray` and these seemed to go okay (with appropriate features) but I can't guarantee I didn't miss something.

If you have any change requests or issues with style, structure, or something else, please let me know and I'll try to clean that up.

Worth noting a release including this PR would close #662 .

Thanks for all your hard work, and I hope this PR proves helpful.